### PR TITLE
feat: add openclaw-training-free — zero-GPU experience loop for LLMs

### DIFF
--- a/openclaw-training-free/README.md
+++ b/openclaw-training-free/README.md
@@ -1,0 +1,168 @@
+# openclaw-training-free
+
+> **Training-Free LLM Improvement** — accumulate conversational wisdom, inject it at inference time. Zero GPU. Zero parameter updates. Zero training cost.
+
+---
+
+## What Is This?
+
+`openclaw-training-free` is a lightweight add-on to [OpenClaw-RL](https://github.com/Gen-Verse/OpenClaw-RL) that improves LLM responses **without touching model weights**.
+
+Existing approaches in this repo update parameters to improve the model:
+
+| Approach | Parameter Update | 
+|---|---|
+| `openclaw-rl` (GRPO) | ✅ Yes | 
+| `openclaw-opd` (OPD) | ✅ Yes |
+| **`openclaw-training-free` (experience)** | ❌ **No** | 
+
+The core idea: **every user follow-up is an implicit training signal**. When a user corrects, clarifies, or asks again, they are telling you exactly what the previous response got wrong. We make that signal explicit (via a Judge LLM), store it as an *experience*, and inject it back into future prompts — forming a self-improving **experience loop**.
+
+```
+         ┌─────────────────── Experience Loop ────────────────────┐
+         │                                                         │
+  User   │   ┌──────────────┐    enriched     ┌───────────────┐   │
+ request ──▶ │PromptInjector│ ──── prompt ───▶│  Upstream LLM │   │
+         │   └──────┬───────┘                 └───────┬───────┘   │
+         │          │ retrieve                        │ response  │
+         │          │                                 │           │
+         │   ┌──────▼───────┐                         │           │
+         │   │ ExperienceStore│ ◀──── store hint ──────┤           │
+         │   └──────────────┘                         │           │
+         │                          ┌─────────────────▼──────┐    │
+         │                          │  ExperienceExtractor   │    │
+         │   next user message ────▶│  (Judge LLM infers     │    │
+         │                          │   what went wrong)     │    │
+         │                          └────────────────────────┘    │
+         └─────────────────────────────────────────────────────────┘
+```
+
+Over time, the experience store becomes a **playbook of lessons learned** — and every future request benefits from it automatically.
+
+---
+
+## How It Works (Step by Step)
+
+**Step 1 — INJECT**
+When a request arrives, retrieve the most relevant past experiences from the store and prepend them to the system prompt. The model sees "lessons learned" before generating its response.
+
+**Step 2 — RESPOND**
+Forward the enriched prompt to the upstream LLM and return its response to the user — transparently, with no latency overhead on the critical path.
+
+**Step 3 — EXTRACT (async)**
+On the *next* user message, a background worker pairs `(previous response, current user message)` and calls a Judge LLM to infer: *"What was lacking in the previous response that caused this follow-up?"* The result is a concise, actionable improvement hint.
+
+**Step 4 — STORE**
+Good hints are saved to the experience store (a local JSON file). On the next similar request, Step 1 retrieves and injects them — completing the loop.
+
+---
+
+## Installation
+
+```bash
+cd openclaw-training-free
+pip install -r requirements.txt
+```
+
+**Requirements:** Python 3.10+, no GPU, no torch.
+
+---
+
+## Quick Start
+
+**1. Start the proxy server**
+
+```bash
+export UPSTREAM_BASE_URL=https://api.openai.com   # your LLM provider
+export UPSTREAM_API_KEY=sk-xxxxxxxx
+python training_free_server.py
+```
+
+**2. Point your client at the proxy**
+
+```python
+import openai
+
+client = openai.OpenAI(
+    base_url="http://localhost:8080/v1",
+    api_key="anything",          # auth handled by the proxy
+)
+```
+
+**3. Chat normally — improvement happens automatically**
+
+```python
+resp = client.chat.completions.create(
+    model="gpt-4o",
+    messages=[{"role": "user", "content": "Explain transformers"}],
+)
+print(resp.choices[0].message.content)
+```
+
+No code changes needed in your application. The proxy accumulates experience transparently. Responses improve over time without any fine-tuning.
+
+---
+
+## Configuration
+
+All settings via environment variables:
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `UPSTREAM_BASE_URL` | **Yes** | — | Base URL of the real LLM API |
+| `UPSTREAM_API_KEY` | **Yes** | — | API key for the upstream LLM |
+| `JUDGE_BASE_URL` | No | same as upstream | Base URL for the Judge LLM |
+| `JUDGE_API_KEY` | No | same as upstream | API key for the Judge LLM |
+| `JUDGE_MODEL` | No | `gpt-4o-mini` | Model used for hint extraction |
+| `EXPERIENCE_STORE_PATH` | No | `experiences.json` | Path to the experience JSON file |
+| `TOP_K_EXPERIENCES` | No | `3` | Experiences injected per request |
+| `PORT` | No | `8080` | Server listen port |
+
+---
+
+## Architecture
+
+```
+openclaw-training-free/
+├── training_free_server.py    # FastAPI proxy server (entrypoint)
+├── experience_extractor.py    # Judge LLM client — extracts hints
+├── experience_store.py        # Keyword-indexed JSON experience library
+├── prompt_injector.py         # Injects retrieved hints into system prompt
+├── requirements.txt
+├── __init__.py
+└── README.md
+```
+
+| Component | Responsibility |
+|---|---|
+| **Server** (`training_free_server.py`) | OpenAI-compatible proxy. Manages session history, coordinates injection and async extraction. Background `asyncio` worker for non-blocking hint extraction. |
+| **Extractor** (`experience_extractor.py`) | Calls Judge LLM to analyze `(response, next_user_message)` pairs. Filters out trivial/empty hints. |
+| **Store** (`experience_store.py`) | Thread-safe, keyword-indexed JSON file. Retrieves experiences by keyword overlap with the current query. |
+| **Injector** (`prompt_injector.py`) | Retrieves top-K experiences and prepends them to the system message with a character budget. |
+
+## API Endpoints
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/v1/chat/completions` | POST | OpenAI-compatible (streaming & non-streaming) |
+| `/v1/experiences/stats` | GET | Store statistics and queue depth |
+| `/health` | GET | Health check |
+
+---
+
+## Comparison with Related Work
+
+| | openclaw-rl | openclaw-opd | **openclaw-training-free** |
+|---|---|---|---|
+| Parameter updates | ✅ Yes | ✅ Yes | ❌ No |
+| GPU required | ✅ Yes | ✅ Yes | ❌ No |
+| Improves over time | ✅ | ✅ | ✅ (via experience injection) |
+| Needs reward signal | ✅ Explicit | ❌ Auto (OPD) | ❌ Auto (next user msg) |
+| Ceiling | Model capacity + training | Model capacity + training | Model capacity only |
+
+**When to use training-free:**
+- You can't afford GPU training
+- You want to start improving immediately (no data collection phase)
+- Your task is open-ended conversation (hard to define a reward function)
+- You want a complement to RL — run training-free first, collect high-signal experiences, then use them to bootstrap RL training data
+

--- a/openclaw-training-free/__init__.py
+++ b/openclaw-training-free/__init__.py
@@ -1,0 +1,32 @@
+"""
+openclaw-training-free — Training-Free LLM improvement via experience loops.
+
+A lightweight system that improves LLM responses over time *without* updating
+model parameters (training-free). It intercepts conversations, extracts
+improvement hints via a Judge LLM, stores them in a keyword-indexed experience
+library, and injects relevant past experiences into future prompts — forming a
+self-improving experience loop.
+
+Compared to openclaw-rl (~$10,000/run) and openclaw-opd (~$18/run), this
+approach costs ~$0 in training compute.
+
+Main components:
+
+- :class:`ExperienceStore`     — persist and retrieve hints (JSON file).
+- :class:`ExperienceExtractor` — call a Judge LLM to extract hints.
+- :class:`PromptInjector`      — inject retrieved hints into prompts.
+
+See ``training_free_server.py`` for the FastAPI proxy that ties them together.
+"""
+
+from __future__ import annotations
+
+from experience_store import ExperienceStore
+from experience_extractor import ExperienceExtractor
+from prompt_injector import PromptInjector
+
+__all__ = [
+    "ExperienceStore",
+    "ExperienceExtractor",
+    "PromptInjector",
+]

--- a/openclaw-training-free/experience_extractor.py
+++ b/openclaw-training-free/experience_extractor.py
@@ -1,0 +1,252 @@
+"""
+ExperienceExtractor — extract improvement hints from conversation pairs.
+
+Uses a Judge LLM (via OpenAI-compatible API) to infer what was lacking in
+an assistant response based on the *next* user message.  This is the core
+of the **ExpLoop** approach: surface quality signals from conversation
+flow without any parameter updates.
+
+Part of the **openclaw-exploop** project (training-free experience loop).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+_DEFAULT_JUDGE_MODEL = "gpt-4o-mini"
+
+_HINT_EXTRACT_PROMPT = """\
+You are an expert conversation analyst.  Given:
+
+1. **Assistant response** (what the model said)
+2. **Next user message** (the user's follow-up)
+
+Infer what was insufficient, incorrect, or missing in the assistant \
+response that caused the user to follow up.  Produce a concise, \
+actionable *improvement hint* that a model could use in future similar \
+situations.
+
+Rules:
+- The hint MUST be a single paragraph, 1-4 sentences.
+- Focus on *what to do differently*, not what went wrong.
+- If the next user message is simply a new topic or a "thanks", \
+  respond with exactly: NO_HINT
+- Do NOT repeat the assistant response verbatim.
+"""
+
+_TRIVIAL_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"^no[_ ]?hint$", re.IGNORECASE),
+    re.compile(r"^\s*$"),
+]
+
+_MIN_HINT_LENGTH = 20  # chars
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _is_trivial(hint: str) -> bool:
+    """Return True if *hint* carries no useful information."""
+    stripped = hint.strip()
+    if len(stripped) < _MIN_HINT_LENGTH:
+        return True
+    for pat in _TRIVIAL_PATTERNS:
+        if pat.fullmatch(stripped):
+            return True
+    return False
+
+
+def _build_user_content(
+    response_text: str,
+    next_user_message: str,
+) -> str:
+    return (
+        f"**Assistant response:**\n{response_text[:1500]}\n\n"
+        f"**Next user message:**\n{next_user_message[:1500]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# ExperienceExtractor
+# ---------------------------------------------------------------------------
+
+class ExperienceExtractor:
+    """Extract improvement hints by calling a Judge LLM.
+
+    Parameters
+    ----------
+    base_url : str | None
+        OpenAI-compatible base URL.  Falls back to ``JUDGE_BASE_URL``
+        then ``UPSTREAM_BASE_URL`` environment variables.
+    api_key : str | None
+        API key.  Falls back to ``JUDGE_API_KEY`` then
+        ``UPSTREAM_API_KEY`` environment variables.
+    model : str | None
+        Model name.  Falls back to ``JUDGE_MODEL`` env var.
+    timeout : float
+        HTTP timeout in seconds for each judge call.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        model: str | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        self.base_url = (
+            base_url
+            or os.environ.get("JUDGE_BASE_URL")
+            or os.environ.get("UPSTREAM_BASE_URL", "")
+        ).rstrip("/")
+        self.api_key = (
+            api_key
+            or os.environ.get("JUDGE_API_KEY")
+            or os.environ.get("UPSTREAM_API_KEY", "")
+        )
+        self.model = (
+            model
+            or os.environ.get("JUDGE_MODEL", _DEFAULT_JUDGE_MODEL)
+        )
+        self.timeout = timeout
+
+        if not self.base_url:
+            logger.warning(
+                "[ExperienceExtractor] no base_url configured — "
+                "hint extraction will fail until set"
+            )
+
+    # ------------------------------------------------------------------
+    # Core
+    # ------------------------------------------------------------------
+
+    async def extract_hint(
+        self,
+        response_text: str,
+        next_user_message: str,
+        session_id: str = "",
+    ) -> str | None:
+        """Call the Judge LLM and return an improvement hint, or *None*.
+
+        Returns *None* when:
+        - both inputs are empty / whitespace-only (nothing to analyse)
+        - the judge says NO_HINT
+        - the resulting hint is trivially short or empty
+        - an HTTP / parsing error occurs (logged, not raised)
+        """
+        # BUG FIX: guard against empty inputs — the Judge LLM would
+        # produce garbage or hallucinated hints when both fields are
+        # blank.
+        if not response_text.strip() and not next_user_message.strip():
+            logger.debug(
+                "[ExperienceExtractor] both inputs empty for "
+                "session=%s — skipping",
+                session_id,
+            )
+            return None
+
+        user_content = _build_user_content(
+            response_text, next_user_message,
+        )
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": _HINT_EXTRACT_PROMPT},
+                {"role": "user", "content": user_content},
+            ],
+            "temperature": 0.3,
+            "max_tokens": 256,
+        }
+        url = f"{self.base_url}/v1/chat/completions"
+        headers: dict[str, str] = {}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                resp = await client.post(
+                    url, json=payload, headers=headers,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+        except httpx.HTTPStatusError as exc:
+            logger.error(
+                "[ExperienceExtractor] judge HTTP %s for session=%s: %s",
+                exc.response.status_code, session_id, exc,
+            )
+            return None
+        except (httpx.RequestError, Exception) as exc:
+            logger.error(
+                "[ExperienceExtractor] judge request failed "
+                "for session=%s: %s",
+                session_id, exc,
+            )
+            return None
+
+        # Parse response
+        try:
+            hint = (
+                data["choices"][0]["message"]["content"]
+                .strip()
+            )
+        except (KeyError, IndexError, TypeError) as exc:
+            logger.warning(
+                "[ExperienceExtractor] unexpected judge response "
+                "structure for session=%s: %s",
+                session_id, exc,
+            )
+            return None
+
+        if _is_trivial(hint):
+            logger.debug(
+                "[ExperienceExtractor] trivial hint discarded "
+                "for session=%s: %r",
+                session_id, hint[:80],
+            )
+            return None
+
+        logger.info(
+            "[ExperienceExtractor] extracted hint for session=%s "
+            "(%d chars)",
+            session_id, len(hint),
+        )
+        return hint
+
+    # ------------------------------------------------------------------
+    # Batch
+    # ------------------------------------------------------------------
+
+    async def batch_extract(
+        self,
+        pairs: list[dict[str, str]],
+    ) -> list[str | None]:
+        """Extract hints for multiple (response, next_message) pairs.
+
+        Each element of *pairs* should be a dict with keys:
+        ``response_text``, ``next_user_message``, and optionally
+        ``session_id``.
+
+        Returns a list of the same length — hint strings or *None*.
+        """
+        tasks = [
+            self.extract_hint(
+                response_text=p.get("response_text", ""),
+                next_user_message=p.get("next_user_message", ""),
+                session_id=p.get("session_id", ""),
+            )
+            for p in pairs
+        ]
+        return await asyncio.gather(*tasks)

--- a/openclaw-training-free/experience_store.py
+++ b/openclaw-training-free/experience_store.py
@@ -1,0 +1,195 @@
+"""
+ExperienceStore — keyword-based experience persistence and retrieval.
+
+Stores hints extracted by the Judge LLM and retrieves them via simple
+keyword matching.  Thread-safe; persists to a single JSON file.
+
+Part of the **openclaw-exploop** project (training-free experience loop).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import threading
+import time
+import uuid
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Matches word-like tokens (letters, digits, underscores) of length > 3.
+_WORD_RE = re.compile(r"[a-zA-Z0-9_]+")
+
+# Common English stop-words that are longer than 3 chars — cheap filter.
+_STOP_WORDS = frozenset({
+    "that", "this", "with", "from", "your", "have", "been", "were", "will",
+    "they", "them", "than", "then", "when", "what", "which", "their", "there",
+    "would", "could", "should", "about", "after", "before", "where", "these",
+    "those", "some", "also", "just", "more", "very", "into", "over", "only",
+    "such", "each", "does", "done", "make", "made", "like", "well", "back",
+    "much", "most", "many", "same", "here", "every", "still", "while",
+    "because", "through", "between", "being", "other", "under",
+})
+
+
+def _extract_keywords(text: str, max_words: int = 20) -> list[str]:
+    """Extract up to *max_words* lowercase keywords (len > 3, deduplicated)."""
+    tokens = _WORD_RE.findall(text.lower())
+    seen: set[str] = set()
+    keywords: list[str] = []
+    for tok in tokens:
+        if len(tok) <= 3:
+            continue
+        if tok in _STOP_WORDS:
+            continue
+        if tok in seen:
+            continue
+        seen.add(tok)
+        keywords.append(tok)
+        if len(keywords) >= max_words:
+            break
+    return keywords
+
+
+class ExperienceStore:
+    """Persists and retrieves experiences from a JSON file.
+
+    Each experience entry looks like::
+
+        {
+            "id":                 "<uuid>",
+            "timestamp":          "2026-03-05 12:00:00",
+            "hint":               "...",
+            "keywords":           ["keyword1", "keyword2", ...],
+            "response_snippet":   "first 300 chars of assistant response",
+            "next_state_snippet": "first 300 chars of next user message",
+            "session_id":         "sess-abc"
+        }
+    """
+
+    SNIPPET_LEN = 300
+
+    def __init__(self, store_path: str = "experiences.json") -> None:
+        self._store_path = store_path
+        self._lock = threading.Lock()
+        self._experiences: list[dict[str, Any]] = []
+        self._load()
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+
+    def _load(self) -> None:
+        """Load existing experiences from disk (if any)."""
+        if not os.path.isfile(self._store_path):
+            logger.info("[ExperienceStore] no existing file at %s — starting fresh", self._store_path)
+            return
+        try:
+            with open(self._store_path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if isinstance(data, list):
+                self._experiences = data
+                logger.info(
+                    "[ExperienceStore] loaded %d experiences from %s",
+                    len(self._experiences),
+                    self._store_path,
+                )
+            else:
+                logger.warning("[ExperienceStore] unexpected JSON root type in %s — ignoring", self._store_path)
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("[ExperienceStore] failed to load %s: %s", self._store_path, exc)
+
+    def _save(self) -> None:
+        """Persist current experiences to disk (caller must hold ``_lock``)."""
+        tmp_path = self._store_path + ".tmp"
+        try:
+            parent = os.path.dirname(self._store_path)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            with open(tmp_path, "w", encoding="utf-8") as fh:
+                json.dump(self._experiences, fh, ensure_ascii=False, indent=2)
+            os.replace(tmp_path, self._store_path)
+        except OSError as exc:
+            logger.error("[ExperienceStore] failed to save to %s: %s", self._store_path, exc)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def add(
+        self,
+        hint: str,
+        response_text: str,
+        next_state_text: str,
+        session_id: str,
+    ) -> dict[str, Any]:
+        """Store a new experience entry.  Returns the created entry dict."""
+        entry: dict[str, Any] = {
+            "id": uuid.uuid4().hex[:12],
+            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "hint": hint.strip(),
+            "keywords": _extract_keywords(hint),
+            "response_snippet": response_text[:self.SNIPPET_LEN].strip(),
+            "next_state_snippet": next_state_text[:self.SNIPPET_LEN].strip(),
+            "session_id": session_id,
+        }
+        with self._lock:
+            self._experiences.append(entry)
+            self._save()
+        logger.info(
+            "[ExperienceStore] added experience id=%s keywords=%s session=%s (total=%d)",
+            entry["id"],
+            entry["keywords"][:5],
+            session_id,
+            len(self._experiences),
+        )
+        return entry
+
+    def retrieve(self, query: str, top_k: int = 3) -> list[dict[str, Any]]:
+        """Keyword-based retrieval.
+
+        Score = number of query keywords that appear in an experience's keywords.
+        Returns up to *top_k* experiences sorted by descending score, then recency.
+        Only entries with score > 0 are returned.
+        """
+        query_kws = set(_extract_keywords(query, max_words=30))
+        if not query_kws:
+            return []
+
+        scored: list[tuple[int, int, dict[str, Any]]] = []
+        with self._lock:
+            for idx, exp in enumerate(self._experiences):
+                exp_kws = set(exp.get("keywords", []))
+                overlap = len(query_kws & exp_kws)
+                if overlap > 0:
+                    scored.append((overlap, idx, exp))
+
+        # Sort by overlap desc, then by index desc (newer first).
+        scored.sort(key=lambda t: (t[0], t[1]), reverse=True)
+        return [entry for _, _, entry in scored[:top_k]]
+
+    def format_for_injection(self, experiences: list[dict[str, Any]]) -> str:
+        """Format retrieved experiences as a prompt prefix string."""
+        if not experiences:
+            return ""
+        lines = ["=== Relevant Past Experiences ==="]
+        for i, exp in enumerate(experiences, 1):
+            lines.append(f"{i}. {exp['hint']}")
+        lines.append("================================")
+        lines.append(
+            "Use the above experiences as context to improve your response. "
+            "They capture lessons learned from previous interactions."
+        )
+        return "\n".join(lines)
+
+    def stats(self) -> dict[str, Any]:
+        """Return summary statistics."""
+        with self._lock:
+            total = len(self._experiences)
+        return {
+            "total_experiences": total,
+            "store_path": self._store_path,
+        }

--- a/openclaw-training-free/prompt_injector.py
+++ b/openclaw-training-free/prompt_injector.py
@@ -1,0 +1,170 @@
+"""
+PromptInjector — retrieve past experiences and inject them into prompts.
+
+Works with :class:`ExperienceStore` to look up relevant hints and
+prepend them to the system message so the upstream LLM can benefit
+from accumulated experience without any parameter updates.
+
+Part of the **openclaw-exploop** project (training-free experience loop).
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any
+
+from experience_store import ExperienceStore
+
+logger = logging.getLogger(__name__)
+
+
+class PromptInjector:
+    """Inject retrieved experience hints into a message list.
+
+    Parameters
+    ----------
+    store : ExperienceStore
+        The backing experience store used for keyword retrieval.
+    max_exp_chars : int
+        Maximum total characters for the injected experience block.
+        Experiences are added in relevance order until the budget is
+        exhausted.
+    """
+
+    def __init__(
+        self,
+        store: ExperienceStore,
+        max_exp_chars: int = 800,
+    ) -> None:
+        self._store = store
+        self._max_exp_chars = max_exp_chars
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def inject(
+        self,
+        messages: list[dict[str, Any]],
+        query: str,
+        top_k: int = 3,
+    ) -> list[dict[str, Any]]:
+        """Return a *new* messages list with experiences prepended.
+
+        The original list is never mutated.
+
+        Steps:
+        1. Retrieve up to *top_k* experiences from the store.
+        2. Format them into a prefix string (respecting char budget).
+        3. Prepend the prefix to the first system message's content.
+           If no system message exists, create one at position 0.
+
+        If *query* is empty no retrieval is attempted and the original
+        messages are returned as-is (shallow copy).
+        """
+        if not query.strip():
+            return list(messages)
+
+        experiences = self._store.retrieve(query, top_k=top_k)
+        if not experiences:
+            return list(messages)  # shallow copy, nothing to inject
+
+        prefix = self._format(experiences)
+        if not prefix:
+            return list(messages)
+
+        logger.info(
+            "[PromptInjector] injecting %d experiences "
+            "(%d chars) for query=%r",
+            len(experiences), len(prefix), query[:60],
+        )
+
+        # Deep-copy to avoid mutating caller's data.
+        new_msgs: list[dict[str, Any]] = copy.deepcopy(messages)
+
+        # Find or create the system message.
+        sys_idx = self._find_system_index(new_msgs)
+        if sys_idx is not None:
+            original = new_msgs[sys_idx].get("content", "")
+            new_msgs[sys_idx]["content"] = (
+                prefix + "\n\n" + original
+            )
+        else:
+            new_msgs.insert(0, {
+                "role": "system",
+                "content": prefix,
+            })
+
+        return new_msgs
+
+    def inject_string(
+        self,
+        text: str,
+        query: str,
+        top_k: int = 3,
+    ) -> str:
+        """Convenience wrapper: inject experiences into a plain string.
+
+        Returns *text* prefixed with the experience block (if any).
+        """
+        if not query.strip():
+            return text
+
+        experiences = self._store.retrieve(query, top_k=top_k)
+        if not experiences:
+            return text
+        prefix = self._format(experiences)
+        if not prefix:
+            return text
+        return prefix + "\n\n" + text
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _find_system_index(
+        messages: list[dict[str, Any]],
+    ) -> int | None:
+        """Return the index of the first system message, or *None*."""
+        for idx, msg in enumerate(messages):
+            if msg.get("role") == "system":
+                return idx
+        return None
+
+    def _format(
+        self,
+        experiences: list[dict[str, Any]],
+    ) -> str:
+        """Format experiences into a prompt prefix within char budget."""
+        header = "=== Relevant Past Experiences ==="
+        footer_line1 = "================================"
+        footer_line2 = (
+            "Use the above experiences as context to improve "
+            "your response."
+        )
+        # Reserve space for header, footer, and newlines between them.
+        reserved = len(header) + len(footer_line1) + len(footer_line2) + 4
+        budget = self._max_exp_chars - reserved
+        if budget <= 0:
+            return ""
+
+        lines: list[str] = [header]
+        count = 0
+
+        for exp in experiences:
+            hint_text = exp.get("hint", "")
+            candidate = f"{count + 1}. {hint_text}"
+            if budget - len(candidate) < 0:
+                break
+            lines.append(candidate)
+            budget -= len(candidate)
+            count += 1
+
+        if count == 0:
+            return ""
+
+        lines.append(footer_line1)
+        lines.append(footer_line2)
+        return "\n".join(lines)

--- a/openclaw-training-free/requirements.txt
+++ b/openclaw-training-free/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+httpx
+pydantic

--- a/openclaw-training-free/training_free_server.py
+++ b/openclaw-training-free/training_free_server.py
@@ -1,0 +1,446 @@
+"""
+ExpLoop API Server — Training-Free Experience Loop
+
+Proxies requests to a real LLM, intercepts conversations, and
+asynchronously collects experience hints for future prompt injection.
+No model parameters are ever updated — all improvement comes from
+accumulated experience injected at prompt time.
+
+Usage::
+
+    UPSTREAM_BASE_URL=https://api.openai.com \\
+    UPSTREAM_API_KEY=sk-xxx \\
+    python training_free_server.py
+
+The server exposes an OpenAI-compatible ``/v1/chat/completions``
+endpoint.  Point any client at ``http://localhost:8080`` and chat
+normally — experience accumulation happens transparently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import time
+import uuid
+from collections import defaultdict
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import Any, AsyncGenerator
+
+import httpx
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from experience_extractor import ExperienceExtractor
+from experience_store import ExperienceStore
+from prompt_injector import PromptInjector
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s — %(message)s",
+)
+logger = logging.getLogger("training-free-server")
+
+# ---------------------------------------------------------------------------
+# Configuration (from environment)
+# ---------------------------------------------------------------------------
+
+UPSTREAM_BASE_URL: str = os.environ.get(
+    "UPSTREAM_BASE_URL", ""
+).rstrip("/")
+UPSTREAM_API_KEY: str = os.environ.get("UPSTREAM_API_KEY", "")
+
+JUDGE_BASE_URL: str = os.environ.get(
+    "JUDGE_BASE_URL", ""
+) or UPSTREAM_BASE_URL
+JUDGE_API_KEY: str = os.environ.get(
+    "JUDGE_API_KEY", ""
+) or UPSTREAM_API_KEY
+JUDGE_MODEL: str = os.environ.get("JUDGE_MODEL", "gpt-4o-mini")
+
+EXPERIENCE_STORE_PATH: str = os.environ.get(
+    "EXPERIENCE_STORE_PATH", "experiences.json"
+)
+TOP_K_EXPERIENCES: int = int(
+    os.environ.get("TOP_K_EXPERIENCES", "3")
+)
+PORT: int = int(os.environ.get("PORT", "8080"))
+
+# ---------------------------------------------------------------------------
+# Shared state
+# ---------------------------------------------------------------------------
+
+store = ExperienceStore(store_path=EXPERIENCE_STORE_PATH)
+extractor = ExperienceExtractor(
+    base_url=JUDGE_BASE_URL,
+    api_key=JUDGE_API_KEY,
+    model=JUDGE_MODEL,
+)
+injector = PromptInjector(store=store)
+
+# session_id → list of {"role": ..., "content": ...}
+# NOTE: conversation history is held in memory only and lost on restart.
+# This is by design — the persistent artefact is the experience store,
+# not the raw conversation log.
+conversation_history: dict[str, list[dict[str, str]]] = (
+    defaultdict(list)
+)
+
+
+@dataclass
+class PendingPair:
+    """A (response, next_user_message) pair waiting for hint extraction."""
+    response_text: str
+    next_user_message: str
+    session_id: str
+    created_at: float = field(default_factory=time.time)
+
+
+hint_queue: asyncio.Queue[PendingPair] = asyncio.Queue()
+
+# ---------------------------------------------------------------------------
+# Background worker
+# ---------------------------------------------------------------------------
+
+
+async def _hint_worker() -> None:
+    """Consume pending pairs, extract hints, store good ones."""
+    logger.info("[hint_worker] started")
+    while True:
+        pair: PendingPair = await hint_queue.get()
+        try:
+            hint = await extractor.extract_hint(
+                response_text=pair.response_text,
+                next_user_message=pair.next_user_message,
+                session_id=pair.session_id,
+            )
+            if hint:
+                store.add(
+                    hint=hint,
+                    response_text=pair.response_text,
+                    next_state_text=pair.next_user_message,
+                    session_id=pair.session_id,
+                )
+                logger.info(
+                    "[hint_worker] stored hint for session=%s",
+                    pair.session_id,
+                )
+            else:
+                logger.debug(
+                    "[hint_worker] no usable hint for session=%s",
+                    pair.session_id,
+                )
+        except Exception:
+            logger.exception(
+                "[hint_worker] unexpected error for session=%s",
+                pair.session_id,
+            )
+        finally:
+            hint_queue.task_done()
+
+
+# ---------------------------------------------------------------------------
+# FastAPI lifespan
+# ---------------------------------------------------------------------------
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    """Start the background hint-extraction worker on startup."""
+    worker_task = asyncio.create_task(_hint_worker())
+    logger.info(
+        "[server] ExpLoop server starting on port %d", PORT,
+    )
+    logger.info(
+        "[server] upstream=%s  judge=%s  store=%s  top_k=%d",
+        UPSTREAM_BASE_URL, JUDGE_BASE_URL,
+        EXPERIENCE_STORE_PATH, TOP_K_EXPERIENCES,
+    )
+    yield
+    worker_task.cancel()
+    try:
+        await worker_task
+    except asyncio.CancelledError:
+        pass
+    logger.info("[server] shutdown complete")
+
+
+app = FastAPI(
+    title="ExpLoop — Training-Free Experience Loop",
+    version="0.2.0",
+    lifespan=lifespan,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_session_id(body: dict[str, Any], request: Request) -> str:
+    """Derive a session id from the request body or connection metadata.
+
+    Priority:
+    1. Explicit ``session_id`` field in the request body.
+    2. ``user`` field in the request body (OpenAI convention).
+    3. ``Authorization`` header (hashed) — stable per API key.
+    4. Client IP address — stable per network origin.
+    5. Random UUID (last resort, but should rarely be reached now).
+
+    BUG FIX: the original code fell through to a random UUID when the
+    body lacked ``session_id``/``user``, which meant the same client
+    would get a new session on every request and lose conversation
+    continuity.
+    """
+    sid = body.get("session_id") or body.get("user")
+    if sid:
+        return str(sid)
+
+    # Use Authorization header hash as a stable session key.
+    auth = request.headers.get("authorization", "")
+    if auth:
+        return "auth-" + hashlib.sha256(auth.encode()).hexdigest()[:16]
+
+    # Fall back to client IP.
+    client_ip = request.client.host if request.client else ""
+    if client_ip:
+        return "ip-" + client_ip
+
+    # Absolute last resort.
+    return uuid.uuid4().hex[:12]
+
+
+def _last_user_text(messages: list[dict[str, Any]]) -> str:
+    """Return the content of the last user message, or empty string."""
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            return str(msg.get("content", ""))
+    return ""
+
+
+def _upstream_headers() -> dict[str, str]:
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if UPSTREAM_API_KEY:
+        headers["Authorization"] = f"Bearer {UPSTREAM_API_KEY}"
+    return headers
+
+
+# ---------------------------------------------------------------------------
+# Streaming proxy
+# ---------------------------------------------------------------------------
+
+async def _collect_streaming_content(
+    payload: dict[str, Any],
+) -> tuple[AsyncGenerator[bytes, None], asyncio.Future[str]]:
+    """Return a streaming generator AND a future that resolves to
+    the full assistant content once the stream is consumed.
+
+    We tee the stream: pass raw bytes to the client (preserving SSE
+    framing) while also parsing delta content tokens.
+
+    BUG FIX: the original implementation used ``aiter_lines()`` and
+    re-appended a single ``\\n``, which could corrupt SSE framing
+    (events are delimited by ``\\n\\n``).  We now use ``aiter_bytes()``
+    for the pass-through path and parse the accumulated buffer
+    separately for content extraction.
+    """
+    loop = asyncio.get_running_loop()
+    content_future: asyncio.Future[str] = loop.create_future()
+    collected_parts: list[str] = []
+
+    async def _gen() -> AsyncGenerator[bytes, None]:
+        url = f"{UPSTREAM_BASE_URL}/v1/chat/completions"
+        line_buffer = b""
+        try:
+            async with httpx.AsyncClient(timeout=120.0) as client:
+                async with client.stream(
+                    "POST", url,
+                    json=payload,
+                    headers=_upstream_headers(),
+                ) as resp:
+                    resp.raise_for_status()
+                    async for raw_chunk in resp.aiter_bytes():
+                        # Pass raw bytes to client unchanged (preserves
+                        # SSE double-newline framing).
+                        yield raw_chunk
+
+                        # Accumulate for content parsing.
+                        line_buffer += raw_chunk
+                        while b"\n" in line_buffer:
+                            line_bytes, line_buffer = (
+                                line_buffer.split(b"\n", 1)
+                            )
+                            line = line_bytes.decode(
+                                "utf-8", errors="replace"
+                            ).strip()
+                            if not line.startswith("data: "):
+                                continue
+                            data_str = line[6:]
+                            if data_str == "[DONE]":
+                                continue
+                            try:
+                                obj = json.loads(data_str)
+                                delta = (
+                                    obj.get("choices", [{}])[0]
+                                    .get("delta", {})
+                                    .get("content", "")
+                                )
+                                if delta:
+                                    collected_parts.append(delta)
+                            except (json.JSONDecodeError, IndexError):
+                                pass
+        except Exception as exc:
+            logger.error(
+                "[stream] upstream error: %s", exc,
+            )
+            if not content_future.done():
+                content_future.set_result("")
+            return
+        if not content_future.done():
+            content_future.set_result("".join(collected_parts))
+
+    return _gen(), content_future
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@app.post("/v1/chat/completions")
+async def chat_completions(request: Request) -> Any:
+    """OpenAI-compatible chat completions endpoint.
+
+    1. Inject past experiences into the prompt.
+    2. Forward to upstream LLM.
+    3. Enqueue the (prev_response, current_user_msg) pair for
+       asynchronous hint extraction.
+    """
+    if not UPSTREAM_BASE_URL:
+        return JSONResponse(
+            {"error": "UPSTREAM_BASE_URL not configured"},
+            status_code=500,
+        )
+
+    body: dict[str, Any] = await request.json()
+    messages: list[dict[str, Any]] = body.get("messages", [])
+    session_id = _resolve_session_id(body, request)
+    is_stream = body.get("stream", False)
+
+    user_text = _last_user_text(messages)
+
+    # --- Enqueue previous turn for hint extraction ----------------------
+    history = conversation_history[session_id]
+    if history and user_text:
+        # Previous assistant response + current user message
+        prev_assistant = ""
+        for msg in reversed(history):
+            if msg.get("role") == "assistant":
+                prev_assistant = msg.get("content", "")
+                break
+        if prev_assistant:
+            await hint_queue.put(PendingPair(
+                response_text=prev_assistant,
+                next_user_message=user_text,
+                session_id=session_id,
+            ))
+
+    # Record user message in history.
+    if user_text:
+        history.append({"role": "user", "content": user_text})
+
+    # --- Inject experiences ---------------------------------------------
+    enriched_messages = injector.inject(
+        messages, query=user_text, top_k=TOP_K_EXPERIENCES,
+    )
+    body["messages"] = enriched_messages
+
+    # --- Forward to upstream --------------------------------------------
+    if is_stream:
+        gen, content_future = await _collect_streaming_content(body)
+
+        async def _wrapped_stream() -> AsyncGenerator[bytes, None]:
+            async for chunk in gen:
+                yield chunk
+            # After stream completes, record assistant reply.
+            full_content = await content_future
+            if full_content:
+                history.append({
+                    "role": "assistant",
+                    "content": full_content,
+                })
+
+        return StreamingResponse(
+            _wrapped_stream(),
+            media_type="text/event-stream",
+        )
+
+    # Non-streaming path.
+    url = f"{UPSTREAM_BASE_URL}/v1/chat/completions"
+    try:
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            resp = await client.post(
+                url, json=body, headers=_upstream_headers(),
+            )
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.HTTPStatusError as exc:
+        logger.error("[proxy] upstream HTTP %s", exc.response.status_code)
+        return JSONResponse(
+            {"error": f"upstream error: {exc.response.status_code}"},
+            status_code=exc.response.status_code,
+        )
+    except (httpx.RequestError, Exception) as exc:
+        logger.error("[proxy] upstream request failed: %s", exc)
+        return JSONResponse(
+            {"error": f"upstream request failed: {exc}"},
+            status_code=502,
+        )
+
+    # Record assistant reply.
+    try:
+        assistant_content = (
+            data["choices"][0]["message"]["content"]
+        )
+        history.append({
+            "role": "assistant",
+            "content": assistant_content,
+        })
+    except (KeyError, IndexError):
+        pass
+
+    return JSONResponse(data)
+
+
+@app.get("/v1/experiences/stats")
+async def experience_stats() -> dict[str, Any]:
+    """Return experience store statistics."""
+    stats = store.stats()
+    stats["pending_hints"] = hint_queue.qsize()
+    stats["active_sessions"] = len(conversation_history)
+    return stats
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Basic health check."""
+    return {"status": "ok", "service": "openclaw-training-free"}
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    uvicorn.run(
+        "training_free_server:app",
+        host="0.0.0.0",
+        port=PORT,
+        log_level="info",
+    )


### PR DESCRIPTION
openclaw-training-free improves LLM responses over time without any model parameter updates, forming a self-improving experience loop:

  intercept → extract hint → store → inject → repeat

Every user follow-up is an implicit training signal. A Judge LLM makes it explicit; the experience store makes it persistent.

Components:
- training_free_server.py: OpenAI-compatible FastAPI proxy (streaming)
- experience_extractor.py: Judge LLM hint extraction via httpx
- experience_store.py:     keyword-indexed JSON experience library
- prompt_injector.py:      injects retrieved hints into system prompt