### PR TITLE
add bundled skill-bridge plugin for self-skill-manage and skill learning loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,8 @@ See [`./openclaw-test/README.md`](./openclaw-test/README.md) for setup and algor
 
 Install OpenClaw from the version bundled in this repository (we will update it regularly):
 
+If you want local file-backed skill authoring in the bundled OpenClaw runtime, see [`openclaw/extensions/skill-bridge/README.md`](./openclaw/extensions/skill-bridge/README.md).
+
 <details>
 <summary><b>Then configure OpenClaw to route requests to your RL server. </b></summary>
 
@@ -554,7 +556,6 @@ When using OpenClaw-RL, please do not provide sensitive personal information dur
 
 
 ---
-
 
 
 

--- a/openclaw/extensions/skill-bridge/README.md
+++ b/openclaw/extensions/skill-bridge/README.md
@@ -1,0 +1,36 @@
+# Skill Bridge
+
+`skill-bridge` adds a `skill_manage` agent tool backed by a bundled Python skill manager.
+
+The plugin is aimed at OpenClaw setups that want writable, file-backed skill authoring from the agent runtime without depending on a separate external package layout.
+
+## Behavior
+
+- Registers a `skill_manage` tool for creating, patching, editing, and deleting `SKILL.md`-based skills.
+- Stores skills in `<workspace>/skills` by default.
+- Adds lightweight prompt guidance and periodic nudges for memory and skill persistence.
+- Enqueues a flush reminder before compaction/reset unless disabled.
+
+## Config
+
+Configure under `plugins.entries.skill-bridge.config`:
+
+```json
+{
+  "pythonPath": "python3",
+  "skillsDir": "/absolute/path/to/skills",
+  "memoryNudgeInterval": 8,
+  "skillNudgeInterval": 15,
+  "enqueueFlushReminder": true
+}
+```
+
+Notes:
+
+- `pythonPath` defaults to `python3`.
+- `skillsDir` is optional. If omitted, the plugin writes to the current workspace `skills/` directory.
+- If both `skillsDir` and `workspaceDir` are unavailable, tool execution fails fast.
+
+## Development
+
+The Python implementation is bundled under [`python/`](./python) so the plugin does not depend on repository-root Python modules or custom `sys.path` setup.

