### PR TITLE
Add LoRA support for Track 1 through FSDP backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ Our long-term goal is to **advance personalized, practically useful agents with 
 #### Track 1 — [Personal Agent Optimization](#personalagent) (Small-Scale but Personal)
 ✅ **Release Track 1:** Fully async OpenClaw-RL framework with Binary RL + OPD  
 ✅ Best recipe discovery via demonstration experiments  
-⬜ Support Lora Training & low-precision training/inference  
+✅ Support LoRA Training
+⬜ Support low-precision training/inference
 ⬜ Deploy training on [Tinker](https://thinkingmachines.ai/tinker/)  
 ⬜ Beyond the policy: extend learning to skills and memory  
 
@@ -123,7 +124,7 @@ We welcome contributions that integrate new learning methods into the OpenClaw-R
 **Highly wanted contributions:**
 - ☁️ **Tinker cloud deployment** — run OpenClaw-RL training on [Tinker](https://thinkingmachines.ai/tinker/)
 - 🤖 **Qwen3.5 model support** — launch scripts and model configs for the Qwen3.5 family
-- 🔧 **LoRA & low-precision examples** — enable training on consumer-grade hardware with fewer GPUs
+- 🔧 **Low-precision training examples** — FP8/INT4 training scripts for existing methods
 
 <details>
 <summary><b>📋 Full contribution guidelines & feature wishlist</b></summary>
@@ -189,16 +190,15 @@ For changes within an existing method folder — such as supporting a new model 
 - Update READMEs to list Qwen3.5 as a supported model.
 
 
-### 3. 🔧 LoRA Training & Low-Precision Training/Inference Examples 
+### 3. 🔧 Low-Precision Training/Inference Examples
 
 **Type:** Extend existing method folders
 
-**Goal:** Add LoRA fine-tuning and low-precision (e.g., INT8/INT4 inference, BF16/FP8 training) example scripts to existing method folders, enabling users to run OpenClaw-RL on consumer-grade hardware with fewer GPUs.
+**Goal:** Add low-precision (e.g., INT8/INT4 inference, BF16/FP8 training) example scripts to existing method folders, enabling users to run OpenClaw-RL on consumer-grade hardware with fewer GPUs.
 
 **Requirements:**
 
-- Add **new** `.sh` scripts within existing method folders (e.g., `openclaw-combine/run_qwen3_4b_lora.sh`, `openclaw-rl/run_qwen3_4b_lora.sh`) — do not modify existing scripts.
-- LoRA training: demonstrate parameter-efficient fine-tuning with configurable rank, alpha, and target modules. Should work with 2–4 GPUs.
+- Add **new** `.sh` scripts within existing method folders — do not modify existing scripts.
 - Low-precision inference: demonstrate launching the SGLang rollout engine with quantized weights (e.g., AWQ/GPTQ INT4) to reduce VRAM for the serving side.
 - Low-precision training: if supported by the Megatron backend, demonstrate FP8 or mixed-precision configurations that reduce training memory.
 - Update the corresponding `README.md` in each method folder with a new section documenting these scripts.
@@ -278,6 +278,20 @@ bash ../openclaw-combine/run_qwen3_4b_openclaw_combine.sh
 This method combines binary RL and OPD to achieve the best optimization.
 
 See [`./openclaw-combine/README.md`](./openclaw-combine/README.md) for algorithm details.
+
+**With LoRA** (parameter-efficient, fewer GPUs):
+```bash
+bash ../openclaw-combine/run_qwen3_4b_openclaw_combine_lora.sh
+```
+
+All LoRA variants use PEFT LoRA adapters on the FSDP backend, training only ~0.8% of model parameters. After training, merge the adapter into a standard HF checkpoint:
+
+```bash
+python slime/tools/merge_lora_adapter.py \
+    --base-model /path/to/base_model \
+    --adapter /path/to/lora_checkpoint/model \
+    --output /path/to/merged_model
+```
 </details>
 
 
@@ -288,6 +302,11 @@ See [`./openclaw-combine/README.md`](./openclaw-combine/README.md) for algorithm
 ```bash
 cd slime
 bash ../openclaw-rl/run_qwen3_4b_openclaw_rl.sh
+```
+
+**With LoRA** (parameter-efficient, fewer GPUs):
+```bash
+bash ../openclaw-rl/run_qwen3_4b_openclaw_rl_lora.sh
 ```
 
 The PRM will automatically judge response quality from next-state feedback. We recommend providing frequent feedback (e.g., 👍/👎) to help the model optimize effectively.
@@ -303,6 +322,11 @@ See [`./openclaw-rl/README.md`](./openclaw-rl/README.md) for algorithm details.
 ```bash
 cd slime
 bash ../openclaw-opd/run_qwen3_4b_openclaw_opd.sh
+```
+
+**With LoRA** (parameter-efficient, fewer GPUs):
+```bash
+bash ../openclaw-opd/run_qwen3_4b_openclaw_opd_topk_lora.sh
 ```
 
 The system extracts hindsight hints from your feedback and distills them into the policy at the token level. We recommend providing concrete feedback (e.g., "you should have checked the file first" or "don't use that library").

--- a/openclaw-combine/run_qwen3_4b_openclaw_combine_lora.sh
+++ b/openclaw-combine/run_qwen3_4b_openclaw_combine_lora.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+
+pkill -9 sglang
+sleep 3
+ray stop --force
+pkill -9 ray
+pkill -9 python
+sleep 3
+pkill -9 ray
+pkill -9 python
+
+set -ex
+
+# keep stdout/stderr unbuffered in ray jobs
+export PYTHONUNBUFFERED=1
+export PYTHONFAULTHANDLER=1
+
+NUM_GPUS=${NUM_GPUS:-4}
+ACTOR_GPUS=${ACTOR_GPUS:-2}
+ROLLOUT_GPUS=${ROLLOUT_GPUS:-1}
+PRM_GPUS=${PRM_GPUS:-1}
+
+if (( ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS > NUM_GPUS )); then
+    echo "ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS must be <= NUM_GPUS"
+    echo "ACTOR_GPUS=${ACTOR_GPUS}, ROLLOUT_GPUS=${ROLLOUT_GPUS}, PRM_GPUS=${PRM_GPUS}, NUM_GPUS=${NUM_GPUS}"
+    exit 1
+fi
+
+export RAY_health_check_failure_threshold=20
+export RAY_health_check_period_ms=5000
+export RAY_health_check_timeout_ms=30000
+export RAY_num_heartbeats_timeout=60
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+SLIME_ROOT="$(cd -- "${SCRIPT_DIR}/../slime" &>/dev/null && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+
+HF_CKPT=${HF_CKPT:-${REPO_ROOT}/models/Qwen3-4B}
+REF_LOAD=${REF_LOAD:-${HF_CKPT}}
+SAVE_CKPT=${SAVE_CKPT:-${REPO_ROOT}/ckpt/qwen3-4b-openclaw-combine-lora}
+PRM_MODEL_PATH=${PRM_MODEL_PATH:-${HF_CKPT}}
+
+export SGLANG_API_KEY="${SGLANG_API_KEY}"
+export SERVED_MODEL_NAME="qwen3-4b"
+export HOST="0.0.0.0"
+export PORT="30000"
+export OPENCLAW_RECORD_ENABLED="${OPENCLAW_RECORD_ENABLED:-1}"  # 0=off, 1=on
+export OPENCLAW_RECORD_FILE="${SCRIPT_DIR}/results/qwen3_4b_lora_record.jsonl"
+export TP="${TP:-1}"
+export CONTEXT_LENGTH="32768"
+export MEM_FRACTION_STATIC="0.85"
+export REASONING_PARSER="qwen3"
+export TOOL_CALL_PARSER="${TOOL_CALL_PARSER:-qwen25}"
+export PRM_M="${PRM_M:-1}"
+export OPENCLAW_OPD_TEACHER_LP_MAX_CONCURRENCY="${OPENCLAW_OPD_TEACHER_LP_MAX_CONCURRENCY:-1}"
+export OPENCLAW_COMBINE_W_RL="${OPENCLAW_COMBINE_W_RL:-1.0}"
+export OPENCLAW_COMBINE_W_OPD="${OPENCLAW_COMBINE_W_OPD:-1.0}"
+
+
+CKPT_ARGS=(
+   --hf-checkpoint "${HF_CKPT}"
+   --ref-load "${REF_LOAD}"
+   --save "${SAVE_CKPT}"
+   --save-interval 1
+)
+
+ROLLOUT_ARGS=(
+   --disable-rollout-global-dataset
+   --rollout-function-path openclaw_combine_rollout.generate_rollout_openclaw_combine
+
+   --num-rollout 100000000
+   --rollout-batch-size 16
+   --n-samples-per-prompt 1
+   --rollout-max-response-len 8192
+   --rollout-max-context-len 32768
+   --rollout-temperature 0.6
+   --reward-key score
+
+   --num-steps-per-rollout 1
+)
+
+PERF_ARGS=(
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu "${MAX_TOKENS_PER_GPU:-8192}"
+   --gradient-checkpointing
+)
+
+COMBINE_ARGS=(
+   --advantage-estimator grpo
+   --disable-rewards-normalization
+   --loss-type custom_loss
+   --custom-loss-function-path combine_loss.combine_loss_function
+   --use-kl-loss
+   --kl-loss-coef 0.0
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-5
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+)
+
+LORA_ARGS=(
+   --use-lora
+   --lora-rank 16
+   --lora-alpha 32
+   --lora-target-modules "q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj"
+)
+
+EVAL_ARGS=()
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine "${TP}"
+   --sglang-tool-call-parser "${TOOL_CALL_PARSER}"
+   --sglang-mem-fraction-static 0.85
+   --sglang-context-length 32768
+   --sglang-reasoning-parser qwen3
+)
+
+PRM_ARGS=(
+   --prm-enable
+   --prm-num-gpus "${PRM_GPUS}"
+   --prm-num-gpus-per-engine "${PRM_TP:-${TP}}"
+   --prm-model-path "${PRM_MODEL_PATH}"
+   --prm-m "${PRM_M}"
+   --prm-temperature "${PRM_TEMPERATURE:-0.6}"
+   --prm-max-new-tokens "${PRM_MAX_NEW_TOKENS:-4096}"
+)
+
+CUSTOM_ARGS=(
+   --custom-generate-function-path openclaw_combine_api_server.generate
+   --custom-rm-path openclaw_combine_api_server.reward_func
+)
+
+USE_WANDB=${USE_WANDB:-1}
+WANDB_PROJECT=${WANDB_PROJECT:-openclaw_rl}
+WANDB_KEY_VALUE=${WANDB_KEY:-${WANDB_API_KEY:-}}
+if [ "${USE_WANDB}" = "1" ] && [ -n "${WANDB_KEY_VALUE}" ]; then
+  WANDB_ARGS=(
+    --use-wandb
+    --wandb-project ${WANDB_PROJECT}
+    --wandb-group qwen3-4b-openclaw-combine-lora
+    --wandb-key ${WANDB_KEY_VALUE}
+  )
+else
+  WANDB_ARGS=()
+fi
+
+export OPENCLAW_EVAL_MODE="${OPENCLAW_EVAL_MODE:-1}"
+
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+export no_proxy="127.0.0.1,${MASTER_ADDR}"
+ray start --head --node-ip-address "${MASTER_ADDR}" --num-gpus "${NUM_GPUS}" --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"${SCRIPT_DIR}:${SCRIPT_DIR}/../openclaw-opd:${SLIME_ROOT}\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"OPENCLAW_EVAL_MODE\": \"${OPENCLAW_EVAL_MODE}\",
+    \"OPENCLAW_COMBINE_W_RL\": \"${OPENCLAW_COMBINE_W_RL}\",
+    \"OPENCLAW_COMBINE_W_OPD\": \"${OPENCLAW_COMBINE_W_OPD}\"
+  }
+}"
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 train_async.py \
+   --train-backend fsdp \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node "${ACTOR_GPUS}" \
+   --rollout-num-gpus "${ROLLOUT_GPUS}" \
+   --num-gpus-per-node "${NUM_GPUS}" \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${COMBINE_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${EVAL_ARGS[@]} \
+   ${SGLANG_ARGS[@]} \
+   ${WANDB_ARGS[@]} \
+   ${CUSTOM_ARGS[@]} \
+   ${PRM_ARGS[@]} \
+   ${LORA_ARGS[@]}

--- a/openclaw-opd/run_qwen3_4b_openclaw_opd_topk_lora.sh
+++ b/openclaw-opd/run_qwen3_4b_openclaw_opd_topk_lora.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+pkill -9 sglang
+sleep 3
+ray stop --force
+pkill -9 ray
+pkill -9 python
+sleep 3
+pkill -9 ray
+pkill -9 python
+
+set -ex
+
+# keep stdout/stderr unbuffered in ray jobs
+export PYTHONUNBUFFERED=1
+export PYTHONFAULTHANDLER=1
+
+NUM_GPUS=${NUM_GPUS:-4}
+ACTOR_GPUS=${ACTOR_GPUS:-2}
+ROLLOUT_GPUS=${ROLLOUT_GPUS:-1}
+PRM_GPUS=${PRM_GPUS:-1}
+
+if (( ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS > NUM_GPUS )); then
+    echo "ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS must be <= NUM_GPUS"
+    echo "ACTOR_GPUS=${ACTOR_GPUS}, ROLLOUT_GPUS=${ROLLOUT_GPUS}, PRM_GPUS=${PRM_GPUS}, NUM_GPUS=${NUM_GPUS}"
+    exit 1
+fi
+
+export RAY_health_check_failure_threshold=20
+export RAY_health_check_period_ms=5000
+export RAY_health_check_timeout_ms=30000
+export RAY_num_heartbeats_timeout=60
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+SLIME_ROOT="$(cd -- "${SCRIPT_DIR}/../slime" &>/dev/null && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+
+HF_CKPT=${HF_CKPT:-${REPO_ROOT}/models/Qwen3-4B}
+REF_LOAD=${REF_LOAD:-${HF_CKPT}}
+SAVE_CKPT=${SAVE_CKPT:-${REPO_ROOT}/ckpt/qwen3-4b-openclaw-opd-topk-lora}
+PRM_MODEL_PATH=${PRM_MODEL_PATH:-${HF_CKPT}}
+
+export SGLANG_API_KEY="${SGLANG_API_KEY}"
+export SERVED_MODEL_NAME="qwen3-4b"
+export HOST="0.0.0.0"
+export PORT="30000"
+export OPENCLAW_RECORD_ENABLED="${OPENCLAW_RECORD_ENABLED:-1}"  # 0=off, 1=on
+export OPENCLAW_RECORD_FILE="${SCRIPT_DIR}/results/qwen3_4b_lora_record.jsonl"
+export TP="${TP:-1}"
+export CONTEXT_LENGTH="32768"
+export MEM_FRACTION_STATIC="0.85"
+export REASONING_PARSER="qwen3"
+export TOOL_CALL_PARSER="${TOOL_CALL_PARSER:-qwen25}"
+export PRM_M="${PRM_M:-3}"
+export OPENCLAW_OPD_TEACHER_LP_MAX_CONCURRENCY="${OPENCLAW_OPD_TEACHER_LP_MAX_CONCURRENCY:-3}"
+
+
+CKPT_ARGS=(
+   --hf-checkpoint "${HF_CKPT}"
+   --ref-load "${REF_LOAD}"
+   --save "${SAVE_CKPT}"
+   --save-interval 1
+)
+
+ROLLOUT_ARGS=(
+   --disable-rollout-global-dataset
+   --rollout-function-path openclaw_opd_rollout.generate_rollout_openclaw_opd
+
+   --num-rollout 100000000
+   --rollout-batch-size 4
+   --n-samples-per-prompt 1
+   --rollout-max-response-len 8192
+   --rollout-max-context-len 32768
+   --rollout-temperature 0.6
+   --reward-key score
+
+   --num-steps-per-rollout 1
+)
+
+PERF_ARGS=(
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu "${MAX_TOKENS_PER_GPU:-8192}"
+   --gradient-checkpointing
+)
+
+OPD_ARGS=(
+   --loss-type custom_loss
+   --custom-loss-function-path topk_distillation_loss.topk_distillation_loss_function
+   --distill-topk 50
+   --disable-compute-advantages-and-returns
+   # OPD rewards are dummy 1.0 values; without this flag, _drop_constant_reward_groups
+   # treats each single-sample group as "constant" and drops all but one, causing an
+   # empty-partition crash when dp_size > 1 (e.g. FSDP with ACTOR_GPUS >= 2).
+   --disable-rewards-normalization
+   --entropy-coef 0.00
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+)
+
+LORA_ARGS=(
+   --use-lora
+   --lora-rank 16
+   --lora-alpha 32
+   --lora-target-modules "q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj"
+)
+
+EVAL_ARGS=()
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine "${TP}"
+   --sglang-tool-call-parser "${TOOL_CALL_PARSER}"
+   --sglang-mem-fraction-static 0.85
+   --sglang-context-length 32768
+   --sglang-reasoning-parser qwen3
+)
+
+PRM_ARGS=(
+   --prm-enable
+   --prm-num-gpus "${PRM_GPUS}"
+   --prm-num-gpus-per-engine "${PRM_TP:-${TP}}"
+   --prm-model-path "${PRM_MODEL_PATH}"
+   --prm-m "${PRM_M}"
+   --prm-temperature "${PRM_TEMPERATURE:-0.6}"
+   --prm-max-new-tokens "${PRM_MAX_NEW_TOKENS:-4096}"
+)
+
+CUSTOM_ARGS=(
+   --custom-generate-function-path openclaw_opd_api_server.generate
+   --custom-rm-path openclaw_opd_api_server.reward_func
+)
+
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+export no_proxy="127.0.0.1,${MASTER_ADDR}"
+ray start --head --node-ip-address "${MASTER_ADDR}" --num-gpus "${NUM_GPUS}" --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"${SCRIPT_DIR}:${SLIME_ROOT}\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\"
+  }
+}"
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 train_async.py \
+   --train-backend fsdp \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node "${ACTOR_GPUS}" \
+   --rollout-num-gpus "${ROLLOUT_GPUS}" \
+   --num-gpus-per-node "${NUM_GPUS}" \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${OPD_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${EVAL_ARGS[@]} \
+   ${SGLANG_ARGS[@]} \
+   ${CUSTOM_ARGS[@]} \
+   ${PRM_ARGS[@]} \
+   ${LORA_ARGS[@]}

--- a/openclaw-rl/run_qwen3_4b_openclaw_rl_lora.sh
+++ b/openclaw-rl/run_qwen3_4b_openclaw_rl_lora.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+
+pkill -9 sglang
+sleep 3
+ray stop --force
+pkill -9 ray
+pkill -9 python
+sleep 3
+pkill -9 ray
+pkill -9 python
+
+set -ex
+
+# keep stdout/stderr unbuffered in ray jobs
+export PYTHONUNBUFFERED=1
+export PYTHONFAULTHANDLER=1
+
+NUM_GPUS=${NUM_GPUS:-4}
+ACTOR_GPUS=${ACTOR_GPUS:-2}
+ROLLOUT_GPUS=${ROLLOUT_GPUS:-1}
+PRM_GPUS=${PRM_GPUS:-1}
+
+if (( ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS > NUM_GPUS )); then
+    echo "ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS must be <= NUM_GPUS"
+    echo "ACTOR_GPUS=${ACTOR_GPUS}, ROLLOUT_GPUS=${ROLLOUT_GPUS}, PRM_GPUS=${PRM_GPUS}, NUM_GPUS=${NUM_GPUS}"
+    exit 1
+fi
+
+export RAY_health_check_failure_threshold=20
+export RAY_health_check_period_ms=5000
+export RAY_health_check_timeout_ms=30000
+export RAY_num_heartbeats_timeout=60
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+SLIME_ROOT="$(cd -- "${SCRIPT_DIR}/../slime" &>/dev/null && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+
+HF_CKPT=${HF_CKPT:-${REPO_ROOT}/models/Qwen3-4B}
+REF_LOAD=${REF_LOAD:-${HF_CKPT}}
+SAVE_CKPT=${SAVE_CKPT:-${REPO_ROOT}/ckpt/qwen3-4b-openclaw-rl-lora}
+PRM_MODEL_PATH=${PRM_MODEL_PATH:-${HF_CKPT}}
+
+export SGLANG_API_KEY="${SGLANG_API_KEY}"
+export SERVED_MODEL_NAME="qwen3-4b"
+export HOST="0.0.0.0"
+export PORT="30000"
+export OPENCLAW_RECORD_ENABLED="${OPENCLAW_RECORD_ENABLED:-1}"  # 0=off, 1=on
+export OPENCLAW_RECORD_FILE="${SCRIPT_DIR}/results/qwen3_4b_lora_record.jsonl"
+export TP="${TP:-1}"
+export CONTEXT_LENGTH="32768"
+export MEM_FRACTION_STATIC="0.85"
+export REASONING_PARSER="qwen3"
+export TOOL_CALL_PARSER="${TOOL_CALL_PARSER:-qwen25}"
+export PRM_M="${PRM_M:-3}"
+
+
+CKPT_ARGS=(
+   --hf-checkpoint "${HF_CKPT}"
+   --ref-load "${REF_LOAD}"
+   --save "${SAVE_CKPT}"
+   --save-interval 1
+)
+
+ROLLOUT_ARGS=(
+   --disable-rollout-global-dataset
+   --rollout-function-path openclaw_rollout.generate_rollout_openclaw
+
+   --num-rollout 100000000
+   --rollout-batch-size 16
+   --n-samples-per-prompt 1
+   --rollout-max-response-len 8192
+   --rollout-max-context-len 32768
+   --rollout-temperature 0.6
+   --reward-key score
+
+   --num-steps-per-rollout 1
+)
+
+PERF_ARGS=(
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu "${MAX_TOKENS_PER_GPU:-8192}"
+   --gradient-checkpointing
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --disable-rewards-normalization
+   --use-kl-loss
+   --kl-loss-coef 0.0
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-5
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+)
+
+LORA_ARGS=(
+   --use-lora
+   --lora-rank 16
+   --lora-alpha 32
+   --lora-target-modules "q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj"
+)
+
+EVAL_ARGS=()
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine "${TP}"
+   --sglang-tool-call-parser "${TOOL_CALL_PARSER}"
+   --sglang-mem-fraction-static 0.85
+   --sglang-context-length 32768
+   --sglang-reasoning-parser qwen3
+)
+
+PRM_ARGS=(
+   --prm-enable
+   --prm-num-gpus "${PRM_GPUS}"
+   --prm-num-gpus-per-engine "${PRM_TP:-${TP}}"
+   --prm-model-path "${PRM_MODEL_PATH}"
+   --prm-m "${PRM_M}"
+   --prm-temperature "${PRM_TEMPERATURE:-0.6}"
+   --prm-max-new-tokens "${PRM_MAX_NEW_TOKENS:-4096}"
+)
+
+CUSTOM_ARGS=(
+   --custom-generate-function-path openclaw_api_server.generate
+   --custom-rm-path openclaw_api_server.reward_func
+)
+
+USE_WANDB=${USE_WANDB:-1}
+WANDB_PROJECT=${WANDB_PROJECT:-openclaw_rl}
+WANDB_KEY_VALUE=${WANDB_KEY:-${WANDB_API_KEY:-}}
+if [ "${USE_WANDB}" = "1" ] && [ -n "${WANDB_KEY_VALUE}" ]; then
+  WANDB_ARGS=(
+    --use-wandb
+    --wandb-project ${WANDB_PROJECT}
+    --wandb-group qwen3-4b-openclaw-rl-lora
+    --wandb-key ${WANDB_KEY_VALUE}
+  )
+else
+  WANDB_ARGS=()
+fi
+
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+export no_proxy="127.0.0.1,${MASTER_ADDR}"
+ray start --head --node-ip-address "${MASTER_ADDR}" --num-gpus "${NUM_GPUS}" --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"${SCRIPT_DIR}:${SLIME_ROOT}\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\"
+  }
+}"
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 train_async.py \
+   --train-backend fsdp \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node "${ACTOR_GPUS}" \
+   --rollout-num-gpus "${ROLLOUT_GPUS}" \
+   --num-gpus-per-node "${NUM_GPUS}" \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${GRPO_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${EVAL_ARGS[@]} \
+   ${SGLANG_ARGS[@]} \
+   ${WANDB_ARGS[@]} \
+   ${CUSTOM_ARGS[@]} \
+   ${PRM_ARGS[@]} \
+   ${LORA_ARGS[@]}

--- a/openclaw-test/README.md
+++ b/openclaw-test/README.md
@@ -118,9 +118,19 @@ cd slime
 bash ../openclaw-combine/run_qwen3_4b_openclaw_combine.sh
 ```
 
+**Combined with LoRA** (parameter-efficient, fewer GPUs):
+```bash
+bash ../openclaw-combine/run_qwen3_4b_openclaw_combine_lora.sh
+```
+
 **Binary RL:**
 ```bash
 bash ../openclaw-rl/run_qwen3_4b_openclaw_rl.sh
+```
+
+**Binary RL with LoRA** (parameter-efficient, fewer GPUs):
+```bash
+bash ../openclaw-rl/run_qwen3_4b_openclaw_rl_lora.sh
 ```
 
 **On-Policy Distillation (OPD):**
@@ -128,7 +138,10 @@ bash ../openclaw-rl/run_qwen3_4b_openclaw_rl.sh
 bash ../openclaw-opd/run_qwen3_4b_openclaw_opd.sh
 ```
 
-
+**OPD with LoRA** (parameter-efficient, fewer GPUs):
+```bash
+bash ../openclaw-opd/run_qwen3_4b_openclaw_opd_topk_lora.sh
+```
 
 > **Eval mode:** To enable evaluation logging with W&B, set `OPENCLAW_EVAL_MODE=1` and provide your W&B key via `WANDB_KEY` before launching. This is already the default in the OPD and Combine scripts.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -177,6 +177,7 @@ outlines_core==0.1.26
 overrides==7.7.0
 packaging==25.0
 pandas==2.3.3
+peft>=0.12.0
 parso==0.8.5
 partial-json-parser==0.2.1.1.post7
 pathspec==1.0.1

--- a/slime/slime/backends/fsdp_utils/actor.py
+++ b/slime/slime/backends/fsdp_utils/actor.py
@@ -93,6 +93,14 @@ class FSDPTrainRayActor(TrainRayActor):
 
         model.train()
 
+        # Apply LoRA adapters before FSDP wrapping
+        self._is_lora = getattr(self.args, "use_lora", False)
+        if self._is_lora:
+            from .lora_utils import apply_lora, propagate_no_split_modules
+
+            model = apply_lora(model, self.args)
+            model = propagate_no_split_modules(model)
+
         full_state = model.state_dict()
 
         model = apply_fsdp2(model, mesh=self.dp_mesh, cpu_offload=self.fsdp_cpu_offload, args=self.args)
@@ -104,11 +112,21 @@ class FSDPTrainRayActor(TrainRayActor):
         self.model = model
 
         if args.gradient_checkpointing:
-            self.model.gradient_checkpointing_enable()
+            # LoRA freezes base params, so reentrant checkpointing fails
+            # (inputs don't have requires_grad=True). Use non-reentrant mode.
+            gc_kwargs = {"use_reentrant": False} if self._is_lora else {}
+            self.model.gradient_checkpointing_enable(gradient_checkpointing_kwargs=gc_kwargs)
+
+        # For LoRA, only pass trainable parameters to the optimizer
+        optim_params = (
+            [p for p in self.model.parameters() if p.requires_grad]
+            if self._is_lora
+            else self.model.parameters()
+        )
 
         if args.optimizer == "adam":
             self.optimizer = torch.optim.AdamW(
-                self.model.parameters(),
+                optim_params,
                 lr=args.lr,
                 betas=(args.adam_beta1, args.adam_beta2),
                 eps=args.adam_eps,
@@ -135,6 +153,23 @@ class FSDPTrainRayActor(TrainRayActor):
             if self.args.colocate
             else UpdateWeightFromDistributed(self.args, self.model)
         )
+
+        # When LoRA is enabled, PEFT wraps parameter names with prefixes that
+        # SGLang doesn't understand.  Strip them and skip adapter-only params.
+        if self._is_lora:
+
+            def _lora_name_transform(name: str) -> str | None:
+                # Skip LoRA adapter parameters — SGLang only needs merged base weights
+                if "lora_A" in name or "lora_B" in name or "lora_embedding" in name:
+                    return None
+                # Strip PEFT outer prefix: base_model.model.xxx → xxx
+                if name.startswith("base_model.model."):
+                    name = name[len("base_model.model."):]
+                # Strip .base_layer. inserted by PEFT for LoRA-targeted modules
+                name = name.replace(".base_layer.", ".")
+                return name
+
+            self.weight_updater._name_transform = _lora_name_transform
 
         checkpoint.finalize_load(self, checkpoint_payload)
 
@@ -539,7 +574,12 @@ class FSDPTrainRayActor(TrainRayActor):
             if dist.get_rank() == 0:
                 logger.info(f"Updating ref model at rollout_id {rollout_id}")
             # Copy actor model state to ref model
-            actor_state = self.model.state_dict()
+            if self._is_lora:
+                from .lora_utils import get_merged_state_dict
+
+                actor_state = get_merged_state_dict(self.model)
+            else:
+                actor_state = self.model.state_dict()
             self.ref_model.load_state_dict(actor_state)
             self.ref_model.cpu()
 
@@ -735,7 +775,15 @@ class FSDPTrainRayActor(TrainRayActor):
             if dist.get_rank() == 0:
                 ray.get(self.rollout_manager.clear_num_new_engines.remote())
 
-        self.weight_updater.update_weights()
+        # Merge LoRA into base weights before syncing to SGLang rollout engines.
+        # SGLang doesn't understand LoRA adapters, so it needs the merged model.
+        if self._is_lora:
+            self.model.merge_adapter()
+        try:
+            self.weight_updater.update_weights()
+        finally:
+            if self._is_lora:
+                self.model.unmerge_adapter()
 
         if self.args.ci_test and len(rollout_engines) > 0:
             engine = random.choice(rollout_engines)
@@ -936,8 +984,12 @@ def apply_fsdp2(model, mesh=None, cpu_offload=False, args=None):
 
     offload_policy = CPUOffloadPolicy() if cpu_offload else None
 
-    layer_cls_to_wrap = model._no_split_modules
-    assert len(layer_cls_to_wrap) > 0 and layer_cls_to_wrap[0] is not None
+    layer_cls_to_wrap = getattr(model, "_no_split_modules", None)
+    # When PEFT wraps the model, _no_split_modules may live on the inner model
+    if not layer_cls_to_wrap and hasattr(model, "base_model"):
+        inner = getattr(model.base_model, "model", model.base_model)
+        layer_cls_to_wrap = getattr(inner, "_no_split_modules", None)
+    assert layer_cls_to_wrap and len(layer_cls_to_wrap) > 0 and layer_cls_to_wrap[0] is not None
 
     modules = [
         module

--- a/slime/slime/backends/fsdp_utils/arguments.py
+++ b/slime/slime/backends/fsdp_utils/arguments.py
@@ -47,6 +47,14 @@ class FSDPArgs:
 
     deterministic_mode: bool = False  # This name must be the same as Megatron's
 
+    # LoRA / PEFT
+    use_lora: bool = False
+    lora_rank: int = 8
+    lora_alpha: int = 16
+    lora_dropout: float = 0.0
+    lora_target_modules: str | None = None  # comma-separated, e.g. "q_proj,v_proj"
+    lora_modules_to_save: str | None = None  # modules kept fully trainable
+
     # Profile
     record_memory_history: bool = False
     memory_snapshot_path: str = "snapshot.pickle"

--- a/slime/slime/backends/fsdp_utils/checkpoint.py
+++ b/slime/slime/backends/fsdp_utils/checkpoint.py
@@ -108,16 +108,29 @@ def load(actor: Any) -> dict[str, Any] | None:
         logger.info(f"[FSDP] Model checkpoint {model_dir} not found; skipping load.")
         return None
 
-    # Load model weights (always)
-    model_state = ModelState(actor.model)
-    state_dict = {"model_state": model_state}
+    # Load model weights (LoRA-only when applicable)
+    is_lora = getattr(actor, "_is_lora", False)
+    adapter_file = model_dir / "adapter_weights.pt"
 
-    try:
-        dcp.load(state_dict=state_dict, checkpoint_id=str(model_dir))
-        logger.info(f"[FSDP] Loaded model from {model_dir}")
-    except Exception as e:
-        logger.error(f"[FSDP] Failed to load model from {model_dir}: {e}")
-        return None
+    if is_lora and adapter_file.exists():
+        from .lora_utils import load_lora_checkpoint
+
+        try:
+            load_lora_checkpoint(actor.model, model_dir)
+            logger.info(f"[FSDP] Loaded LoRA adapter from {model_dir}")
+        except Exception as e:
+            logger.error(f"[FSDP] Failed to load LoRA adapter from {model_dir}: {e}")
+            return None
+    else:
+        model_state = ModelState(actor.model)
+        state_dict = {"model_state": model_state}
+
+        try:
+            dcp.load(state_dict=state_dict, checkpoint_id=str(model_dir))
+            logger.info(f"[FSDP] Loaded model from {model_dir}")
+        except Exception as e:
+            logger.error(f"[FSDP] Failed to load model from {model_dir}: {e}")
+            return None
 
     # Load optimizer state (optional)
     load_optimizer = not getattr(actor.args, "no_load_optim", False) and hasattr(actor, "optimizer")
@@ -209,10 +222,16 @@ def save(actor: Any, iteration: int) -> None:
         lr_scheduler_dir.mkdir(parents=True, exist_ok=True)
     dist.barrier()
 
-    # Save model weights
-    model_state = ModelState(actor.model)
-    state_dict = {"model_state": model_state}
-    dcp.save(state_dict, checkpoint_id=str(model_dir))
+    # Save model weights (LoRA-only when applicable)
+    is_lora = getattr(actor, "_is_lora", False)
+    if is_lora:
+        from .lora_utils import save_lora_checkpoint
+
+        save_lora_checkpoint(actor.model, model_dir)
+    else:
+        model_state = ModelState(actor.model)
+        state_dict = {"model_state": model_state}
+        dcp.save(state_dict, checkpoint_id=str(model_dir))
 
     # Save optimizer state (skip if --no-save-optim is set)
     save_optimizer_state = not getattr(actor.args, "no_save_optim", False)

--- a/slime/slime/backends/fsdp_utils/lora_utils.py
+++ b/slime/slime/backends/fsdp_utils/lora_utils.py
@@ -1,0 +1,185 @@
+"""LoRA utilities for FSDP-based training.
+
+Provides helpers to apply HuggingFace PEFT LoRA adapters to a model,
+save/load LoRA-only checkpoints, and merge/unmerge adapters for weight sync.
+"""
+
+from __future__ import annotations
+
+import logging
+from argparse import Namespace
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+
+logger = logging.getLogger(__name__)
+
+
+def apply_lora(model: torch.nn.Module, args: Namespace) -> torch.nn.Module:
+    """Wrap *model* with PEFT LoRA adapters according to *args*.
+
+    Returns the PeftModel wrapper.  All base-model parameters are frozen;
+    only the LoRA parameters are trainable.
+    """
+    from peft import LoraConfig, get_peft_model
+
+    target_modules = None
+    if args.lora_target_modules:
+        target_modules = [m.strip() for m in args.lora_target_modules.split(",")]
+
+    modules_to_save = None
+    if args.lora_modules_to_save:
+        modules_to_save = [m.strip() for m in args.lora_modules_to_save.split(",")]
+
+    lora_config = LoraConfig(
+        r=args.lora_rank,
+        lora_alpha=args.lora_alpha,
+        lora_dropout=args.lora_dropout,
+        target_modules=target_modules,
+        modules_to_save=modules_to_save,
+        bias="none",
+        task_type="CAUSAL_LM",
+    )
+
+    model = get_peft_model(model, lora_config)
+
+    if dist.get_rank() == 0:
+        model.print_trainable_parameters()
+
+    return model
+
+
+def propagate_no_split_modules(model: torch.nn.Module) -> torch.nn.Module:
+    """Ensure ``_no_split_modules`` is visible through the PEFT wrapper.
+
+    PEFT wraps the original model as ``model.base_model.model``.  FSDP's
+    ``apply_fsdp2`` reads ``model._no_split_modules`` to decide which layers
+    to shard individually.  This helper copies the attribute up when missing.
+    """
+    if getattr(model, "_no_split_modules", None):
+        return model
+
+    # PeftModel -> LoraModel -> original HF model
+    inner = getattr(model, "base_model", None)
+    if inner is not None:
+        inner = getattr(inner, "model", inner)
+    if inner is not None:
+        no_split = getattr(inner, "_no_split_modules", None)
+        if no_split:
+            model._no_split_modules = no_split
+            logger.info(f"Propagated _no_split_modules from inner model: {no_split}")
+
+    return model
+
+
+def save_lora_checkpoint(model: torch.nn.Module, path: Path) -> None:
+    """Save only the LoRA adapter weights + config to *path*.
+
+    Only rank 0 writes to disk.  All ranks participate in the state-dict
+    gathering (handled by FSDP through ``state_dict()``).
+    """
+    from torch.distributed.checkpoint.state_dict import StateDictOptions, get_model_state_dict
+
+    # Gather full state dict (FSDP2 sharded -> full)
+    full_state = get_model_state_dict(
+        model,
+        options=StateDictOptions(full_state_dict=True, cpu_offload=True),
+    )
+
+    if dist.get_rank() == 0:
+        # Filter to only LoRA keys
+        lora_state = {k: v for k, v in full_state.items() if "lora_" in k}
+        path.mkdir(parents=True, exist_ok=True)
+        torch.save(lora_state, path / "adapter_weights.pt")
+
+        # Save the PEFT config so we can reload
+        if hasattr(model, "peft_config"):
+            import json
+
+            for adapter_name, cfg in model.peft_config.items():
+                cfg_dict = cfg.to_dict()
+                # Convert sets to sorted lists for JSON serialization
+                for k, v in cfg_dict.items():
+                    if isinstance(v, set):
+                        cfg_dict[k] = sorted(v)
+                with open(path / "adapter_config.json", "w") as f:
+                    json.dump(cfg_dict, f, indent=2)
+                break  # Only save the first (default) adapter
+
+        logger.info(f"Saved LoRA adapter ({len(lora_state)} tensors) to {path}")
+
+    dist.barrier()
+
+
+def load_lora_checkpoint(model: torch.nn.Module, path: Path) -> None:
+    """Load LoRA adapter weights from *path* into *model*.
+
+    Broadcasts from rank 0 to all other ranks.
+    """
+    from torch.distributed.checkpoint.state_dict import StateDictOptions, set_model_state_dict
+
+    adapter_file = path / "adapter_weights.pt"
+    if not adapter_file.exists():
+        logger.warning(f"No LoRA adapter found at {adapter_file}; skipping load.")
+        return
+
+    if dist.get_rank() == 0:
+        lora_state = torch.load(adapter_file, map_location="cpu", weights_only=True)
+        logger.info(f"Loaded LoRA adapter ({len(lora_state)} tensors) from {path}")
+    else:
+        lora_state = {}
+
+    # Build a full state dict with LoRA weights overlaid
+    full_state = {}
+    for name, param in model.named_parameters():
+        if "lora_" in name:
+            if name in lora_state:
+                full_state[name] = lora_state[name]
+
+    if full_state:
+        set_model_state_dict(
+            model,
+            full_state,
+            options=StateDictOptions(
+                full_state_dict=True,
+                cpu_offload=True,
+                broadcast_from_rank0=True,
+                strict=False,
+            ),
+        )
+        logger.info(f"Loaded {len(full_state)} LoRA parameters from checkpoint.")
+
+    dist.barrier()
+
+
+def get_merged_state_dict(model: torch.nn.Module) -> dict[str, torch.Tensor]:
+    """Return a merged (base + LoRA) state dict on CPU.
+
+    Merges the adapter in-place, copies the state dict, then unmerges.
+    The returned dict uses base-model keys (no ``lora_`` or ``base_model.`` prefixes).
+    """
+    model.merge_adapter()
+    try:
+        from torch.distributed.checkpoint.state_dict import StateDictOptions, get_model_state_dict
+
+        merged_state = get_model_state_dict(
+            model,
+            options=StateDictOptions(full_state_dict=True, cpu_offload=True),
+        )
+        # Strip PEFT wrapper prefixes so keys match the original HF model
+        cleaned = {}
+        for k, v in merged_state.items():
+            # Skip lora-specific keys (they've been merged into base)
+            if "lora_" in k:
+                continue
+            # Strip common PEFT prefixes
+            clean_key = k
+            for prefix in ["base_model.model.", "base_model."]:
+                if clean_key.startswith(prefix):
+                    clean_key = clean_key[len(prefix):]
+                    break
+            cleaned[clean_key] = v
+        return cleaned
+    finally:
+        model.unmerge_adapter()

--- a/slime/slime/backends/fsdp_utils/update_weight_utils.py
+++ b/slime/slime/backends/fsdp_utils/update_weight_utils.py
@@ -34,6 +34,7 @@ class UpdateWeight(abc.ABC):
         self.args = args
         self.model = model
         self.weight_version = 0
+        self._name_transform = None  # Optional: callable(name) -> new_name or None to skip
 
     @abc.abstractmethod
     def connect_rollout_engines(
@@ -48,6 +49,10 @@ class UpdateWeight(abc.ABC):
         bucket = []
         bucket_size = 0
         for name, param in self.model.state_dict().items():
+            if self._name_transform is not None:
+                name = self._name_transform(name)
+                if name is None:
+                    continue
             param_size = param.numel() * param.element_size()
             if bucket and bucket_size + param_size >= self.args.update_weight_buffer_size:
                 self.wait_and_update_bucket_weights(bucket)

--- a/slime/slime/utils/arguments.py
+++ b/slime/slime/utils/arguments.py
@@ -1881,6 +1881,9 @@ def slime_validate_args(args):
     if args.only_train_params_name_list and args.freeze_params_name_list:
         raise ValueError("You can only specify ONE of: --only-train-params-name-list, or --freeze-params-name-list.")
 
+    if getattr(args, "use_lora", False):
+        assert args.train_backend == "fsdp", "LoRA is only supported with --train-backend fsdp"
+
 
 def hf_validate_args(args, hf_config):
     def equal(x, y):

--- a/slime/tools/merge_lora_adapter.py
+++ b/slime/tools/merge_lora_adapter.py
@@ -1,0 +1,129 @@
+"""Merge a LoRA adapter into a base HuggingFace model and export.
+
+Usage:
+    python merge_lora_adapter.py \
+        --base-model /path/to/Qwen3-4B \
+        --adapter /path/to/lora_checkpoint/model \
+        --output /path/to/merged_model
+
+The merged model can then be quantized with existing tools:
+    python convert_hf_to_fp8.py ...
+    python convert_hf_to_int4.py ...
+"""
+
+import argparse
+import os
+import shutil
+
+import torch
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Merge LoRA adapter into base model")
+    parser.add_argument("--base-model", type=str, required=True, help="Path to base HuggingFace model")
+    parser.add_argument("--adapter", type=str, required=True, help="Path to LoRA adapter directory")
+    parser.add_argument("--output", type=str, required=True, help="Output directory for merged model")
+    parser.add_argument("-f", "--force", action="store_true", help="Overwrite output directory if it exists")
+    args = parser.parse_args()
+
+    if os.path.exists(args.output) and not args.force:
+        raise ValueError(f"Output directory {args.output} already exists. Use --force to overwrite.")
+
+    print(f"Loading base model from {args.base_model}")
+    from transformers import AutoConfig, AutoModelForCausalLM, AutoModelForImageTextToText
+
+    config = AutoConfig.from_pretrained(args.base_model, trust_remote_code=True)
+    model_cls = AutoModelForImageTextToText if hasattr(config, "vision_config") else AutoModelForCausalLM
+    model = model_cls.from_pretrained(args.base_model, trust_remote_code=True, torch_dtype=torch.bfloat16)
+
+    # Load LoRA adapter weights
+    adapter_weights_path = os.path.join(args.adapter, "adapter_weights.pt")
+    adapter_config_path = os.path.join(args.adapter, "adapter_config.json")
+
+    if os.path.exists(adapter_config_path):
+        # Load via PEFT if config is available
+        print(f"Loading LoRA adapter via PEFT from {args.adapter}")
+        from peft import LoraConfig, get_peft_model
+
+        import json
+
+        with open(adapter_config_path) as f:
+            lora_cfg = json.load(f)
+
+        peft_config = LoraConfig(**{k: v for k, v in lora_cfg.items() if k in LoraConfig.__dataclass_fields__})
+        model = get_peft_model(model, peft_config)
+
+        if os.path.exists(adapter_weights_path):
+            lora_state = torch.load(adapter_weights_path, map_location="cpu", weights_only=True)
+            # Load LoRA weights into the PEFT model
+            model_state = model.state_dict()
+            for k, v in lora_state.items():
+                if k in model_state:
+                    model_state[k] = v
+            model.load_state_dict(model_state, strict=False)
+
+        print("Merging LoRA adapter into base model...")
+        model = model.merge_and_unload()
+    elif os.path.exists(adapter_weights_path):
+        # Manual merge: load LoRA weights and add to base
+        print(f"Loading LoRA weights from {adapter_weights_path}")
+        lora_state = torch.load(adapter_weights_path, map_location="cpu", weights_only=True)
+        print(f"Loaded {len(lora_state)} LoRA tensors")
+
+        # Group by module: find pairs of lora_A and lora_B
+        # Key pattern: base_model.model.<module>.lora_A.default.weight
+        from collections import defaultdict
+
+        modules = defaultdict(dict)
+        for k, v in lora_state.items():
+            if "lora_A" in k:
+                base_key = k.split(".lora_A")[0]
+                modules[base_key]["A"] = v
+            elif "lora_B" in k:
+                base_key = k.split(".lora_B")[0]
+                modules[base_key]["B"] = v
+
+        model_state = model.state_dict()
+        merged_count = 0
+        for module_key, ab in modules.items():
+            if "A" not in ab or "B" not in ab:
+                continue
+            # Strip PEFT prefix to find base model key
+            base_key = module_key
+            for prefix in ["base_model.model.", "base_model."]:
+                if base_key.startswith(prefix):
+                    base_key = base_key[len(prefix):]
+                    break
+            weight_key = f"{base_key}.weight"
+            if weight_key in model_state:
+                # LoRA merge: W = W + B @ A * (alpha / r)
+                delta = ab["B"].float() @ ab["A"].float()
+                model_state[weight_key] = model_state[weight_key].float() + delta
+                model_state[weight_key] = model_state[weight_key].to(torch.bfloat16)
+                merged_count += 1
+
+        model.load_state_dict(model_state)
+        print(f"Merged {merged_count} LoRA modules into base model")
+    else:
+        raise FileNotFoundError(f"No adapter found at {args.adapter}. Expected adapter_weights.pt or adapter_config.json")
+
+    # Save merged model
+    os.makedirs(args.output, exist_ok=True)
+    print(f"Saving merged model to {args.output}")
+    model.save_pretrained(args.output, safe_serialization=True)
+
+    # Copy tokenizer and other assets from base model
+    for filename in os.listdir(args.base_model):
+        if filename.endswith(".safetensors") or filename == "model.safetensors.index.json":
+            continue
+        src = os.path.join(args.base_model, filename)
+        if os.path.isfile(src):
+            dst = os.path.join(args.output, filename)
+            if not os.path.exists(dst):
+                shutil.copy(src, dst)
+
+    print(f"Done! Merged model saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Like the title suggests. Some discussions can be found at https://github.com/Gen-Verse/OpenClaw-RL/issues/19.

Summary:

- Add LoRA (Low-Rank Adaptation) training support for all three Track 1 optimization methods: Binary RL, OPD, and Combined, via the FSDP backend
- Implement LoRA utilities in slime (`slime/slime/backends/fsdp_utils/lora_utils.py`) with configurable rank, alpha, and target modules
- Add `slime/tools/merge_lora_adapter.py` tool for merging LoRA adapters into standard HF checkpoints
- Add launch scripts: `openclaw-rl/run_qwen3_4b_openclaw_rl_lora.sh`, `openclaw-opd/run_qwen3_4b_openclaw_opd_topk_lora.sh`, `openclaw-combine/run_qwen3_4b_openclaw_combine_lora.sh`
- Update README and openclaw-test README with LoRA options for each method

What has been tested:

  - Tested LoRA training for all three methods (RL, OPD, Combined) using the openclaw-test evaluation suite (GSM8K student/teacher chat) with 4 H200 GPUs (2 for actor, 1 for rollout, and 1 for PRM). By changing the `MAX_TOKENS_PER_GPU` parameter I would expect that using fewer GPUs or having bigger models (8B, 14B, etc) should work out-of-the-box
  - Verified checkpoint saving with LoRA adapters
  - Verified adapter merging via merge_lora_adapter.py