### PR TITLE
fix: derive Megatron-LM PYTHONPATH from script location

### DIFF
--- a/openclaw-opd/run_qwen3_4b_openclaw_opd.sh
+++ b/openclaw-opd/run_qwen3_4b_openclaw_opd.sh
@@ -31,6 +31,7 @@ export RAY_num_heartbeats_timeout=60
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 SLIME_ROOT="$(cd -- "${SCRIPT_DIR}/../slime" &>/dev/null && pwd)"
+MEGATRON_ROOT="$(cd -- "${SCRIPT_DIR}/../Megatron-LM" &>/dev/null && pwd)"
 source "${SLIME_ROOT}/scripts/models/qwen3-4B.sh"
 
 HF_CKPT=${HF_CKPT:-/absolute/path/to/Qwen3-4B-Thinking-2507}
@@ -152,7 +153,7 @@ ray start --head --node-ip-address "${MASTER_ADDR}" --num-gpus "${NUM_GPUS}" --d
 
 RUNTIME_ENV_JSON="{
   \"env_vars\": {
-    \"PYTHONPATH\": \"/absolute/path/to/OpenClaw-RL/Megatron-LM/:${SCRIPT_DIR}:${SLIME_ROOT}\",
+    \"PYTHONPATH\": \"${MEGATRON_ROOT}:${SCRIPT_DIR}:${SLIME_ROOT}\",
     \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\"
   }
 }"

--- a/openclaw-rl/run_qwen3_4b_openclaw_rl.sh
+++ b/openclaw-rl/run_qwen3_4b_openclaw_rl.sh
@@ -31,6 +31,7 @@ export RAY_num_heartbeats_timeout=60
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 SLIME_ROOT="$(cd -- "${SCRIPT_DIR}/../slime" &>/dev/null && pwd)"
+MEGATRON_ROOT="$(cd -- "${SCRIPT_DIR}/../Megatron-LM" &>/dev/null && pwd)"
 source "${SLIME_ROOT}/scripts/models/qwen3-4B.sh"
 
 HF_CKPT=${HF_CKPT:-/absolute/path/to/Qwen3-4B-Thinking-2507}
@@ -157,7 +158,7 @@ ray start --head --node-ip-address "${MASTER_ADDR}" --num-gpus "${NUM_GPUS}" --d
 
 RUNTIME_ENV_JSON="{
   \"env_vars\": {
-    \"PYTHONPATH\": \"/absolute/path/to/OpenClaw-RL/Megatron-LM/:${SCRIPT_DIR}:${SLIME_ROOT}\",
+    \"PYTHONPATH\": \"${MEGATRON_ROOT}:${SCRIPT_DIR}:${SLIME_ROOT}\",
     \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\"
   }
 }"


### PR DESCRIPTION
## Summary

- Replace the hardcoded placeholder `/absolute/path/to/OpenClaw-RL/Megatron-LM/` in `RUNTIME_ENV_JSON`'s `PYTHONPATH` with a dynamically computed `MEGATRON_ROOT` variable

Unlike `HF_CKPT`, `SAVE_CKPT`, and `PRM_MODEL_PATH` — which use `${VAR:-default}` syntax and are clearly marked as user-configurable — this Megatron-LM path was embedded inside a JSON string and easy to overlook. Users who correctly set the model paths could still hit import failures because this `PYTHONPATH` entry silently pointed to a non-existent placeholder directory.

The fix computes `MEGATRON_ROOT` using the same `cd && pwd` pattern already established for `SLIME_ROOT`, so it resolves correctly regardless of where the repository is cloned.

## Files changed

- `openclaw-rl/run_qwen3_4b_openclaw_rl.sh`
- `openclaw-opd/run_qwen3_4b_openclaw_opd.sh`

## Test plan

- [x] Verified `SCRIPT_DIR/../Megatron-LM` resolves to the correct sibling directory
- [x] Confirmed the pattern is identical to the existing `SLIME_ROOT` computation
- [x] Checked that trailing slash removal has no effect on `PYTHONPATH` resolution
- [x] Verified shell quoting is correct within the JSON string