--- a/openclaw/extensions/skill-bridge/index.test.ts
+++ b/openclaw/extensions/skill-bridge/index.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPluginRuntimeMock } from "../test-utils/plugin-runtime-mock.js";
+
+const spawnSyncMock = vi.fn();
+
+vi.mock("node:child_process", () => ({
+  spawnSync: spawnSyncMock,
+}));
+
+import register from "./index.js";
+
+describe("skill-bridge plugin", () => {
+  const hooks: Record<string, Function> = {};
+  const registerTool = vi.fn();
+  const enqueueSystemEvent = vi.fn();
+  const api = {
+    id: "skill-bridge",
+    name: "Skill Bridge",
+    pluginConfig: {},
+    config: {},
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    runtime: createPluginRuntimeMock({
+      system: {
+        enqueueSystemEvent: enqueueSystemEvent as any,
+      },
+    }),
+    resolvePath: vi.fn((input: string) =>
+      input === "." ? "/repo/openclaw/extensions/skill-bridge" : input,
+    ),
+    registerTool,
+    on: vi.fn((name: string, handler: Function) => {
+      hooks[name] = handler;
+    }),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    spawnSyncMock.mockReset();
+    for (const key of Object.keys(hooks)) {
+      delete hooks[key];
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers tool and lifecycle hooks", () => {
+    register(api as any);
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    expect(registerTool).toHaveBeenCalledWith(expect.any(Function), { name: "skill_manage" });
+    expect(api.on).toHaveBeenCalledWith("before_prompt_build", expect.any(Function));
+    expect(api.on).toHaveBeenCalledWith("after_tool_call", expect.any(Function));
+    expect(api.on).toHaveBeenCalledWith("before_compaction", expect.any(Function));
+    expect(api.on).toHaveBeenCalledWith("before_reset", expect.any(Function));
+    expect(api.on).toHaveBeenCalledWith("session_end", expect.any(Function));
+  });
+
+  it("executes the bundled python bridge with workspace skills by default", async () => {
+    register(api as any);
+    const toolFactory = registerTool.mock.calls[0]?.[0] as Function;
+    const tool = toolFactory({ workspaceDir: "/tmp/workspace" });
+
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ success: true, message: "ok" }),
+      stderr: "",
+    });
+
+    const result = await tool.execute("call-1", {
+      action: "create",
+      name: "demo-skill",
+      category: "workspace",
+      content: "---\nname: demo-skill\ndescription: demo\n---\nbody",
+    });
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      "python3",
+      [
+        "/repo/openclaw/extensions/skill-bridge/python/bridge_runner.py",
+        expect.any(String),
+      ],
+      expect.objectContaining({
+        cwd: "/repo/openclaw/extensions/skill-bridge",
+        env: expect.objectContaining({
+          SKILL_PLUGIN_SKILLS_DIR: "/tmp/workspace/skills",
+          SKILL_PLUGIN_TOOL_NAME: "skill_manage",
+        }),
+      }),
+    );
+    expect(JSON.parse(spawnSyncMock.mock.calls[0]?.[1]?.[1] as string)).toEqual({
+      action: "create",
+      name: "demo-skill",
+      content: "---\nname: demo-skill\ndescription: demo\n---\nbody",
+    });
+    expect(result).toMatchObject({
+      content: [
+        {
+          type: "text",
+          text: expect.stringContaining('"success": true'),
+        },
+      ],
+      details: {
+        success: true,
+        message: "ok",
+      },
+    });
+  });
+
+  it("adds flush reminders when enabled", async () => {
+    register(api as any);
+
+    await hooks.before_compaction({}, { sessionKey: "session-1" });
+    await hooks.before_reset({}, { sessionKey: "session-1" });
+
+    expect(enqueueSystemEvent).toHaveBeenCalledTimes(2);
+    expect(enqueueSystemEvent).toHaveBeenCalledWith(
+      expect.stringContaining("Context may be compacted or reset soon."),
+      { sessionKey: "session-1" },
+    );
+  });
+});

