### PR TITLE
feat: add Qwen3.5-4B launch scripts

### DIFF
--- a/openclaw-combine/README.md
+++ b/openclaw-combine/README.md
@@ -43,6 +43,16 @@ cd slime
 bash ../openclaw-combine/run_qwen3_4b_openclaw_combine.sh
 ```
 
+### Qwen3.5-4B
+
+Use the Qwen3.5 launch script and pass the local checkpoint path through environment variables:
+
+```bash
+HF_CKPT=/path/to/Qwen3.5-4B \
+PRM_MODEL_PATH=/path/to/Qwen3.5-4B \
+bash ../openclaw-combine/run_qwen3.5_4b_openclaw_combine.sh
+```
+
 ### Key Environment Variables
 
 | Variable | Default | Description |
@@ -59,6 +69,7 @@ All other variables (`NUM_GPUS`, `ACTOR_GPUS`, `HF_CKPT`, etc.) are shared with 
 openclaw-combine/
 ├── README.md
 ├── run_qwen3_4b_openclaw_combine.sh   # Launch script
+├── run_qwen3.5_4b_openclaw_combine.sh # Qwen3.5-4B launch script
 ├── openclaw_combine_api_server.py     # Async proxy: hint judge + PRM eval + sample submission
 ├── openclaw_combine_rollout.py        # Rollout bridge to SLIME trainer
 ├── combine_loss.py                    # Weighted advantage: w_rl * GRPO + w_opd * teacher

--- a/openclaw-combine/run_qwen3.5_4b_openclaw_combine.sh
+++ b/openclaw-combine/run_qwen3.5_4b_openclaw_combine.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+
+pkill -9 sglang
+sleep 3
+ray stop --force
+pkill -9 ray
+pkill -9 python
+sleep 3
+pkill -9 ray
+pkill -9 python
+
+set -ex
+
+export PYTHONUNBUFFERED=1
+export PYTHONFAULTHANDLER=1
+
+NUM_GPUS=${NUM_GPUS:-8}
+ACTOR_GPUS=${ACTOR_GPUS:-4}
+ROLLOUT_GPUS=${ROLLOUT_GPUS:-2}
+PRM_GPUS=${PRM_GPUS:-2}
+
+if (( ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS > NUM_GPUS )); then
+    echo "ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS must be <= NUM_GPUS"
+    echo "ACTOR_GPUS=${ACTOR_GPUS}, ROLLOUT_GPUS=${ROLLOUT_GPUS}, PRM_GPUS=${PRM_GPUS}, NUM_GPUS=${NUM_GPUS}"
+    exit 1
+fi
+
+export RAY_health_check_failure_threshold=20
+export RAY_health_check_period_ms=5000
+export RAY_health_check_timeout_ms=30000
+export RAY_num_heartbeats_timeout=60
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+SLIME_ROOT="${REPO_ROOT}/slime"
+TRAIN_ASYNC="${SLIME_ROOT}/train_async.py"
+source "${SLIME_ROOT}/scripts/models/qwen3.5-4B.sh"
+
+HF_CKPT=${HF_CKPT:-/path/to/Qwen3.5-4B}
+REF_LOAD=${REF_LOAD:-${HF_CKPT}}
+SAVE_CKPT=${SAVE_CKPT:-${REPO_ROOT}/ckpt/qwen3.5-4b-openclaw-combine}
+PRM_MODEL_PATH=${PRM_MODEL_PATH:-${HF_CKPT}}
+
+if [ ! -d "${HF_CKPT}" ]; then
+    echo "HF_CKPT does not exist: ${HF_CKPT}"
+    echo "Set HF_CKPT to your local Qwen3.5-4B checkpoint path."
+    exit 1
+fi
+
+export SGLANG_API_KEY="${SGLANG_API_KEY}"
+export SERVED_MODEL_NAME="qwen3.5-4b"
+export HOST="0.0.0.0"
+export PORT="30000"
+export OPENCLAW_RECORD_ENABLED="${OPENCLAW_RECORD_ENABLED:-1}"  # 0=off, 1=on
+export OPENCLAW_RECORD_FILE="${SCRIPT_DIR}/results/qwen3.5_4b_record.jsonl"
+export TP="2"
+export CONTEXT_LENGTH="32768"
+export MEM_FRACTION_STATIC="0.8"
+export REASONING_PARSER="qwen3"
+export TOOL_CALL_PARSER="${TOOL_CALL_PARSER:-qwen25}"
+export PRM_M="${PRM_M:-1}"
+export OPENCLAW_OPD_TEACHER_LP_MAX_CONCURRENCY="${OPENCLAW_OPD_TEACHER_LP_MAX_CONCURRENCY:-1}"
+export OPENCLAW_COMBINE_W_RL="${OPENCLAW_COMBINE_W_RL:-1.0}"
+export OPENCLAW_COMBINE_W_OPD="${OPENCLAW_COMBINE_W_OPD:-1.0}"
+
+CKPT_ARGS=(
+   --megatron-to-hf-mode bridge
+   --hf-checkpoint "${HF_CKPT}"
+   --ref-load "${REF_LOAD}"
+   --save "${SAVE_CKPT}"
+   --save-interval 100
+   --rotary-base 10000000
+)
+
+ROLLOUT_ARGS=(
+   --disable-rollout-global-dataset
+   --rollout-function-path openclaw_combine_rollout.generate_rollout_openclaw_combine
+
+   --num-rollout 100000000
+   --rollout-batch-size 16
+   --n-samples-per-prompt 1
+   --rollout-max-response-len 8192
+   --rollout-max-context-len 32768
+   --rollout-temperature 0.6
+   --reward-key score
+
+   --num-steps-per-rollout 1
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 4
+   --sequence-parallel
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 32768
+   --log-probs-chunk-size 1024
+)
+
+COMBINE_ARGS=(
+   --advantage-estimator grpo
+   --disable-rewards-normalization
+   --loss-type custom_loss
+   --custom-loss-function-path combine_loss.combine_loss_function
+   --use-kl-loss
+   --kl-loss-coef 0.0
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-5
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+)
+
+EVAL_ARGS=()
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 2
+   --sglang-tool-call-parser "${TOOL_CALL_PARSER}"
+   --sglang-mem-fraction-static 0.8
+   --sglang-context-length 32768
+   --sglang-reasoning-parser qwen3
+)
+
+PRM_ARGS=(
+   --prm-enable
+   --prm-num-gpus "${PRM_GPUS}"
+   --prm-num-gpus-per-engine 2
+   --prm-model-path "${PRM_MODEL_PATH}"
+   --prm-m "${PRM_M}"
+   --prm-temperature "${PRM_TEMPERATURE:-0.6}"
+   --prm-max-new-tokens "${PRM_MAX_NEW_TOKENS:-8192}"
+)
+
+CUSTOM_ARGS=(
+   --custom-generate-function-path openclaw_combine_api_server.generate
+   --custom-rm-path openclaw_combine_api_server.reward_func
+)
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+)
+
+USE_WANDB=${USE_WANDB:-1}
+WANDB_PROJECT=${WANDB_PROJECT:-openclaw_rl}
+WANDB_KEY_VALUE=${WANDB_KEY:-${WANDB_API_KEY:-}}
+if [ "${USE_WANDB}" = "1" ] && [ -n "${WANDB_KEY_VALUE}" ]; then
+  WANDB_ARGS=(
+    --use-wandb
+    --wandb-project ${WANDB_PROJECT}
+    --wandb-group qwen3.5-4b-openclaw-combine
+    --wandb-key ${WANDB_KEY_VALUE}
+  )
+else
+  WANDB_ARGS=()
+fi
+
+export OPENCLAW_EVAL_MODE="${OPENCLAW_EVAL_MODE:-1}"
+
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+export no_proxy="127.0.0.1,${MASTER_ADDR}"
+ray start --head --node-ip-address "${MASTER_ADDR}" --num-gpus "${NUM_GPUS}" --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"${REPO_ROOT}/Megatron-LM:${SCRIPT_DIR}:${REPO_ROOT}/openclaw-opd:${SLIME_ROOT}\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"OPENCLAW_EVAL_MODE\": \"${OPENCLAW_EVAL_MODE}\",
+    \"OPENCLAW_COMBINE_W_RL\": \"${OPENCLAW_COMBINE_W_RL}\",
+    \"OPENCLAW_COMBINE_W_OPD\": \"${OPENCLAW_COMBINE_W_OPD}\"
+  }
+}"
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 "${TRAIN_ASYNC}" \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node "${ACTOR_GPUS}" \
+   --rollout-num-gpus "${ROLLOUT_GPUS}" \
+   --num-gpus-per-node "${NUM_GPUS}" \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${COMBINE_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${EVAL_ARGS[@]} \
+   ${SGLANG_ARGS[@]} \
+   ${MISC_ARGS[@]} \
+   ${WANDB_ARGS[@]} \
+   ${CUSTOM_ARGS[@]} \
+   ${PRM_ARGS[@]}

--- a/openclaw-rl/README.md
+++ b/openclaw-rl/README.md
@@ -45,6 +45,16 @@ cd slime
 bash ../openclaw-rl/run_qwen3_4b_openclaw_rl.sh
 ```
 
