### PR TITLE
docs: fix kl-loss-coef default value in instructions

### DIFF
--- a/instructions/README.md
+++ b/instructions/README.md
@@ -44,7 +44,7 @@ apt-get install -y python3-apt
 | `rollout-max-context-len` | `32768` | max context length in a session |
 | `rollout-temperature` | `0.6` | temperature |
 | `advantage-estimator` | (see script) | `on_policy_distillation` / `grpo` |
-| `kl-loss-coef` | `0.01` | kl loss weight |
+| `kl-loss-coef` | `0.02` | kl loss weight |
 
 
 


### PR DESCRIPTION
## Summary

- Fix the documented default value of `kl-loss-coef` from `0.01` to `0.02` in `instructions/README.md`

Both launch scripts (`openclaw-rl/run_qwen3_4b_openclaw_rl.sh` line 100 and `openclaw-opd/run_qwen3_4b_openclaw_opd.sh` line 99) use `--kl-loss-coef 0.02`, but the configuration table in `instructions/README.md` listed `0.01`.

## Files changed

- `instructions/README.md`

## Test plan

- [x] Verified both launch scripts use `0.02`
- [x] Cross-checked all other values in the configuration table — no other mismatches