--- a/openclaw/extensions/skill-bridge/index.ts
+++ b/openclaw/extensions/skill-bridge/index.ts
@@ -1,0 +1,233 @@
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import type { AnyAgentTool, OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { jsonResult, readStringParam } from "openclaw/plugin-sdk";
+
+const TOOL_NAME = "skill_manage";
+
+const SKILL_POLICY_PROMPT =
+  "Skills are reusable procedural memory. Save a skill after a complex or iterative task, " +
+  "after recovering from non-trivial errors, when a user corrects the approach and the corrected " +
+  "workflow works, or when the user explicitly asks you to remember a procedure. Prefer patching " +
+  "an existing skill when the workflow is mostly right but stale or missing a pitfall. Update a " +
+  "skill during use when instructions are stale, steps are missing, pitfalls are discovered, or " +
+  "the workflow fails on a specific OS or environment. Use patch for targeted fixes, edit for " +
+  "major rewrites, and write_file for supporting references, scripts, templates, or assets. " +
+  `When acting, use \`${TOOL_NAME}\` to create, patch, edit, or delete skill files. Confirm before creating or deleting a skill.`;
+
+const SKILL_CREATOR_STYLE_PROMPT =
+  "When creating or rewriting a skill, keep the skill concise, include clear YAML frontmatter " +
+  "with name and description, keep the SKILL.md body focused on essential procedural guidance, " +
+  "avoid extra documentation files, and move detailed material into references/, scripts/, or " +
+  "assets/ only when needed. Prefer patch for small fixes and edit for major rewrites.";
+
+const MEMORY_NUDGE_TEXT =
+  "[System: You've had several exchanges in this session. Consider whether there's anything worth saving to your memories.]";
+
+const SKILL_NUDGE_TEXT =
+  "[System: The previous task involved many steps. If you discovered a reusable workflow, consider saving it as a skill.]";
+
+const FLUSH_REMINDER_TEXT =
+  "[System: Context may be compacted or reset soon. Before it is discarded, save important facts to memory and capture reusable workflows as skills if they will help future sessions.]";
+
+type SessionCounters = {
+  turnsSinceMemory: number;
+  turnsSinceSkill: number;
+};
+
+type SkillBridgeConfig = {
+  pythonPath?: string;
+  skillsDir?: string;
+  memoryNudgeInterval?: number;
+  skillNudgeInterval?: number;
+  enqueueFlushReminder?: boolean;
+};
+
+const sessionState = new Map<string, SessionCounters>();
+
+function getSessionState(sessionId?: string, sessionKey?: string): SessionCounters {
+  const key = sessionId || sessionKey || "global";
+  const existing = sessionState.get(key);
+  if (existing) {
+    return existing;
+  }
+  const created = { turnsSinceMemory: 0, turnsSinceSkill: 0 };
+  sessionState.set(key, created);
+  return created;
+}
+
+function deleteSessionState(sessionId?: string, sessionKey?: string): void {
+  const key = sessionId || sessionKey;
+  if (key) {
+    sessionState.delete(key);
+  }
+}
+
+function toNonNegativeInt(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? Math.trunc(value)
+    : fallback;
+}
+
+function resolveBridgeConfig(api: OpenClawPluginApi): Required<SkillBridgeConfig> {
+  const raw = (api.pluginConfig ?? {}) as SkillBridgeConfig;
+  return {
+    pythonPath: raw.pythonPath?.trim() || "python3",
+    skillsDir: raw.skillsDir?.trim() || "",
+    memoryNudgeInterval: toNonNegativeInt(raw.memoryNudgeInterval, 8),
+    skillNudgeInterval: toNonNegativeInt(raw.skillNudgeInterval, 15),
+    enqueueFlushReminder: raw.enqueueFlushReminder !== false,
+  };
+}
+
+function resolveSkillsDir(config: Required<SkillBridgeConfig>, workspaceDir?: string): string {
+  if (config.skillsDir.trim()) {
+    return path.resolve(config.skillsDir);
+  }
+  if (workspaceDir?.trim()) {
+    return path.join(path.resolve(workspaceDir), "skills");
+  }
+  throw new Error("skill-bridge: workspaceDir is unavailable and skillsDir is not configured.");
+}
+
+function createSkillManageTool(api: OpenClawPluginApi, workspaceDir?: string): AnyAgentTool {
+  const parameters = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      action: {
+        type: "string",
+        enum: ["create", "patch", "edit", "delete", "write_file", "remove_file"],
+      },
+      name: { type: "string" },
+      content: { type: "string" },
+      category: { type: "string" },
+      file_path: { type: "string" },
+      file_content: { type: "string" },
+      old_string: { type: "string" },
+      new_string: { type: "string" },
+      replace_all: { type: "boolean" },
+    },
+    required: ["action", "name"],
+  };
+
+  return {
+    name: TOOL_NAME,
+    label: "Skill Manage",
+    description:
+      "Manage reusable workflow skills stored on disk. Create or update SKILL.md files and supporting references, scripts, templates, or assets.",
+    parameters,
+    async execute(_toolCallId: string, rawParams: Record<string, unknown>) {
+      const config = resolveBridgeConfig(api);
+      const pluginRoot = api.resolvePath(".");
+      const runnerPath = path.join(pluginRoot, "python", "bridge_runner.py");
+      const skillsDir = resolveSkillsDir(config, workspaceDir);
+      const action = readStringParam(rawParams, "action", { required: true });
+      const name = readStringParam(rawParams, "name", { required: true });
+      const payload: Record<string, unknown> = {
+        ...rawParams,
+        action,
+        name,
+      };
+      const category = readStringParam(rawParams, "category");
+      if (category && category.trim() && category.trim() !== "workspace") {
+        payload.category = category.trim();
+      } else {
+        delete payload.category;
+      }
+
+      const result = spawnSync(config.pythonPath, [runnerPath, JSON.stringify(payload)], {
+        cwd: pluginRoot,
+        encoding: "utf8",
+        timeout: 30_000,
+        maxBuffer: 1024 * 1024,
+        env: {
+          ...process.env,
+          SKILL_PLUGIN_SKILLS_DIR: skillsDir,
+          SKILL_PLUGIN_TOOL_NAME: TOOL_NAME,
+        },
+      });
+
+      if (result.error) {
+        throw result.error;
+      }
+      if (result.status !== 0) {
+        const stderr = result.stderr?.trim();
+        const stdout = result.stdout?.trim();
+        throw new Error(stderr || stdout || `skill-bridge python exit code ${result.status}`);
+      }
+
+      const stdout = result.stdout?.trim();
+      if (!stdout) {
+        throw new Error("skill-bridge returned empty output.");
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(stdout);
+      } catch (error) {
+        throw new Error(`skill-bridge returned invalid JSON: ${String(error)}`);
+      }
+
+      return jsonResult(parsed);
+    },
+  };
+}
+
+export default function register(api: OpenClawPluginApi) {
+  api.registerTool((ctx) => createSkillManageTool(api, ctx.workspaceDir), { name: TOOL_NAME });
+
+  api.on("before_prompt_build", async (_event, ctx) => {
+    const config = resolveBridgeConfig(api);
+    const state = getSessionState(ctx.sessionId, ctx.sessionKey);
+    const parts = [SKILL_POLICY_PROMPT, SKILL_CREATOR_STYLE_PROMPT];
+
+    if (config.memoryNudgeInterval > 0) {
+      state.turnsSinceMemory += 1;
+      if (state.turnsSinceMemory >= config.memoryNudgeInterval) {
+        parts.push(MEMORY_NUDGE_TEXT);
+        state.turnsSinceMemory = 0;
+      }
+    }
+
+    if (config.skillNudgeInterval > 0) {
+      state.turnsSinceSkill += 1;
+      if (state.turnsSinceSkill >= config.skillNudgeInterval) {
+        parts.push(SKILL_NUDGE_TEXT);
+        state.turnsSinceSkill = 0;
+      }
+    }
+
+    return { prependContext: parts.join("\n\n") };
+  });
+
+  api.on("after_tool_call", async (event, ctx) => {
+    const state = getSessionState(ctx.sessionId, ctx.sessionKey);
+    if (event.toolName === TOOL_NAME) {
+      state.turnsSinceSkill = 0;
+    }
+    if (event.toolName === "memory" || event.toolName.startsWith("memory_")) {
+      state.turnsSinceMemory = 0;
+    }
+  });
+
+  api.on("before_compaction", async (_event, ctx) => {
+    const config = resolveBridgeConfig(api);
+    if (!config.enqueueFlushReminder || !ctx.sessionKey) {
+      return;
+    }
+    api.runtime.system.enqueueSystemEvent(FLUSH_REMINDER_TEXT, { sessionKey: ctx.sessionKey });
+  });
+
+  api.on("before_reset", async (_event, ctx) => {
+    const config = resolveBridgeConfig(api);
+    if (!config.enqueueFlushReminder || !ctx.sessionKey) {
+      return;
+    }
+    api.runtime.system.enqueueSystemEvent(FLUSH_REMINDER_TEXT, { sessionKey: ctx.sessionKey });
+  });
+
+  api.on("session_end", async (_event, ctx) => {
+    deleteSessionState(ctx.sessionId, ctx.sessionKey);
+  });
+}