+### Qwen3.5-4B
+
+Use the Qwen3.5 launch script and pass the local checkpoint path through environment variables:
+
+```bash
+HF_CKPT=/path/to/Qwen3.5-4B \
+PRM_MODEL_PATH=/path/to/Qwen3.5-4B \
+bash ../openclaw-rl/run_qwen3.5_4b_openclaw_rl.sh
+```
+
 
 
 ## File Structure
@@ -53,6 +63,7 @@ bash ../openclaw-rl/run_qwen3_4b_openclaw_rl.sh
 openclaw-rl/
 ├── README.md
 ├── run_qwen3_4b_openclaw_rl.sh     # Launch script
+├── run_qwen3.5_4b_openclaw_rl.sh   # Qwen3.5-4B launch script
 ├── openclaw_api_server.py           # FastAPI proxy + PRM scoring + sample submission
 ├── openclaw_rollout.py              # Async rollout worker (bridges API server ↔ SLIME trainer)
 └── results/                         # Runtime records (auto-created)

--- a/openclaw-rl/run_qwen3.5_4b_openclaw_rl.sh
+++ b/openclaw-rl/run_qwen3.5_4b_openclaw_rl.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+
+pkill -9 sglang
+sleep 3
+ray stop --force
+pkill -9 ray
+pkill -9 python
+sleep 3
+pkill -9 ray
+pkill -9 python
+
+set -ex
+
+# keep stdout/stderr unbuffered in ray jobs
+export PYTHONUNBUFFERED=1
+export PYTHONFAULTHANDLER=1
+
+NUM_GPUS=${NUM_GPUS:-8}
+ACTOR_GPUS=${ACTOR_GPUS:-4}
+ROLLOUT_GPUS=${ROLLOUT_GPUS:-2}
+PRM_GPUS=${PRM_GPUS:-2}
+
+if (( ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS > NUM_GPUS )); then
+    echo "ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS must be <= NUM_GPUS"
+    echo "ACTOR_GPUS=${ACTOR_GPUS}, ROLLOUT_GPUS=${ROLLOUT_GPUS}, PRM_GPUS=${PRM_GPUS}, NUM_GPUS=${NUM_GPUS}"
+    exit 1
+fi
+
+export RAY_health_check_failure_threshold=20
+export RAY_health_check_period_ms=5000
+export RAY_health_check_timeout_ms=30000
+export RAY_num_heartbeats_timeout=60
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+SLIME_ROOT="${REPO_ROOT}/slime"
+TRAIN_ASYNC="${SLIME_ROOT}/train_async.py"
+source "${SLIME_ROOT}/scripts/models/qwen3.5-4B.sh"
+
+HF_CKPT=${HF_CKPT:-/path/to/Qwen3.5-4B}
+REF_LOAD=${REF_LOAD:-${HF_CKPT}}
+SAVE_CKPT=${SAVE_CKPT:-${REPO_ROOT}/ckpt/qwen3.5-4b-openclaw-rl}
+PRM_MODEL_PATH=${PRM_MODEL_PATH:-${HF_CKPT}}
+
+if [ ! -d "${HF_CKPT}" ]; then
+    echo "HF_CKPT does not exist: ${HF_CKPT}"
+    echo "Set HF_CKPT to your local Qwen3.5-4B checkpoint path."
+    exit 1
+fi
+
+export SGLANG_API_KEY="${SGLANG_API_KEY}"
+export SERVED_MODEL_NAME="qwen3.5-4b"
+export HOST="0.0.0.0"
+export PORT="30000"
+export OPENCLAW_RECORD_ENABLED="${OPENCLAW_RECORD_ENABLED:-1}"  # 0=off, 1=on
+export OPENCLAW_RECORD_FILE="${SCRIPT_DIR}/results/qwen3.5_4b_record.jsonl"
+export TP="2"
+export CONTEXT_LENGTH="32768"
+export MEM_FRACTION_STATIC="0.85"
+export REASONING_PARSER="qwen3"
+export TOOL_CALL_PARSER="${TOOL_CALL_PARSER:-qwen25}"
+export PRM_M="${PRM_M:-3}"
+
+
+CKPT_ARGS=(
+   --megatron-to-hf-mode bridge
+   --hf-checkpoint "${HF_CKPT}"
+   --ref-load "${REF_LOAD}"
+   --save "${SAVE_CKPT}"
+   --save-interval 100
+   --rotary-base 10000000
+)
+
+ROLLOUT_ARGS=(
+   --disable-rollout-global-dataset
+   --rollout-function-path openclaw_rollout.generate_rollout_openclaw
+
+   --num-rollout 100000000
+   --rollout-batch-size 16
+   --n-samples-per-prompt 1
+   --rollout-max-response-len 8192
+   --rollout-max-context-len 32768
+   --rollout-temperature 0.6
+   --reward-key score
+
+   --num-steps-per-rollout 1
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 4
+   --sequence-parallel
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 32768
+   --log-probs-chunk-size 1024
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --disable-rewards-normalization
+   --use-kl-loss
+   --kl-loss-coef 0.0
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-5
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+)
+
+
+
+EVAL_ARGS=()
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 2
+   --sglang-tool-call-parser "${TOOL_CALL_PARSER}"
+   --sglang-mem-fraction-static 0.85
+   --sglang-context-length 32768
+   --sglang-reasoning-parser qwen3
+)
+
+PRM_ARGS=(
+   --prm-enable
+   --prm-num-gpus "${PRM_GPUS}"
+   --prm-num-gpus-per-engine 2
+   --prm-model-path "${PRM_MODEL_PATH}"
+   --prm-m "${PRM_M}"
+   --prm-temperature "${PRM_TEMPERATURE:-0.6}"
+   --prm-max-new-tokens "${PRM_MAX_NEW_TOKENS:-4096}"
+)
+
+CUSTOM_ARGS=(
+   --custom-generate-function-path openclaw_api_server.generate
+   --custom-rm-path openclaw_api_server.reward_func
+)
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+)
+
+USE_WANDB=${USE_WANDB:-1}
+WANDB_PROJECT=${WANDB_PROJECT:-openclaw_rl}
+WANDB_KEY_VALUE=${WANDB_KEY:-${WANDB_API_KEY:-}}
+if [ "${USE_WANDB}" = "1" ] && [ -n "${WANDB_KEY_VALUE}" ]; then
+  WANDB_ARGS=(
+    --use-wandb
+    --wandb-project ${WANDB_PROJECT}
+    --wandb-group qwen3.5-4b-openclaw-rl
+    --wandb-key ${WANDB_KEY_VALUE}
+  )
+else
+  WANDB_ARGS=()
+fi
+
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+export no_proxy="127.0.0.1,${MASTER_ADDR}"
+ray start --head --node-ip-address "${MASTER_ADDR}" --num-gpus "${NUM_GPUS}" --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"${REPO_ROOT}/Megatron-LM:${SCRIPT_DIR}:${SLIME_ROOT}\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\"
+  }
+}"
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 "${TRAIN_ASYNC}" \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node "${ACTOR_GPUS}" \
+   --rollout-num-gpus "${ROLLOUT_GPUS}" \
+   --num-gpus-per-node "${NUM_GPUS}" \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${GRPO_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${EVAL_ARGS[@]} \
+   ${SGLANG_ARGS[@]} \
+   ${MISC_ARGS[@]} \
+   ${WANDB_ARGS[@]} \
+   ${CUSTOM_ARGS[@]} \
+   ${PRM_ARGS[@]}


### PR DESCRIPTION
Add Qwen3.5-4B launch scripts for:
  - `openclaw-rl`
  - `openclaw-combine`

  ## Files
  - `openclaw-rl/run_qwen3.5_4b_openclaw_rl.sh`
  - `openclaw-combine/run_qwen3.5_4b_openclaw_combine.sh`
  - `openclaw-rl/README.md`
  - `openclaw-combine/README.md`

I tested the Qwen3.5-4B launch path locally:
- Ray job starts successfully
- SGLang loads the model successfully
- OpenClaw API starts successfully
- Chat completion works correctly
