### PR TITLE
fix: correct PYTHONBUFFERED typo to PYTHONUNBUFFERED

### DIFF
--- a/openclaw-opd/run_qwen3_4b_openclaw_opd.sh
+++ b/openclaw-opd/run_qwen3_4b_openclaw_opd.sh
@@ -11,7 +11,7 @@ pkill -9 python
 
 set -ex
 
-export PYTHONBUFFERED=16
+export PYTHONUNBUFFERED=1
 
 NUM_GPUS=${NUM_GPUS:-8}
 ACTOR_GPUS=${ACTOR_GPUS:-4}

--- a/openclaw-rl/run_qwen3_4b_openclaw_rl.sh
+++ b/openclaw-rl/run_qwen3_4b_openclaw_rl.sh
@@ -11,7 +11,7 @@ pkill -9 python
 
 set -ex
 
-export PYTHONBUFFERED=16
+export PYTHONUNBUFFERED=1
 
 NUM_GPUS=${NUM_GPUS:-8}
 ACTOR_GPUS=${ACTOR_GPUS:-4}


### PR DESCRIPTION
## Summary

- Fix environment variable name `PYTHONBUFFERED` → `PYTHONUNBUFFERED` in both launch scripts
- Fix value from `16` to `1` (the canonical value for enabling unbuffered mode)

`PYTHONBUFFERED` is not a recognized Python environment variable — Python silently ignores it. The correct variable is [`PYTHONUNBUFFERED`](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUNBUFFERED), which disables stdout/stderr buffering when set to any non-empty string.

Without this fix, Python output remains fully buffered when piped (e.g., via `ray job submit`), causing delayed or lost log output during long-running RL training jobs.

## Files changed

- `openclaw-rl/run_qwen3_4b_openclaw_rl.sh`
- `openclaw-opd/run_qwen3_4b_openclaw_opd.sh`

## Test plan

- [x] Verified `PYTHONUNBUFFERED` is the correct env var per [Python docs](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUNBUFFERED)
- [x] Verified `1` is the standard value (boolean flag, any non-empty string enables it)
- [x] Confirmed no other in-scope files have this typo