--- a/openclaw/extensions/skill-bridge/openclaw.plugin.json
+++ b/openclaw/extensions/skill-bridge/openclaw.plugin.json
@@ -1,0 +1,50 @@
+{
+  "id": "skill-bridge",
+  "name": "Skill Bridge",
+  "description": "Adds a skill_manage tool backed by a local Python skill manager.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "pythonPath": {
+        "type": "string"
+      },
+      "skillsDir": {
+        "type": "string"
+      },
+      "memoryNudgeInterval": {
+        "type": "number",
+        "minimum": 0,
+        "default": 8
+      },
+      "skillNudgeInterval": {
+        "type": "number",
+        "minimum": 0,
+        "default": 15
+      },
+      "enqueueFlushReminder": {
+        "type": "boolean",
+        "default": true
+      }
+    }
+  },
+  "uiHints": {
+    "pythonPath": {
+      "label": "Python Path",
+      "help": "Python interpreter used to run the bundled skill manager bridge."
+    },
+    "skillsDir": {
+      "label": "Skills Dir",
+      "help": "Override the default workspace skills directory."
+    },
+    "memoryNudgeInterval": {
+      "label": "Memory Nudge Interval"
+    },
+    "skillNudgeInterval": {
+      "label": "Skill Nudge Interval"
+    },
+    "enqueueFlushReminder": {
+      "label": "Flush Reminder"
+    }
+  }
+}

