### PR TITLE
fix: add cd to SLIME_ROOT before train_async.py in all training scripts

### DIFF
--- a/openclaw-opd/run_qwen3_4b_openclaw_opd.sh
+++ b/openclaw-opd/run_qwen3_4b_openclaw_opd.sh
@@ -34,6 +34,9 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 SLIME_ROOT="$(cd -- "${SCRIPT_DIR}/../slime" &>/dev/null && pwd)"
 source "${SLIME_ROOT}/scripts/models/qwen3-4B.sh"
 
+cd "${SLIME_ROOT}"
+echo "Current Working Directory: $(pwd)"
+
 HF_CKPT=${HF_CKPT:-/absolute/path/to/Qwen3-4B-Thinking-2507}
 REF_LOAD=${REF_LOAD:-${HF_CKPT}}
 SAVE_CKPT=${SAVE_CKPT:-/absolute/path/to/OpenClaw-RL/ckpt/qwen3-4b-openclaw-opd}

--- a/openclaw-opd/run_qwen3_4b_openclaw_opd_topk.sh
+++ b/openclaw-opd/run_qwen3_4b_openclaw_opd_topk.sh
@@ -33,6 +33,9 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 SLIME_ROOT="$(cd -- "${SCRIPT_DIR}/../slime" &>/dev/null && pwd)"
 source "${SLIME_ROOT}/scripts/models/qwen3-4B.sh"
 
+cd "${SLIME_ROOT}"
+echo "Current Working Directory: $(pwd)"
+
 HF_CKPT=${HF_CKPT:-/absolute/path/to/Qwen3-4B-Thinking-2507}
 REF_LOAD=${REF_LOAD:-${HF_CKPT}}
 SAVE_CKPT=${SAVE_CKPT:-/absolute/path/to/OpenClaw-RL/ckpt/qwen3-4b-openclaw-opd-topk}

--- a/openclaw-rl/run_qwen3_4b_openclaw_rl.sh
+++ b/openclaw-rl/run_qwen3_4b_openclaw_rl.sh
@@ -35,6 +35,9 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 SLIME_ROOT="$(cd -- "${SCRIPT_DIR}/../slime" &>/dev/null && pwd)"
 source "${SLIME_ROOT}/scripts/models/qwen3-4B.sh"
 
+cd "${SLIME_ROOT}"
+echo "Current Working Directory: $(pwd)"
+
 HF_CKPT=${HF_CKPT:-/absolute/path/to/Qwen3-4B-Thinking-2507}
 REF_LOAD=${REF_LOAD:-${HF_CKPT}}
 SAVE_CKPT=${SAVE_CKPT:-/absolute/path/to/OpenClaw-RL/ckpt/qwen3-4b-openclaw-rl}


### PR DESCRIPTION
  ## Summary

  - train_async.py requires the working directory to be slime/, otherwise it cannot find the necessary modules and configs
  - Added cd "${SLIME_ROOT}" before ray job submit in all three training scripts:
    - openclaw-rl/run_qwen3_4b_openclaw_rl.sh
    - openclaw-opd/run_qwen3_4b_openclaw_opd.sh
    - openclaw-opd/run_qwen3_4b_openclaw_opd_topk.sh

  ## Changes

  Each script now includes the following lines after source "${SLIME_ROOT}/scripts/models/qwen3-4B.sh":
  cd "${SLIME_ROOT}"
  echo "Current Working Directory: $(pwd)"