### PR TITLE
fix: Tinker path: all turns classified as "side" when using OpenClaw client

### DIFF
--- a/openclaw-tinker/README.md
+++ b/openclaw-tinker/README.md
@@ -93,6 +93,7 @@ All parameters can be set via CLI flags or environment variables:
 | `--proxy-port` | `PROXY_PORT` | `30000` | API server bind port |
 | `--served-model-name` | `SERVED_MODEL_NAME` | `qwen3-4b` | Model name in OpenAI API responses |
 | `--api-key` | `SGLANG_API_KEY` | | API key for proxy authentication |
+| `--default-turn-type` | `DEFAULT_TURN_TYPE` | `main` | Default turn type when client omits `X-Turn-Type` header (`main` or `side`) |
 
 ## Training Methods
 

--- a/openclaw-tinker/api_server.py
+++ b/openclaw-tinker/api_server.py
@@ -207,7 +207,7 @@ class _BaseServer:
 
             body = await request.json()
             session_id = x_session_id or body.get("session_id") or "unknown"
-            turn_type = (x_turn_type or body.get("turn_type") or "side").strip().lower()
+            turn_type = (x_turn_type or body.get("turn_type") or owner.config.default_turn_type).strip().lower()
             session_done = (
                 (x_session_done and x_session_done.strip().lower() in {"1", "true", "yes", "on"})
                 or str(body.get("session_done", "")).strip().lower() in {"1", "true", "yes", "on"}

--- a/openclaw-tinker/config.py
+++ b/openclaw-tinker/config.py
@@ -58,6 +58,14 @@ class TinkerConfig:
     api_key: str = ""
     max_context_tokens: int = 20000
 
+    # -- Turn classification --
+    # Default turn type when neither X-Turn-Type header nor body field is
+    # provided by the client.  Standard OpenAI-compatible clients (including
+    # OpenClaw) do not send turn-type metadata, so "main" ensures their
+    # turns are collected for training by default.  Set to "side" to require
+    # explicit opt-in via the X-Turn-Type header.
+    default_turn_type: str = "main"
+
     # -- Logging --
     record_dir: str = "records/"
     wandb_project: str = "openclaw-tinker"

--- a/openclaw-tinker/run.py
+++ b/openclaw-tinker/run.py
@@ -66,6 +66,9 @@ def parse_args() -> TinkerConfig:
     parser.add_argument("--proxy-port", type=int, default=int(os.getenv("PROXY_PORT", "30000")))
     parser.add_argument("--served-model-name", default=os.getenv("SERVED_MODEL_NAME", "qwen3-4b"))
     parser.add_argument("--api-key", default=os.getenv("SGLANG_API_KEY", ""))
+    parser.add_argument("--default-turn-type", default=os.getenv("DEFAULT_TURN_TYPE", "main"),
+                        choices=["main", "side"],
+                        help="Default turn type when client sends no X-Turn-Type header (default: main)")
 
     # Logging
     parser.add_argument("--record-dir", default=os.getenv("RECORD_DIR", "records/"))
@@ -95,6 +98,7 @@ def parse_args() -> TinkerConfig:
         proxy_port=args.proxy_port,
         served_model_name=args.served_model_name,
         api_key=args.api_key,
+        default_turn_type=args.default_turn_type,
         record_dir=args.record_dir,
         wandb_project=args.wandb_project,
     )


### PR DESCRIPTION
## Problem

Fixes #31

When using standard OpenAI-compatible clients (like OpenClaw), the `X-Turn-Type` header is not sent. The current default falls back to `"side"`, which means all turns from these clients are classified as side turns and excluded from training data.

## Solution

Make the default turn type configurable via:
- CLI flag: `--default-turn-type main`
- Environment variable: `DEFAULT_TURN_TYPE=main`
- Config field: `default_turn_type` in `TinkerConfig`

The default value is changed from `"side"` to `"main"`, so standard clients work correctly out of the box. Users who need explicit opt-in can set it back to `"side"`.

## Changes

- `config.py`: Added `default_turn_type` field with documentation
- `api_server.py`: Use `config.default_turn_type` instead of hardcoded `"side"`
- `run.py`: Added `--default-turn-type` CLI argument
- `README.md`: Documented the new parameter

## Note

I see @yinjjiew mentioned plans for an openclaw extension approach in the issue. This PR takes a simpler config-based approach — happy to close if the extension route is preferred. The two approaches aren't mutually exclusive either.