--- a/openclaw/extensions/skill-bridge/package.json
+++ b/openclaw/extensions/skill-bridge/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/skill-bridge",
+  "version": "2026.3.2",
+  "private": true,
+  "description": "OpenClaw skill management bridge plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/openclaw/extensions/skill-bridge/python/bridge_runner.py
+++ b/openclaw/extensions/skill-bridge/python/bridge_runner.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        raise SystemExit("Expected JSON arguments as argv[1].")
+
+    python_root = Path(__file__).resolve().parent
+    sys.path.insert(0, str(python_root))
+
+    from skill_plugin import SkillManager, SkillToolAdapter
+
+    skills_dir = os.environ["SKILL_PLUGIN_SKILLS_DIR"]
+    tool_name = os.environ.get("SKILL_PLUGIN_TOOL_NAME", "skill_manage")
+    arguments = json.loads(sys.argv[1])
+    adapter = SkillToolAdapter(SkillManager(skills_dir), tool_name=tool_name)
+    print(adapter.dispatch(arguments))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/openclaw/extensions/skill-bridge/python/skill_plugin/__init__.py
+++ b/openclaw/extensions/skill-bridge/python/skill_plugin/__init__.py
@@ -1,0 +1,12 @@
+from .adapters import OPENAI_SKILL_TOOL_SCHEMA, SkillToolAdapter
+from .manager import SkillManager, SkillManagerError
+from .models import SkillInfo, SkillOperationResult
+
+__all__ = [
+    "OPENAI_SKILL_TOOL_SCHEMA",
+    "SkillInfo",
+    "SkillManager",
+    "SkillManagerError",
+    "SkillOperationResult",
+    "SkillToolAdapter",
+]

--- a/openclaw/extensions/skill-bridge/python/skill_plugin/adapters.py
+++ b/openclaw/extensions/skill-bridge/python/skill_plugin/adapters.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from .manager import SkillManager, SkillManagerError
+
+OPENAI_SKILL_TOOL_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "skill_manage",
+        "description": (
+            "Manage reusable workflow skills stored on disk. Use create for a new "
+            "SKILL.md, patch for targeted fixes, edit for full rewrites, delete to "
+            "remove a skill, and write_file/remove_file for references, templates, "
+            "scripts, and assets."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["create", "patch", "edit", "delete", "write_file", "remove_file"],
+                },
+                "name": {"type": "string"},
+                "content": {"type": "string"},
+                "category": {"type": "string"},
+                "file_path": {"type": "string"},
+                "file_content": {"type": "string"},
+                "old_string": {"type": "string"},
+                "new_string": {"type": "string"},
+                "replace_all": {"type": "boolean"},
+            },
+            "required": ["action", "name"],
+        },
+    },
+}
+
+
+class SkillToolAdapter:
+    def __init__(self, manager: SkillManager, tool_name: str = "skill_manage"):
+        self.manager = manager
+        self.tool_name = tool_name
+
+    def schema(self) -> dict[str, Any]:
+        schema = dict(OPENAI_SKILL_TOOL_SCHEMA)
+        schema["function"] = dict(schema["function"])
+        schema["function"]["name"] = self.tool_name
+        return schema
+
+    def dispatch(self, arguments: Mapping[str, Any]) -> str:
+        action = arguments.get("action")
+        name = arguments.get("name")
+
+        try:
+            if action == "create":
+                result = self.manager.create(
+                    name=name,
+                    content=arguments.get("content") or "",
+                    category=arguments.get("category"),
+                )
+            elif action == "edit":
+                result = self.manager.edit(name=name, content=arguments.get("content") or "")
+            elif action == "patch":
+                result = self.manager.patch(
+                    name=name,
+                    old_string=arguments.get("old_string") or "",
+                    new_string=arguments.get("new_string"),
+                    file_path=arguments.get("file_path"),
+                    replace_all=bool(arguments.get("replace_all", False)),
+                )
+            elif action == "delete":
+                result = self.manager.delete(name=name)
+            elif action == "write_file":
+                result = self.manager.write_file(
+                    name=name,
+                    file_path=arguments.get("file_path") or "",
+                    file_content=arguments.get("file_content", ""),
+                )
+            elif action == "remove_file":
+                result = self.manager.remove_file(
+                    name=name,
+                    file_path=arguments.get("file_path") or "",
+                )
+            else:
+                return json.dumps(
+                    {"success": False, "error": f"Unknown action '{action}'."},
+                    ensure_ascii=False,
+                )
+        except SkillManagerError as exc:
+            return json.dumps({"success": False, "error": str(exc)}, ensure_ascii=False)
+
+        return json.dumps(result.as_dict(), ensure_ascii=False)

--- a/openclaw/extensions/skill-bridge/python/skill_plugin/manager.py
+++ b/openclaw/extensions/skill-bridge/python/skill_plugin/manager.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from .models import SkillInfo, SkillOperationResult
+
+MAX_NAME_LENGTH = 64
+VALID_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+ALLOWED_SUBDIRS = {"references", "templates", "scripts", "assets"}
+
+
+class SkillManagerError(ValueError):
+    pass
+
+
+class SkillManager:
+    def __init__(self, skills_dir: str | os.PathLike[str]):
+        self.skills_dir = Path(skills_dir).expanduser()
+
+    def create(self, name: str, content: str, category: str | None = None) -> SkillOperationResult:
+        self._validate_name(name)
+        self._validate_frontmatter(content)
+        existing = self.find(name)
+        if existing:
+            raise SkillManagerError(f"A skill named '{name}' already exists at {existing.path}.")
+
+        skill_dir = self._resolve_skill_dir(name, category)
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        skill_md = skill_dir / "SKILL.md"
+        self._atomic_write_text(skill_md, content)
+
+        result = {
+            "name": name,
+            "path": str(skill_dir),
+            "skill_md": str(skill_md),
+        }
+        if category:
+            result["category"] = category
+        return SkillOperationResult(True, f"Skill '{name}' created.", result)
+
+    def edit(self, name: str, content: str) -> SkillOperationResult:
+        self._validate_frontmatter(content)
+        skill = self._require_skill(name)
+        self._atomic_write_text(skill.skill_md, content)
+        return SkillOperationResult(True, f"Skill '{name}' updated.", {"path": str(skill.path)})
+
+    def patch(
+        self,
+        name: str,
+        old_string: str,
+        new_string: str,
+        file_path: str | None = None,
+        replace_all: bool = False,
+    ) -> SkillOperationResult:
+        if not old_string:
+            raise SkillManagerError("old_string is required for patch().")
+        if new_string is None:
+            raise SkillManagerError("new_string is required for patch(). Use an empty string to delete text.")
+
+        skill = self._require_skill(name)
+        target = self._resolve_target_file(skill, file_path)
+        if not target.exists():
+            raise SkillManagerError(f"File not found: {target.relative_to(skill.path)}")
+
+        content = target.read_text(encoding="utf-8")
+        count = content.count(old_string)
+        if count == 0:
+            preview = content[:500] + ("..." if len(content) > 500 else "")
+            raise SkillManagerError(f"old_string not found in file. Preview:\n{preview}")
+        if count > 1 and not replace_all:
+            raise SkillManagerError(
+                f"old_string matched {count} times. Provide more context or set replace_all=True."
+            )
+
+        new_content = (
+            content.replace(old_string, new_string)
+            if replace_all
+            else content.replace(old_string, new_string, 1)
+        )
+        if file_path is None:
+            self._validate_frontmatter(new_content)
+
+        self._atomic_write_text(target, new_content)
+        replacements = count if replace_all else 1
+        target_label = file_path or "SKILL.md"
+        return SkillOperationResult(
+            True,
+            f"Patched {target_label} in skill '{name}' ({replacements} replacement{'s' if replacements != 1 else ''}).",
+        )
+
+    def delete(self, name: str) -> SkillOperationResult:
+        skill = self._require_skill(name)
+        shutil.rmtree(skill.path)
+
+        parent = skill.path.parent
+        if parent != self.skills_dir and parent.exists() and not any(parent.iterdir()):
+            parent.rmdir()
+
+        return SkillOperationResult(True, f"Skill '{name}' deleted.")
+
+    def write_file(self, name: str, file_path: str, file_content: str) -> SkillOperationResult:
+        self._validate_file_path(file_path)
+        skill = self._require_skill(name)
+        target = skill.path / file_path
+        self._atomic_write_text(target, file_content)
+        return SkillOperationResult(
+            True,
+            f"File '{file_path}' written to skill '{name}'.",
+            {"path": str(target)},
+        )
+
+    def remove_file(self, name: str, file_path: str) -> SkillOperationResult:
+        self._validate_file_path(file_path)
+        skill = self._require_skill(name)
+        target = skill.path / file_path
+        if not target.exists():
+            raise SkillManagerError(f"File '{file_path}' not found in skill '{name}'.")
+
+        target.unlink()
+        parent = target.parent
+        if parent != skill.path and parent.exists() and not any(parent.iterdir()):
+            parent.rmdir()
+
+        return SkillOperationResult(True, f"File '{file_path}' removed from skill '{name}'.")
+
+    def list_skills(self) -> list[SkillInfo]:
+        if not self.skills_dir.exists():
+            return []
+
+        skills: list[SkillInfo] = []
+        for skill_md in sorted(self.skills_dir.rglob("SKILL.md")):
+            skill_dir = skill_md.parent
+            relative = skill_dir.relative_to(self.skills_dir)
+            category = relative.parts[0] if len(relative.parts) > 1 else None
+            content = skill_md.read_text(encoding="utf-8")
+            frontmatter = self.parse_frontmatter(content)
+            skills.append(
+                SkillInfo(
+                    name=skill_dir.name,
+                    path=skill_dir,
+                    skill_md=skill_md,
+                    category=category,
+                    description=str(frontmatter.get("description", "")) or None,
+                    frontmatter=frontmatter,
+                )
+            )
+        return skills
+
+    def find(self, name: str) -> SkillInfo | None:
+        for skill in self.list_skills():
+            if skill.name == name:
+                return skill
+        return None
+
+    def _require_skill(self, name: str) -> SkillInfo:
+        skill = self.find(name)
+        if not skill:
+            raise SkillManagerError(f"Skill '{name}' not found.")
+        return skill
+
+    def _resolve_skill_dir(self, name: str, category: str | None = None) -> Path:
+        return self.skills_dir / category / name if category else self.skills_dir / name
+
+    def _resolve_target_file(self, skill: SkillInfo, file_path: str | None) -> Path:
+        if file_path is None:
+            return skill.skill_md
+        self._validate_file_path(file_path)
+        return skill.path / file_path
+
+    @staticmethod
+    def parse_frontmatter(content: str) -> dict[str, Any]:
+        start, end = SkillManager._split_frontmatter(content)
+        payload: dict[str, Any] = {}
+        for line in start.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#") or ":" not in stripped:
+                continue
+            key, value = stripped.split(":", 1)
+            key = key.strip()
+            value = value.strip().strip("\"'")
+            if value.lower() == "true":
+                payload[key] = True
+            elif value.lower() == "false":
+                payload[key] = False
+            elif value.isdigit():
+                payload[key] = int(value)
+            else:
+                payload[key] = value
+        SkillManager._validate_required_frontmatter(payload)
+        return payload
+
+    @staticmethod
+    def _validate_name(name: str) -> None:
+        if not name:
+            raise SkillManagerError("Skill name is required.")
+        if len(name) > MAX_NAME_LENGTH:
+            raise SkillManagerError(f"Skill name exceeds {MAX_NAME_LENGTH} characters.")
+        if not VALID_NAME_RE.match(name):
+            raise SkillManagerError(
+                f"Invalid skill name '{name}'. Use lowercase letters, numbers, hyphens, dots, and underscores."
+            )
+
+    @staticmethod
+    def _validate_frontmatter(content: str) -> None:
+        frontmatter, _ = SkillManager._split_frontmatter(content)
+        parsed = SkillManager.parse_frontmatter(f"---\n{frontmatter}\n---\n")
+        SkillManager._validate_required_frontmatter(parsed)
+
+    @staticmethod
+    def _validate_required_frontmatter(parsed: dict[str, Any]) -> None:
+        name = parsed.get("name")
+        description = parsed.get("description")
+        if not isinstance(name, str) or not name.strip():
+            raise SkillManagerError("SKILL.md frontmatter requires a non-empty string 'name'.")
+        if not isinstance(description, str) or not description.strip():
+            raise SkillManagerError("SKILL.md frontmatter requires a non-empty string 'description'.")
+
+    @staticmethod
+    def _split_frontmatter(content: str) -> tuple[str, str]:
+        if not content.startswith("---\n"):
+            raise SkillManagerError("SKILL.md must start with YAML frontmatter delimited by --- lines.")
+        marker = "\n---\n"
+        end_index = content.find(marker, 4)
+        if end_index < 0:
+            raise SkillManagerError("SKILL.md frontmatter must end with a closing --- line.")
+        return content[4:end_index], content[end_index + len(marker) :]
+
+    @staticmethod
+    def _validate_file_path(file_path: str) -> None:
+        normalized = Path(file_path)
+        if normalized.is_absolute():
+            raise SkillManagerError("file_path must be relative to the skill directory.")
+        if any(part == ".." for part in normalized.parts):
+            raise SkillManagerError("file_path cannot traverse outside the skill directory.")
+        if not normalized.parts:
+            raise SkillManagerError("file_path is required.")
+        if normalized.parts[0] not in ALLOWED_SUBDIRS:
+            raise SkillManagerError(
+                f"file_path must start with one of {sorted(ALLOWED_SUBDIRS)}."
+            )
+
+    @staticmethod
+    def _atomic_write_text(target: Path, content: str) -> None:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False, dir=target.parent) as tmp:
+            tmp.write(content)
+            tmp_path = Path(tmp.name)
+        tmp_path.replace(target)

--- a/openclaw/extensions/skill-bridge/python/skill_plugin/models.py
+++ b/openclaw/extensions/skill-bridge/python/skill_plugin/models.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class SkillInfo:
+    name: str
+    path: Path
+    skill_md: Path
+    category: str | None = None
+    description: str | None = None
+    frontmatter: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class SkillOperationResult:
+    success: bool
+    message: str
+    data: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        payload = {"success": self.success, "message": self.message}
+        payload.update(self.data)
+        return payload


### PR DESCRIPTION
# PR Title

`add bundled skill-bridge plugin for self-skill-manage and skill learning loops`

# PR Summary

This PR adds a bundled `skill-bridge` plugin that gives OpenClaw a local `skill_manage` tool for self-skill-manage.

The goal is to make OpenClaw closer to an agent with a built-in learning loop: it can create skills from experience, improve them during use, and nudge itself to persist reusable knowledge before context is compacted or reset.

In practice, this means the agent can turn successful workflows into reusable `SKILL.md` skills, patch stale or incomplete skills while working, and keep procedural knowledge in the workspace instead of losing it across sessions.

# Why This Matters

OpenClaw already has a strong skill system, but skill authoring is still mostly external or manual.

This plugin makes skill maintenance agent-accessible inside the runtime:

- The agent can create skills from successful multi-step work.
- The agent can patch or rewrite skills when a workflow turns out to be stale or incomplete.
- The runtime can periodically nudge the agent to persist reusable knowledge.
- Before compaction/reset, the runtime can remind the agent to save important procedural knowledge.

This pushes OpenClaw toward a stronger self-improving loop rather than treating skills as static assets only.

# What This PR Adds

- A bundled plugin at `openclaw/extensions/skill-bridge`
- A `skill_manage` tool exposed to the agent
- Prompt guidance for when to save or update skills
- Periodic nudges for persistence
- Pre-compaction / pre-reset reminders to persist useful knowledge
- A bundled Python implementation scoped to the plugin itself, not the repo root
- Minimal plugin docs and test scaffold

# Implementation Notes

- Default storage target is `<workspace>/skills`
- `skillsDir` can be overridden in plugin config
- The Python bridge is bundled under the plugin so it does not depend on a custom local repo layout
- The Python side is kept lightweight and compatible with `python3` on Python 3.9+