### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/openclaw/docs/concepts/model-providers.md
+++ b/openclaw/docs/concepts/model-providers.md
@@ -316,13 +316,13 @@ Synthetic provides Anthropic-compatible models behind the `synthetic` provider:
 
 - Provider: `synthetic`
 - Auth: `SYNTHETIC_API_KEY`
-- Example model: `synthetic/hf:MiniMaxAI/MiniMax-M2.7`
+- Example model: `synthetic/hf:MiniMaxAI/MiniMax-M3`
 - CLI: `openclaw onboard --auth-choice synthetic-api-key`
 
 ```json5
 {
   agents: {
-    defaults: { model: { primary: "synthetic/hf:MiniMaxAI/MiniMax-M2.7" } },
+    defaults: { model: { primary: "synthetic/hf:MiniMaxAI/MiniMax-M3" } },
   },
   models: {
     mode: "merge",
@@ -331,7 +331,7 @@ Synthetic provides Anthropic-compatible models behind the `synthetic` provider:
         baseUrl: "https://api.synthetic.new/anthropic",
         apiKey: "${SYNTHETIC_API_KEY}",
         api: "anthropic-messages",
-        models: [{ id: "hf:MiniMaxAI/MiniMax-M2.7", name: "MiniMax M2.7" }],
+        models: [{ id: "hf:MiniMaxAI/MiniMax-M3", name: "MiniMax M3" }],
       },
     },
   },

--- a/openclaw/docs/concepts/model-providers.md
+++ b/openclaw/docs/concepts/model-providers.md
@@ -316,13 +316,13 @@ Synthetic provides Anthropic-compatible models behind the `synthetic` provider:
 
 - Provider: `synthetic`
 - Auth: `SYNTHETIC_API_KEY`
-- Example model: `synthetic/hf:MiniMaxAI/MiniMax-M2.5`
+- Example model: `synthetic/hf:MiniMaxAI/MiniMax-M2.7`
 - CLI: `openclaw onboard --auth-choice synthetic-api-key`
 
 ```json5
 {
   agents: {
-    defaults: { model: { primary: "synthetic/hf:MiniMaxAI/MiniMax-M2.5" } },
+    defaults: { model: { primary: "synthetic/hf:MiniMaxAI/MiniMax-M2.7" } },
   },
   models: {
     mode: "merge",
@@ -331,7 +331,7 @@ Synthetic provides Anthropic-compatible models behind the `synthetic` provider:
         baseUrl: "https://api.synthetic.new/anthropic",
         apiKey: "${SYNTHETIC_API_KEY}",
         api: "anthropic-messages",
-        models: [{ id: "hf:MiniMaxAI/MiniMax-M2.5", name: "MiniMax M2.5" }],
+        models: [{ id: "hf:MiniMaxAI/MiniMax-M2.7", name: "MiniMax M2.7" }],
       },
     },
   },

--- a/openclaw/docs/gateway/configuration-examples.md
+++ b/openclaw/docs/gateway/configuration-examples.md
@@ -566,7 +566,7 @@ terms before depending on subscription auth.
     workspace: "~/.openclaw/workspace",
     model: {
       primary: "anthropic/claude-opus-4-6",
-      fallbacks: ["minimax/MiniMax-M2.5"],
+      fallbacks: ["minimax/MiniMax-M2.7"],
     },
   },
 }

--- a/openclaw/docs/gateway/configuration-examples.md
+++ b/openclaw/docs/gateway/configuration-examples.md
@@ -566,7 +566,7 @@ terms before depending on subscription auth.
     workspace: "~/.openclaw/workspace",
     model: {
       primary: "anthropic/claude-opus-4-6",
-      fallbacks: ["minimax/MiniMax-M2.7"],
+      fallbacks: ["minimax/MiniMax-M3"],
     },
   },
 }

--- a/openclaw/docs/gateway/configuration-reference.md
+++ b/openclaw/docs/gateway/configuration-reference.md
@@ -825,11 +825,11 @@ Time format in system prompt. Default: `auto` (OS preference).
     defaults: {
       models: {
         "anthropic/claude-opus-4-6": { alias: "opus" },
-        "minimax/MiniMax-M2.5": { alias: "minimax" },
+        "minimax/MiniMax-M3": { alias: "minimax" },
       },
       model: {
         primary: "anthropic/claude-opus-4-6",
-        fallbacks: ["minimax/MiniMax-M2.5"],
+        fallbacks: ["minimax/MiniMax-M3"],
       },
       imageModel: {
         primary: "openrouter/qwen/qwen-2.5-vl-72b-instruct:free",
@@ -1896,7 +1896,7 @@ Notes:
   agents: {
     defaults: {
       subagents: {
-        model: "minimax/MiniMax-M2.5",
+        model: "minimax/MiniMax-M3",
         maxConcurrent: 1,
         runTimeoutSeconds: 900,
         archiveAfterMinutes: 60,
@@ -2113,8 +2113,8 @@ Anthropic-compatible, built-in provider. Shortcut: `openclaw onboard --auth-choi
   env: { SYNTHETIC_API_KEY: "sk-..." },
   agents: {
     defaults: {
-      model: { primary: "synthetic/hf:MiniMaxAI/MiniMax-M2.5" },
-      models: { "synthetic/hf:MiniMaxAI/MiniMax-M2.5": { alias: "MiniMax M2.5" } },
+      model: { primary: "synthetic/hf:MiniMaxAI/MiniMax-M3" },
+      models: { "synthetic/hf:MiniMaxAI/MiniMax-M3": { alias: "MiniMax M3" } },
     },
   },
   models: {
@@ -2126,13 +2126,13 @@ Anthropic-compatible, built-in provider. Shortcut: `openclaw onboard --auth-choi
         api: "anthropic-messages",
         models: [
           {
-            id: "hf:MiniMaxAI/MiniMax-M2.5",
-            name: "MiniMax M2.5",
+            id: "hf:MiniMaxAI/MiniMax-M3",
+            name: "MiniMax M3",
             reasoning: false,
-            input: ["text"],
+            input: ["text", "image"],
             cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            contextWindow: 192000,
-            maxTokens: 65536,
+            contextWindow: 512000,
+            maxTokens: 128000,
           },
         ],
       },
@@ -2145,15 +2145,15 @@ Base URL should omit `/v1` (Anthropic client appends it). Shortcut: `openclaw on
 
 </Accordion>
 
-<Accordion title="MiniMax M2.5 (direct)">
+<Accordion title="MiniMax M3 (direct)">
 
 ```json5
 {
   agents: {
     defaults: {
-      model: { primary: "minimax/MiniMax-M2.5" },
+      model: { primary: "minimax/MiniMax-M3" },
       models: {
-        "minimax/MiniMax-M2.5": { alias: "Minimax" },
+        "minimax/MiniMax-M3": { alias: "Minimax" },
       },
     },
   },
@@ -2166,13 +2166,13 @@ Base URL should omit `/v1` (Anthropic client appends it). Shortcut: `openclaw on
         api: "anthropic-messages",
         models: [
           {
-            id: "MiniMax-M2.5",
-            name: "MiniMax M2.5",
-            reasoning: false,
-            input: ["text"],
-            cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 },
-            contextWindow: 200000,
-            maxTokens: 8192,
+            id: "MiniMax-M3",
+            name: "MiniMax M3",
+            reasoning: true,
+            input: ["text", "image"],
+            cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
+            contextWindow: 512000,
+            maxTokens: 128000,
           },
         ],
       },

--- a/openclaw/docs/help/faq.md
+++ b/openclaw/docs/help/faq.md
@@ -148,7 +148,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
   - [How do I switch models on the fly (without restarting)?](#how-do-i-switch-models-on-the-fly-without-restarting)
   - [Can I use GPT 5.2 for daily tasks and Codex 5.3 for coding](#can-i-use-gpt-52-for-daily-tasks-and-codex-53-for-coding)
   - [Why do I see "Model … is not allowed" and then no reply?](#why-do-i-see-model-is-not-allowed-and-then-no-reply)
-  - [Why do I see "Unknown model: minimax/MiniMax-M2.5"?](#why-do-i-see-unknown-model-minimaxminimaxm25)
+  - [Why do I see "Unknown model: minimax/MiniMax-M3"?](#why-do-i-see-unknown-model-minimaxminimaxm3)
   - [Can I use MiniMax as my default and OpenAI for complex tasks?](#can-i-use-minimax-as-my-default-and-openai-for-complex-tasks)
   - [Are opus / sonnet / gpt built-in shortcuts?](#are-opus-sonnet-gpt-builtin-shortcuts)
   - [How do I define/override model shortcuts (aliases)?](#how-do-i-defineoverride-model-shortcuts-aliases)
@@ -2185,8 +2185,8 @@ Fix checklist:
 1. Upgrade to **2026.1.12** (or run from source `main`), then restart the gateway.
 2. Make sure MiniMax is configured (wizard or JSON), or that a MiniMax API key
    exists in env/auth profiles so the provider can be injected.
-3. Use the exact model id (case-sensitive): `minimax/MiniMax-M2.5` or
-   `minimax/MiniMax-M2.5-highspeed` (legacy: `minimax/MiniMax-M2.5-Lightning`).
+3. Use the exact model id (case-sensitive): `minimax/MiniMax-M3` or
+   `minimax/MiniMax-M2.7`.
 4. Run:
 
    ```bash
@@ -2209,9 +2209,9 @@ Fallbacks are for **errors**, not "hard tasks," so use `/model` or a separate ag
   env: { MINIMAX_API_KEY: "sk-...", OPENAI_API_KEY: "sk-..." },
   agents: {
     defaults: {
-      model: { primary: "minimax/MiniMax-M2.5" },
+      model: { primary: "minimax/MiniMax-M3" },
       models: {
-        "minimax/MiniMax-M2.5": { alias: "minimax" },
+        "minimax/MiniMax-M3": { alias: "minimax" },
         "openai/gpt-5.2": { alias: "gpt" },
       },
     },

--- a/openclaw/docs/providers/minimax.md
+++ b/openclaw/docs/providers/minimax.md
@@ -1,5 +1,5 @@
 ---
-summary: "Use MiniMax M2.7 in OpenClaw"
+summary: "Use MiniMax M3 in OpenClaw"
 read_when:
   - You want MiniMax models in OpenClaw
   - You need MiniMax setup guidance
@@ -8,17 +8,19 @@ title: "MiniMax"
 
 # MiniMax
 
-MiniMax is an AI company that builds the **M2/M2.5/M2.7** model family. The current
-coding-focused release is **MiniMax M2.7**, the latest flagship model with
-enhanced reasoning and coding capabilities.
+MiniMax is an AI company that builds the **M2/M2.7/M3** model family. The current
+coding-focused release is **MiniMax M3**, the latest flagship model with
+enhanced reasoning, coding, and image-input capabilities (512K context, 128K max output).
 
-## Model overview (M2.7)
+## Model overview (M3)
 
-MiniMax M2.7 builds on the M2.5 foundation with key improvements:
+MiniMax M3 builds on the M2.7 foundation with key improvements:
 
 - Enhanced **reasoning and coding** capabilities across all supported languages.
 - Stronger **multi-language coding** (Rust, Java, Go, C++, Kotlin, Objective-C, TS/JS).
 - Better **web/app development** and aesthetic output quality (including native mobile).
+- **Native image input** support for vision workflows.
+- **512K context window** and **128K max output** for longer, more complex tasks.
 - Improved **composite instruction** handling for office-style workflows, building on
   interleaved thinking and integrated constraint execution.
 - **More concise responses** with lower token usage and faster iteration loops.
@@ -26,12 +28,12 @@ MiniMax M2.7 builds on the M2.5 foundation with key improvements:
   Droid/Factory AI, Cline, Kilo Code, Roo Code, BlackBox).
 - Higher-quality **dialogue and technical writing** outputs.
 
-## MiniMax M2.7 vs MiniMax M2.7 Highspeed
+## MiniMax M3 vs MiniMax M2.7
 
-- **Speed:** `MiniMax-M2.7-highspeed` is the official fast tier for low-latency scenarios.
-- **Cost:** MiniMax pricing lists the same input cost and a higher output cost for highspeed.
-- **Compatibility:** OpenClaw still accepts legacy `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`,
-  and `MiniMax-M2.5-Lightning` configs, but prefer `MiniMax-M2.7` for new setup.
+- **Speed:** `MiniMax-M2.7` is still available as a fast/legacy tier for low-latency scenarios.
+- **Capabilities:** M3 adds image input and larger context (512K vs 192K).
+- **Compatibility:** OpenClaw accepts both `MiniMax-M3` and `MiniMax-M2.7`; prefer
+  `MiniMax-M3` for new setup.
 
 ## Choose a setup
 
@@ -54,7 +56,7 @@ You will be prompted to select an endpoint:
 
 See [MiniMax OAuth plugin README](https://github.com/openclaw/openclaw/tree/main/extensions/minimax-portal-auth) for details.
 
-### MiniMax M2.7 (API key)
+### MiniMax M3 (API key)
 
 **Best for:** hosted MiniMax with Anthropic-compatible API.
 
@@ -62,12 +64,12 @@ Configure via CLI:
 
 - Run `openclaw configure`
 - Select **Model/auth**
-- Choose **MiniMax M2.7**
+- Choose **MiniMax M3**
 
 ```json5
 {
   env: { MINIMAX_API_KEY: "sk-..." },
-  agents: { defaults: { model: { primary: "minimax/MiniMax-M2.7" } } },
+  agents: { defaults: { model: { primary: "minimax/MiniMax-M3" } } },
   models: {
     mode: "merge",
     providers: {
@@ -77,22 +79,22 @@ Configure via CLI:
         api: "anthropic-messages",
         models: [
           {
+            id: "MiniMax-M3",
+            name: "MiniMax M3",
+            reasoning: true,
+            input: ["text", "image"],
+            cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
+            contextWindow: 512000,
+            maxTokens: 128000,
+          },
+          {
             id: "MiniMax-M2.7",
             name: "MiniMax M2.7",
             reasoning: true,
             input: ["text"],
             cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
-            contextWindow: 200000,
-            maxTokens: 8192,
-          },
-          {
-            id: "MiniMax-M2.7-highspeed",
-            name: "MiniMax M2.7 Highspeed",
-            reasoning: true,
-            input: ["text"],
-            cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
-            contextWindow: 200000,
-            maxTokens: 8192,
+            contextWindow: 192000,
+            maxTokens: 65536,
           },
         ],
       },
@@ -101,9 +103,9 @@ Configure via CLI:
 }
 ```
 
-### MiniMax M2.7 as fallback (example)
+### MiniMax M3 as fallback (example)
 
-**Best for:** keep your strongest latest-generation model as primary, fail over to MiniMax M2.7.
+**Best for:** keep your strongest latest-generation model as primary, fail over to MiniMax M3.
 Example below uses Opus as a concrete primary; swap to your preferred latest-gen primary model.
 
 ```json5
@@ -113,11 +115,11 @@ Example below uses Opus as a concrete primary; swap to your preferred latest-gen
     defaults: {
       models: {
         "anthropic/claude-opus-4-6": { alias: "primary" },
-        "minimax/MiniMax-M2.7": { alias: "minimax" },
+        "minimax/MiniMax-M3": { alias: "minimax" },
       },
       model: {
         primary: "anthropic/claude-opus-4-6",
-        fallbacks: ["minimax/MiniMax-M2.7"],
+        fallbacks: ["minimax/MiniMax-M3"],
       },
     },
   },
@@ -170,7 +172,7 @@ Use the interactive config wizard to set MiniMax without editing JSON:
 
 1. Run `openclaw configure`.
 2. Select **Model/auth**.
-3. Choose **MiniMax M2.7**.
+3. Choose **MiniMax M3**.
 4. Pick your default model when prompted.
 
 ## Configuration options
@@ -185,34 +187,30 @@ Use the interactive config wizard to set MiniMax without editing JSON:
 ## Notes
 
 - Model refs are `minimax/<model>`.
-- Recommended model IDs: `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`.
-- Legacy model IDs (`MiniMax-M2.5`, `MiniMax-M2.5-highspeed`, `MiniMax-M2.5-Lightning`) are still supported.
+- Recommended model IDs: `MiniMax-M3` (latest flagship) and `MiniMax-M2.7` (previous flagship).
 - Coding Plan usage API: `https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains` (requires a coding plan key).
 - Update pricing values in `models.json` if you need exact cost tracking.
 - Referral link for MiniMax Coding Plan (10% off): [https://platform.minimax.io/subscribe/coding-plan?code=DbXJTRClnb&source=link](https://platform.minimax.io/subscribe/coding-plan?code=DbXJTRClnb&source=link)
 - See [/concepts/model-providers](/concepts/model-providers) for provider rules.
-- Use `openclaw models list` and `openclaw models set minimax/MiniMax-M2.7` to switch.
+- Use `openclaw models list` and `openclaw models set minimax/MiniMax-M3` to switch.
 
 ## Troubleshooting
 
-### "Unknown model: minimax/MiniMax-M2.7"
+### "Unknown model: minimax/MiniMax-M3"
 
 This usually means the **MiniMax provider isn't configured** (no provider entry
 and no MiniMax auth profile/env key found). A fix for this detection is in
 **2026.1.12** (unreleased at the time of writing). Fix by:
 
 - Upgrading to **2026.1.12** (or run from source `main`), then restarting the gateway.
-- Running `openclaw configure` and selecting **MiniMax M2.7**, or
+- Running `openclaw configure` and selecting **MiniMax M3**, or
 - Adding the `models.providers.minimax` block manually, or
 - Setting `MINIMAX_API_KEY` (or a MiniMax auth profile) so the provider can be injected.
 
 Make sure the model id is **case‑sensitive**:
 
+- `minimax/MiniMax-M3`
 - `minimax/MiniMax-M2.7`
-- `minimax/MiniMax-M2.7-highspeed`
-- `minimax/MiniMax-M2.5` (legacy)
-- `minimax/MiniMax-M2.5-highspeed` (legacy)
-- `minimax/MiniMax-M2.5-Lightning` (legacy)
 
 Then recheck with:
 

--- a/openclaw/docs/providers/minimax.md
+++ b/openclaw/docs/providers/minimax.md
@@ -1,5 +1,5 @@
 ---
-summary: "Use MiniMax M2.5 in OpenClaw"
+summary: "Use MiniMax M2.7 in OpenClaw"
 read_when:
   - You want MiniMax models in OpenClaw
   - You need MiniMax setup guidance
@@ -8,16 +8,15 @@ title: "MiniMax"
 
 # MiniMax
 
-MiniMax is an AI company that builds the **M2/M2.5** model family. The current
-coding-focused release is **MiniMax M2.5** (December 23, 2025), built for
-real-world complex tasks.
+MiniMax is an AI company that builds the **M2/M2.5/M2.7** model family. The current
+coding-focused release is **MiniMax M2.7**, the latest flagship model with
+enhanced reasoning and coding capabilities.
 
-Source: [MiniMax M2.5 release note](https://www.minimax.io/news/minimax-m25)
+## Model overview (M2.7)
 
-## Model overview (M2.5)
+MiniMax M2.7 builds on the M2.5 foundation with key improvements:
 
-MiniMax highlights these improvements in M2.5:
-
+- Enhanced **reasoning and coding** capabilities across all supported languages.
 - Stronger **multi-language coding** (Rust, Java, Go, C++, Kotlin, Objective-C, TS/JS).
 - Better **web/app development** and aesthetic output quality (including native mobile).
 - Improved **composite instruction** handling for office-style workflows, building on
@@ -27,12 +26,12 @@ MiniMax highlights these improvements in M2.5:
   Droid/Factory AI, Cline, Kilo Code, Roo Code, BlackBox).
 - Higher-quality **dialogue and technical writing** outputs.
 
-## MiniMax M2.5 vs MiniMax M2.5 Highspeed
+## MiniMax M2.7 vs MiniMax M2.7 Highspeed
 
-- **Speed:** `MiniMax-M2.5-highspeed` is the official fast tier in MiniMax docs.
+- **Speed:** `MiniMax-M2.7-highspeed` is the official fast tier for low-latency scenarios.
 - **Cost:** MiniMax pricing lists the same input cost and a higher output cost for highspeed.
-- **Compatibility:** OpenClaw still accepts legacy `MiniMax-M2.5-Lightning` configs, but prefer
-  `MiniMax-M2.5-highspeed` for new setup.
+- **Compatibility:** OpenClaw still accepts legacy `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`,
+  and `MiniMax-M2.5-Lightning` configs, but prefer `MiniMax-M2.7` for new setup.
 
 ## Choose a setup
 
@@ -55,7 +54,7 @@ You will be prompted to select an endpoint:
 
 See [MiniMax OAuth plugin README](https://github.com/openclaw/openclaw/tree/main/extensions/minimax-portal-auth) for details.
 
-### MiniMax M2.5 (API key)
+### MiniMax M2.7 (API key)
 
 **Best for:** hosted MiniMax with Anthropic-compatible API.
 
@@ -63,12 +62,12 @@ Configure via CLI:
 
 - Run `openclaw configure`
 - Select **Model/auth**
-- Choose **MiniMax M2.5**
+- Choose **MiniMax M2.7**
 
 ```json5
 {
   env: { MINIMAX_API_KEY: "sk-..." },
-  agents: { defaults: { model: { primary: "minimax/MiniMax-M2.5" } } },
+  agents: { defaults: { model: { primary: "minimax/MiniMax-M2.7" } } },
   models: {
     mode: "merge",
     providers: {
@@ -78,8 +77,8 @@ Configure via CLI:
         api: "anthropic-messages",
         models: [
           {
-            id: "MiniMax-M2.5",
-            name: "MiniMax M2.5",
+            id: "MiniMax-M2.7",
+            name: "MiniMax M2.7",
             reasoning: true,
             input: ["text"],
             cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
@@ -87,8 +86,8 @@ Configure via CLI:
             maxTokens: 8192,
           },
           {
-            id: "MiniMax-M2.5-highspeed",
-            name: "MiniMax M2.5 Highspeed",
+            id: "MiniMax-M2.7-highspeed",
+            name: "MiniMax M2.7 Highspeed",
             reasoning: true,
             input: ["text"],
             cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
@@ -102,9 +101,9 @@ Configure via CLI:
 }
 ```
 
-### MiniMax M2.5 as fallback (example)
+### MiniMax M2.7 as fallback (example)
 
-**Best for:** keep your strongest latest-generation model as primary, fail over to MiniMax M2.5.
+**Best for:** keep your strongest latest-generation model as primary, fail over to MiniMax M2.7.
 Example below uses Opus as a concrete primary; swap to your preferred latest-gen primary model.
 
 ```json5
@@ -114,11 +113,11 @@ Example below uses Opus as a concrete primary; swap to your preferred latest-gen
     defaults: {
       models: {
         "anthropic/claude-opus-4-6": { alias: "primary" },
-        "minimax/MiniMax-M2.5": { alias: "minimax" },
+        "minimax/MiniMax-M2.7": { alias: "minimax" },
       },
       model: {
         primary: "anthropic/claude-opus-4-6",
-        fallbacks: ["minimax/MiniMax-M2.5"],
+        fallbacks: ["minimax/MiniMax-M2.7"],
       },
     },
   },
@@ -171,7 +170,7 @@ Use the interactive config wizard to set MiniMax without editing JSON:
 
 1. Run `openclaw configure`.
 2. Select **Model/auth**.
-3. Choose **MiniMax M2.5**.
+3. Choose **MiniMax M2.7**.
 4. Pick your default model when prompted.
 
 ## Configuration options
@@ -186,30 +185,33 @@ Use the interactive config wizard to set MiniMax without editing JSON:
 ## Notes
 
 - Model refs are `minimax/<model>`.
-- Recommended model IDs: `MiniMax-M2.5` and `MiniMax-M2.5-highspeed`.
+- Recommended model IDs: `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`.
+- Legacy model IDs (`MiniMax-M2.5`, `MiniMax-M2.5-highspeed`, `MiniMax-M2.5-Lightning`) are still supported.
 - Coding Plan usage API: `https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains` (requires a coding plan key).
 - Update pricing values in `models.json` if you need exact cost tracking.
 - Referral link for MiniMax Coding Plan (10% off): [https://platform.minimax.io/subscribe/coding-plan?code=DbXJTRClnb&source=link](https://platform.minimax.io/subscribe/coding-plan?code=DbXJTRClnb&source=link)
 - See [/concepts/model-providers](/concepts/model-providers) for provider rules.
-- Use `openclaw models list` and `openclaw models set minimax/MiniMax-M2.5` to switch.
+- Use `openclaw models list` and `openclaw models set minimax/MiniMax-M2.7` to switch.
 
 ## Troubleshooting
 
-### “Unknown model: minimax/MiniMax-M2.5”
+### "Unknown model: minimax/MiniMax-M2.7"
 
-This usually means the **MiniMax provider isn’t configured** (no provider entry
+This usually means the **MiniMax provider isn't configured** (no provider entry
 and no MiniMax auth profile/env key found). A fix for this detection is in
 **2026.1.12** (unreleased at the time of writing). Fix by:
 
 - Upgrading to **2026.1.12** (or run from source `main`), then restarting the gateway.
-- Running `openclaw configure` and selecting **MiniMax M2.5**, or
+- Running `openclaw configure` and selecting **MiniMax M2.7**, or
 - Adding the `models.providers.minimax` block manually, or
 - Setting `MINIMAX_API_KEY` (or a MiniMax auth profile) so the provider can be injected.
 
 Make sure the model id is **case‑sensitive**:
 
-- `minimax/MiniMax-M2.5`
-- `minimax/MiniMax-M2.5-highspeed`
+- `minimax/MiniMax-M2.7`
+- `minimax/MiniMax-M2.7-highspeed`
+- `minimax/MiniMax-M2.5` (legacy)
+- `minimax/MiniMax-M2.5-highspeed` (legacy)
 - `minimax/MiniMax-M2.5-Lightning` (legacy)
 
 Then recheck with:

--- a/openclaw/docs/providers/synthetic.md
+++ b/openclaw/docs/providers/synthetic.md
@@ -23,7 +23,7 @@ openclaw onboard --auth-choice synthetic-api-key
 The default model is set to:
 
 ```
-synthetic/hf:MiniMaxAI/MiniMax-M2.5
+synthetic/hf:MiniMaxAI/MiniMax-M3
 ```
 
 ## Config example
@@ -33,8 +33,8 @@ synthetic/hf:MiniMaxAI/MiniMax-M2.5
   env: { SYNTHETIC_API_KEY: "sk-..." },
   agents: {
     defaults: {
-      model: { primary: "synthetic/hf:MiniMaxAI/MiniMax-M2.5" },
-      models: { "synthetic/hf:MiniMaxAI/MiniMax-M2.5": { alias: "MiniMax M2.5" } },
+      model: { primary: "synthetic/hf:MiniMaxAI/MiniMax-M3" },
+      models: { "synthetic/hf:MiniMaxAI/MiniMax-M3": { alias: "MiniMax M3" } },
     },
   },
   models: {
@@ -46,13 +46,13 @@ synthetic/hf:MiniMaxAI/MiniMax-M2.5
         api: "anthropic-messages",
         models: [
           {
-            id: "hf:MiniMaxAI/MiniMax-M2.5",
-            name: "MiniMax M2.5",
-            reasoning: false,
-            input: ["text"],
+            id: "hf:MiniMaxAI/MiniMax-M3",
+            name: "MiniMax M3",
+            reasoning: true,
+            input: ["text", "image"],
             cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            contextWindow: 192000,
-            maxTokens: 65536,
+            contextWindow: 512000,
+            maxTokens: 128000,
           },
         ],
       },
@@ -71,7 +71,8 @@ All models below use cost `0` (input/output/cache).
 
 | Model ID                                               | Context window | Max tokens | Reasoning | Input        |
 | ------------------------------------------------------ | -------------- | ---------- | --------- | ------------ |
-| `hf:MiniMaxAI/MiniMax-M2.5`                            | 192000         | 65536      | false     | text         |
+| `hf:MiniMaxAI/MiniMax-M3`                              | 512000         | 128000     | true      | text + image |
+| `hf:MiniMaxAI/MiniMax-M2.7`                            | 192000         | 65536      | false     | text         |
 | `hf:moonshotai/Kimi-K2-Thinking`                       | 256000         | 8192       | true      | text         |
 | `hf:zai-org/GLM-4.7`                                   | 198000         | 128000     | false     | text         |
 | `hf:deepseek-ai/DeepSeek-R1-0528`                      | 128000         | 8192       | false     | text         |

--- a/openclaw/docs/reference/wizard.md
+++ b/openclaw/docs/reference/wizard.md
@@ -44,7 +44,7 @@ For a high-level overview, see [Onboarding Wizard](/start/wizard).
     - More detail: [Vercel AI Gateway](/providers/vercel-ai-gateway)
     - **Cloudflare AI Gateway**: prompts for Account ID, Gateway ID, and `CLOUDFLARE_AI_GATEWAY_API_KEY`.
     - More detail: [Cloudflare AI Gateway](/providers/cloudflare-ai-gateway)
-    - **MiniMax M2.5**: config is auto-written.
+    - **MiniMax M2.7**: config is auto-written.
     - More detail: [MiniMax](/providers/minimax)
     - **Synthetic (Anthropic-compatible)**: prompts for `SYNTHETIC_API_KEY`.
     - More detail: [Synthetic](/providers/synthetic)

--- a/openclaw/docs/reference/wizard.md
+++ b/openclaw/docs/reference/wizard.md
@@ -44,7 +44,7 @@ For a high-level overview, see [Onboarding Wizard](/start/wizard).
     - More detail: [Vercel AI Gateway](/providers/vercel-ai-gateway)
     - **Cloudflare AI Gateway**: prompts for Account ID, Gateway ID, and `CLOUDFLARE_AI_GATEWAY_API_KEY`.
     - More detail: [Cloudflare AI Gateway](/providers/cloudflare-ai-gateway)
-    - **MiniMax M2.7**: config is auto-written.
+    - **MiniMax M3**: config is auto-written.
     - More detail: [MiniMax](/providers/minimax)
     - **Synthetic (Anthropic-compatible)**: prompts for `SYNTHETIC_API_KEY`.
     - More detail: [Synthetic](/providers/synthetic)

--- a/openclaw/docs/start/wizard-cli-reference.md
+++ b/openclaw/docs/start/wizard-cli-reference.md
@@ -163,7 +163,7 @@ What you set:
     Prompts for account ID, gateway ID, and `CLOUDFLARE_AI_GATEWAY_API_KEY`.
     More detail: [Cloudflare AI Gateway](/providers/cloudflare-ai-gateway).
   </Accordion>
-  <Accordion title="MiniMax M2.5">
+  <Accordion title="MiniMax M2.7">
     Config is auto-written.
     More detail: [MiniMax](/providers/minimax).
   </Accordion>

--- a/openclaw/docs/start/wizard-cli-reference.md
+++ b/openclaw/docs/start/wizard-cli-reference.md
@@ -163,7 +163,7 @@ What you set:
     Prompts for account ID, gateway ID, and `CLOUDFLARE_AI_GATEWAY_API_KEY`.
     More detail: [Cloudflare AI Gateway](/providers/cloudflare-ai-gateway).
   </Accordion>
-  <Accordion title="MiniMax M2.7">
+  <Accordion title="MiniMax M3">
     Config is auto-written.
     More detail: [MiniMax](/providers/minimax).
   </Accordion>

--- a/openclaw/docs/zh-CN/providers/minimax.md
+++ b/openclaw/docs/zh-CN/providers/minimax.md
@@ -2,27 +2,26 @@
 read_when:
   - 你想在 OpenClaw 中使用 MiniMax 模型
   - 你需要 MiniMax 设置指南
-summary: 在 OpenClaw 中使用 MiniMax M2.1
+summary: 在 OpenClaw 中使用 MiniMax M2.7
 title: MiniMax
 x-i18n:
-  generated_at: "2026-02-03T10:08:52Z"
-  model: claude-opus-4-5
+  generated_at: "2026-03-18T00:00:00Z"
+  model: claude-opus-4-6
   provider: pi
-  source_hash: 861e1ddc3c24be88f716bfb72d6015d62875a9087f8e89ea4ba3a35f548c7fae
+  source_hash: updated
   source_path: providers/minimax.md
   workflow: 15
 ---
 
 # MiniMax
 
-MiniMax 是一家构建 **M2/M2.1** 模型系列的 AI 公司。当前面向编程的版本是 **MiniMax M2.1**（2025 年 12 月 23 日），专为现实世界的复杂任务而构建。
+MiniMax 是一家构建 **M2/M2.5/M2.7** 模型系列的 AI 公司。当前最新的旗舰模型是 **MiniMax M2.7**，具备增强的推理和编程能力。
 
-来源：[MiniMax M2.1 发布说明](https://www.minimax.io/news/minimax-m21)
+## 模型概述（M2.7）
 
-## 模型概述（M2.1）
+MiniMax M2.7 在 M2.5 基础上进行了关键改进：
 
-MiniMax 强调 M2.1 的以下改进：
-
+- 增强的**推理和编程**能力，覆盖所有支持的语言。
 - 更强的**多语言编程**能力（Rust、Java、Go、C++、Kotlin、Objective-C、TS/JS）。
 - 更好的 **Web/应用开发**和美观输出质量（包括原生移动端）。
 - 改进的**复合指令**处理，适用于办公风格的工作流程，基于交错思考和集成约束执行。
@@ -30,11 +29,11 @@ MiniMax 强调 M2.1 的以下改进：
 - 更强的**工具/智能体框架**兼容性和上下文管理（Claude Code、Droid/Factory AI、Cline、Kilo Code、Roo Code、BlackBox）。
 - 更高质量的**对话和技术写作**输出。
 
-## MiniMax M2.1 vs MiniMax M2.1 Lightning
+## MiniMax M2.7 vs MiniMax M2.7 Highspeed
 
-- **速度：** Lightning 是 MiniMax 定价文档中的"快速"变体。
-- **成本：** 定价显示相同的输入成本，但 Lightning 的输出成本更高。
-- **编程计划路由：** Lightning 后端在 MiniMax 编程计划中不能直接使用。MiniMax 自动将大多数请求路由到 Lightning，但在流量高峰期会回退到常规 M2.1 后端。
+- **速度：** `MiniMax-M2.7-highspeed` 是面向低延迟场景的官方快速版本。
+- **成本：** 定价显示相同的输入成本，但 Highspeed 的输出成本更高。
+- **兼容性：** OpenClaw 仍然接受旧版 `MiniMax-M2.5`、`MiniMax-M2.5-highspeed` 和 `MiniMax-M2.5-Lightning` 配置，但新设置推荐使用 `MiniMax-M2.7`。
 
 ## 选择设置方式
 
@@ -57,7 +56,7 @@ openclaw onboard --auth-choice minimax-portal
 
 详情参见 [MiniMax OAuth 插件 README](https://github.com/openclaw/openclaw/tree/main/extensions/minimax-portal-auth)。
 
-### MiniMax M2.1（API 密钥）
+### MiniMax M2.7（API 密钥）
 
 **适用于：** 使用 Anthropic 兼容 API 的托管 MiniMax。
 
@@ -65,12 +64,12 @@ openclaw onboard --auth-choice minimax-portal
 
 - 运行 `openclaw configure`
 - 选择 **Model/auth**
-- 选择 **MiniMax M2.1**
+- 选择 **MiniMax M2.7**
 
 ```json5
 {
   env: { MINIMAX_API_KEY: "sk-..." },
-  agents: { defaults: { model: { primary: "minimax/MiniMax-M2.1" } } },
+  agents: { defaults: { model: { primary: "minimax/MiniMax-M2.7" } } },
   models: {
     mode: "merge",
     providers: {
@@ -80,11 +79,20 @@ openclaw onboard --auth-choice minimax-portal
         api: "anthropic-messages",
         models: [
           {
-            id: "MiniMax-M2.1",
-            name: "MiniMax M2.1",
-            reasoning: false,
+            id: "MiniMax-M2.7",
+            name: "MiniMax M2.7",
+            reasoning: true,
             input: ["text"],
-            cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 },
+            cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
+            contextWindow: 200000,
+            maxTokens: 8192,
+          },
+          {
+            id: "MiniMax-M2.7-highspeed",
+            name: "MiniMax M2.7 Highspeed",
+            reasoning: true,
+            input: ["text"],
+            cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
             contextWindow: 200000,
             maxTokens: 8192,
           },
@@ -95,9 +103,9 @@ openclaw onboard --auth-choice minimax-portal
 }
 ```
 
-### MiniMax M2.1 作为备用（Opus 为主）
+### MiniMax M2.7 作为备用（示例）
 
-**适用于：** 保持 Opus 4.5 为主模型，故障时切换到 MiniMax M2.1。
+**适用于：** 保持最强模型为主模型，故障时切换到 MiniMax M2.7。
 
 ```json5
 {
@@ -105,12 +113,12 @@ openclaw onboard --auth-choice minimax-portal
   agents: {
     defaults: {
       models: {
-        "anthropic/claude-opus-4-5": { alias: "opus" },
-        "minimax/MiniMax-M2.1": { alias: "minimax" },
+        "anthropic/claude-opus-4-6": { alias: "primary" },
+        "minimax/MiniMax-M2.7": { alias: "minimax" },
       },
       model: {
-        primary: "anthropic/claude-opus-4-5",
-        fallbacks: ["minimax/MiniMax-M2.1"],
+        primary: "anthropic/claude-opus-4-6",
+        fallbacks: ["minimax/MiniMax-M2.7"],
       },
     },
   },
@@ -120,7 +128,7 @@ openclaw onboard --auth-choice minimax-portal
 ### 可选：通过 LM Studio 本地运行（手动）
 
 **适用于：** 使用 LM Studio 进行本地推理。
-我们在强大硬件（例如台式机/服务器）上使用 LM Studio 的本地服务器运行 MiniMax M2.1 时看到了出色的效果。
+我们在强大硬件（例如台式机/服务器）上使用 LM Studio 的本地服务器运行 MiniMax M2.5 时看到了出色的效果。
 
 通过 `openclaw.json` 手动配置：
 
@@ -128,8 +136,8 @@ openclaw onboard --auth-choice minimax-portal
 {
   agents: {
     defaults: {
-      model: { primary: "lmstudio/minimax-m2.1-gs32" },
-      models: { "lmstudio/minimax-m2.1-gs32": { alias: "Minimax" } },
+      model: { primary: "lmstudio/minimax-m2.5-gs32" },
+      models: { "lmstudio/minimax-m2.5-gs32": { alias: "Minimax" } },
     },
   },
   models: {
@@ -141,8 +149,8 @@ openclaw onboard --auth-choice minimax-portal
         api: "openai-responses",
         models: [
           {
-            id: "minimax-m2.1-gs32",
-            name: "MiniMax M2.1 GS32",
+            id: "minimax-m2.5-gs32",
+            name: "MiniMax M2.5 GS32",
             reasoning: false,
             input: ["text"],
             cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -162,7 +170,7 @@ openclaw onboard --auth-choice minimax-portal
 
 1. 运行 `openclaw configure`。
 2. 选择 **Model/auth**。
-3. 选择 **MiniMax M2.1**。
+3. 选择 **MiniMax M2.7**。
 4. 在提示时选择你的默认模型。
 
 ## 配置选项
@@ -177,27 +185,32 @@ openclaw onboard --auth-choice minimax-portal
 ## 注意事项
 
 - 模型引用格式为 `minimax/<model>`。
+- 推荐模型 ID：`MiniMax-M2.7` 和 `MiniMax-M2.7-highspeed`。
+- 旧版模型 ID（`MiniMax-M2.5`、`MiniMax-M2.5-highspeed`、`MiniMax-M2.5-Lightning`）仍然受支持。
 - 编程计划使用量 API：`https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains`（需要编程计划密钥）。
 - 如果需要精确的成本跟踪，请更新 `models.json` 中的定价值。
 - MiniMax 编程计划推荐链接（9 折优惠）：https://platform.minimax.io/subscribe/coding-plan?code=DbXJTRClnb&source=link
 - 参见 [/concepts/model-providers](/concepts/model-providers) 了解提供商规则。
-- 使用 `openclaw models list` 和 `openclaw models set minimax/MiniMax-M2.1` 切换模型。
+- 使用 `openclaw models list` 和 `openclaw models set minimax/MiniMax-M2.7` 切换模型。
 
 ## 故障排除
 
-### "Unknown model: minimax/MiniMax-M2.1"
+### "Unknown model: minimax/MiniMax-M2.7"
 
 这通常意味着 **MiniMax 提供商未配置**（没有提供商条目，也没有找到 MiniMax 认证配置文件/环境变量密钥）。此检测的修复在 **2026.1.12** 中（撰写本文时尚未发布）。修复方法：
 
 - 升级到 **2026.1.12**（或从源码 `main` 分支运行），然后重启 Gateway 网关。
-- 运行 `openclaw configure` 并选择 **MiniMax M2.1**，或
+- 运行 `openclaw configure` 并选择 **MiniMax M2.7**，或
 - 手动添加 `models.providers.minimax` 块，或
 - 设置 `MINIMAX_API_KEY`（或 MiniMax 认证配置文件）以便注入提供商。
 
 确保模型 id **区分大小写**：
 
-- `minimax/MiniMax-M2.1`
-- `minimax/MiniMax-M2.1-lightning`
+- `minimax/MiniMax-M2.7`
+- `minimax/MiniMax-M2.7-highspeed`
+- `minimax/MiniMax-M2.5`（旧版）
+- `minimax/MiniMax-M2.5-highspeed`（旧版）
+- `minimax/MiniMax-M2.5-Lightning`（旧版）
 
 然后重新检查：
 

--- a/openclaw/docs/zh-CN/providers/minimax.md
+++ b/openclaw/docs/zh-CN/providers/minimax.md
@@ -2,10 +2,10 @@
 read_when:
   - 你想在 OpenClaw 中使用 MiniMax 模型
   - 你需要 MiniMax 设置指南
-summary: 在 OpenClaw 中使用 MiniMax M2.7
+summary: 在 OpenClaw 中使用 MiniMax M3
 title: MiniMax
 x-i18n:
-  generated_at: "2026-03-18T00:00:00Z"
+  generated_at: "2026-06-03T00:00:00Z"
   model: claude-opus-4-6
   provider: pi
   source_hash: updated
@@ -15,25 +15,26 @@ x-i18n:
 
 # MiniMax
 
-MiniMax 是一家构建 **M2/M2.5/M2.7** 模型系列的 AI 公司。当前最新的旗舰模型是 **MiniMax M2.7**，具备增强的推理和编程能力。
+MiniMax 是一家构建 **M2/M2.7/M3** 模型系列的 AI 公司。当前最新的旗舰模型是 **MiniMax M3**，具备增强的推理、编程和图像输入能力（512K 上下文，128K 最大输出）。
 
-## 模型概述（M2.7）
+## 模型概述（M3）
 
-MiniMax M2.7 在 M2.5 基础上进行了关键改进：
+MiniMax M3 在 M2.7 基础上进行了关键改进：
 
 - 增强的**推理和编程**能力，覆盖所有支持的语言。
 - 更强的**多语言编程**能力（Rust、Java、Go、C++、Kotlin、Objective-C、TS/JS）。
 - 更好的 **Web/应用开发**和美观输出质量（包括原生移动端）。
+- **原生图像输入**支持视觉工作流。
+- **512K 上下文窗口**和 **128K 最大输出**，支持更长、更复杂的任务。
 - 改进的**复合指令**处理，适用于办公风格的工作流程，基于交错思考和集成约束执行。
 - **更简洁的响应**，更低的 token 使用量和更快的迭代循环。
 - 更强的**工具/智能体框架**兼容性和上下文管理（Claude Code、Droid/Factory AI、Cline、Kilo Code、Roo Code、BlackBox）。
 - 更高质量的**对话和技术写作**输出。
 
-## MiniMax M2.7 vs MiniMax M2.7 Highspeed
+## MiniMax M3 vs MiniMax M2.7
 
-- **速度：** `MiniMax-M2.7-highspeed` 是面向低延迟场景的官方快速版本。
-- **成本：** 定价显示相同的输入成本，但 Highspeed 的输出成本更高。
-- **兼容性：** OpenClaw 仍然接受旧版 `MiniMax-M2.5`、`MiniMax-M2.5-highspeed` 和 `MiniMax-M2.5-Lightning` 配置，但新设置推荐使用 `MiniMax-M2.7`。
+- **能力：** M3 新增图像输入和更大的上下文（512K vs 192K）。
+- **兼容性：** OpenClaw 同时支持 `MiniMax-M3` 和 `MiniMax-M2.7`，新设置推荐使用 `MiniMax-M3`。
 
 ## 选择设置方式
 
@@ -56,7 +57,7 @@ openclaw onboard --auth-choice minimax-portal
 
 详情参见 [MiniMax OAuth 插件 README](https://github.com/openclaw/openclaw/tree/main/extensions/minimax-portal-auth)。
 
-### MiniMax M2.7（API 密钥）
+### MiniMax M3（API 密钥）
 
 **适用于：** 使用 Anthropic 兼容 API 的托管 MiniMax。
 
@@ -64,12 +65,12 @@ openclaw onboard --auth-choice minimax-portal
 
 - 运行 `openclaw configure`
 - 选择 **Model/auth**
-- 选择 **MiniMax M2.7**
+- 选择 **MiniMax M3**
 
 ```json5
 {
   env: { MINIMAX_API_KEY: "sk-..." },
-  agents: { defaults: { model: { primary: "minimax/MiniMax-M2.7" } } },
+  agents: { defaults: { model: { primary: "minimax/MiniMax-M3" } } },
   models: {
     mode: "merge",
     providers: {
@@ -79,22 +80,22 @@ openclaw onboard --auth-choice minimax-portal
         api: "anthropic-messages",
         models: [
           {
+            id: "MiniMax-M3",
+            name: "MiniMax M3",
+            reasoning: true,
+            input: ["text", "image"],
+            cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
+            contextWindow: 512000,
+            maxTokens: 128000,
+          },
+          {
             id: "MiniMax-M2.7",
             name: "MiniMax M2.7",
             reasoning: true,
             input: ["text"],
             cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
-            contextWindow: 200000,
-            maxTokens: 8192,
-          },
-          {
-            id: "MiniMax-M2.7-highspeed",
-            name: "MiniMax M2.7 Highspeed",
-            reasoning: true,
-            input: ["text"],
-            cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
-            contextWindow: 200000,
-            maxTokens: 8192,
+            contextWindow: 192000,
+            maxTokens: 65536,
           },
         ],
       },
@@ -103,9 +104,9 @@ openclaw onboard --auth-choice minimax-portal
 }
 ```
 
-### MiniMax M2.7 作为备用（示例）
+### MiniMax M3 作为备用（示例）
 
-**适用于：** 保持最强模型为主模型，故障时切换到 MiniMax M2.7。
+**适用于：** 保持最强模型为主模型，故障时切换到 MiniMax M3。
 
 ```json5
 {
@@ -114,11 +115,11 @@ openclaw onboard --auth-choice minimax-portal
     defaults: {
       models: {
         "anthropic/claude-opus-4-6": { alias: "primary" },
-        "minimax/MiniMax-M2.7": { alias: "minimax" },
+        "minimax/MiniMax-M3": { alias: "minimax" },
       },
       model: {
         primary: "anthropic/claude-opus-4-6",
-        fallbacks: ["minimax/MiniMax-M2.7"],
+        fallbacks: ["minimax/MiniMax-M3"],
       },
     },
   },
@@ -170,7 +171,7 @@ openclaw onboard --auth-choice minimax-portal
 
 1. 运行 `openclaw configure`。
 2. 选择 **Model/auth**。
-3. 选择 **MiniMax M2.7**。
+3. 选择 **MiniMax M3**。
 4. 在提示时选择你的默认模型。
 
 ## 配置选项
@@ -185,32 +186,28 @@ openclaw onboard --auth-choice minimax-portal
 ## 注意事项
 
 - 模型引用格式为 `minimax/<model>`。
-- 推荐模型 ID：`MiniMax-M2.7` 和 `MiniMax-M2.7-highspeed`。
-- 旧版模型 ID（`MiniMax-M2.5`、`MiniMax-M2.5-highspeed`、`MiniMax-M2.5-Lightning`）仍然受支持。
+- 推荐模型 ID：`MiniMax-M3`（最新旗舰）和 `MiniMax-M2.7`（上一代旗舰）。
 - 编程计划使用量 API：`https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains`（需要编程计划密钥）。
 - 如果需要精确的成本跟踪，请更新 `models.json` 中的定价值。
 - MiniMax 编程计划推荐链接（9 折优惠）：https://platform.minimax.io/subscribe/coding-plan?code=DbXJTRClnb&source=link
 - 参见 [/concepts/model-providers](/concepts/model-providers) 了解提供商规则。
-- 使用 `openclaw models list` 和 `openclaw models set minimax/MiniMax-M2.7` 切换模型。
+- 使用 `openclaw models list` 和 `openclaw models set minimax/MiniMax-M3` 切换模型。
 
 ## 故障排除
 
-### "Unknown model: minimax/MiniMax-M2.7"
+### "Unknown model: minimax/MiniMax-M3"
 
 这通常意味着 **MiniMax 提供商未配置**（没有提供商条目，也没有找到 MiniMax 认证配置文件/环境变量密钥）。此检测的修复在 **2026.1.12** 中（撰写本文时尚未发布）。修复方法：
 
 - 升级到 **2026.1.12**（或从源码 `main` 分支运行），然后重启 Gateway 网关。
-- 运行 `openclaw configure` 并选择 **MiniMax M2.7**，或
+- 运行 `openclaw configure` 并选择 **MiniMax M3**，或
 - 手动添加 `models.providers.minimax` 块，或
 - 设置 `MINIMAX_API_KEY`（或 MiniMax 认证配置文件）以便注入提供商。
 
 确保模型 id **区分大小写**：
 
+- `minimax/MiniMax-M3`
 - `minimax/MiniMax-M2.7`
-- `minimax/MiniMax-M2.7-highspeed`
-- `minimax/MiniMax-M2.5`（旧版）
-- `minimax/MiniMax-M2.5-highspeed`（旧版）
-- `minimax/MiniMax-M2.5-Lightning`（旧版）
 
 然后重新检查：
 

--- a/openclaw/extensions/minimax-portal-auth/index.ts
+++ b/openclaw/extensions/minimax-portal-auth/index.ts
@@ -8,11 +8,11 @@ import { loginMiniMaxPortalOAuth, type MiniMaxRegion } from "./oauth.js";
 
 const PROVIDER_ID = "minimax-portal";
 const PROVIDER_LABEL = "MiniMax";
-const DEFAULT_MODEL = "MiniMax-M2.5";
+const DEFAULT_MODEL = "MiniMax-M3";
 const DEFAULT_BASE_URL_CN = "https://api.minimaxi.com/anthropic";
 const DEFAULT_BASE_URL_GLOBAL = "https://api.minimax.io/anthropic";
-const DEFAULT_CONTEXT_WINDOW = 200000;
-const DEFAULT_MAX_TOKENS = 8192;
+const DEFAULT_CONTEXT_WINDOW = 512000;
+const DEFAULT_MAX_TOKENS = 128000;
 const OAUTH_PLACEHOLDER = "minimax-oauth";
 
 function getDefaultBaseUrl(region: MiniMaxRegion): string {
@@ -85,19 +85,14 @@ function createOAuthHandler(region: MiniMaxRegion) {
                 api: "anthropic-messages",
                 models: [
                   buildModelDefinition({
-                    id: "MiniMax-M2.5",
-                    name: "MiniMax M2.5",
-                    input: ["text"],
-                  }),
-                  buildModelDefinition({
-                    id: "MiniMax-M2.5-highspeed",
-                    name: "MiniMax M2.5 Highspeed",
-                    input: ["text"],
+                    id: "MiniMax-M3",
+                    name: "MiniMax M3",
+                    input: ["text", "image"],
                     reasoning: true,
                   }),
                   buildModelDefinition({
-                    id: "MiniMax-M2.5-Lightning",
-                    name: "MiniMax M2.5 Lightning",
+                    id: "MiniMax-M2.7",
+                    name: "MiniMax M2.7",
                     input: ["text"],
                     reasoning: true,
                   }),
@@ -108,13 +103,8 @@ function createOAuthHandler(region: MiniMaxRegion) {
           agents: {
             defaults: {
               models: {
-                [modelRef("MiniMax-M2.5")]: { alias: "minimax-m2.5" },
-                [modelRef("MiniMax-M2.5-highspeed")]: {
-                  alias: "minimax-m2.5-highspeed",
-                },
-                [modelRef("MiniMax-M2.5-Lightning")]: {
-                  alias: "minimax-m2.5-lightning",
-                },
+                [modelRef("MiniMax-M3")]: { alias: "minimax-m3" },
+                [modelRef("MiniMax-M2.7")]: { alias: "minimax-m2.7" },
               },
             },
           },

--- a/openclaw/scripts/bench-model.ts
+++ b/openclaw/scripts/bench-model.ts
@@ -92,7 +92,7 @@ async function main(): Promise<void> {
   }
 
   const minimaxBaseUrl = process.env.MINIMAX_BASE_URL?.trim() || "https://api.minimax.io/v1";
-  const minimaxModelId = process.env.MINIMAX_MODEL?.trim() || "MiniMax-M2.1";
+  const minimaxModelId = process.env.MINIMAX_MODEL?.trim() || "MiniMax-M2.7";
 
   const minimaxModel: Model<"openai-completions"> = {
     id: minimaxModelId,

--- a/openclaw/scripts/bench-model.ts
+++ b/openclaw/scripts/bench-model.ts
@@ -92,7 +92,7 @@ async function main(): Promise<void> {
   }
 
   const minimaxBaseUrl = process.env.MINIMAX_BASE_URL?.trim() || "https://api.minimax.io/v1";
-  const minimaxModelId = process.env.MINIMAX_MODEL?.trim() || "MiniMax-M2.7";
+  const minimaxModelId = process.env.MINIMAX_MODEL?.trim() || "MiniMax-M3";
 
   const minimaxModel: Model<"openai-completions"> = {
     id: minimaxModelId,
@@ -103,8 +103,8 @@ async function main(): Promise<void> {
     reasoning: false,
     input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: 200000,
-    maxTokens: 8192,
+    contextWindow: 512000,
+    maxTokens: 128000,
   };
   const opusModel = getModel("anthropic", "claude-opus-4-6");
 

--- a/openclaw/src/agents/live-model-filter.ts
+++ b/openclaw/src/agents/live-model-filter.ts
@@ -22,7 +22,7 @@ const CODEX_MODELS = [
 ];
 const GOOGLE_PREFIXES = ["gemini-3"];
 const ZAI_PREFIXES = ["glm-5", "glm-4.7", "glm-4.7-flash", "glm-4.7-flashx"];
-const MINIMAX_PREFIXES = ["minimax-m2.5", "minimax-m2.5"];
+const MINIMAX_PREFIXES = ["minimax-m2.7", "minimax-m2.7", "minimax-m2.5", "minimax-m2.5"];
 const XAI_PREFIXES = ["grok-4"];
 
 function matchesPrefix(id: string, prefixes: string[]): boolean {

--- a/openclaw/src/agents/live-model-filter.ts
+++ b/openclaw/src/agents/live-model-filter.ts
@@ -22,7 +22,7 @@ const CODEX_MODELS = [
 ];
 const GOOGLE_PREFIXES = ["gemini-3"];
 const ZAI_PREFIXES = ["glm-5", "glm-4.7", "glm-4.7-flash", "glm-4.7-flashx"];
-const MINIMAX_PREFIXES = ["minimax-m2.7", "minimax-m2.7", "minimax-m2.5", "minimax-m2.5"];
+const MINIMAX_PREFIXES = ["minimax-m3", "minimax-m2.7"];
 const XAI_PREFIXES = ["grok-4"];
 
 function matchesPrefix(id: string, prefixes: string[]): boolean {

--- a/openclaw/src/agents/minimax.live.test.ts
+++ b/openclaw/src/agents/minimax.live.test.ts
@@ -4,7 +4,7 @@ import { isTruthyEnvValue } from "../infra/env.js";
 
 const MINIMAX_KEY = process.env.MINIMAX_API_KEY ?? "";
 const MINIMAX_BASE_URL = process.env.MINIMAX_BASE_URL?.trim() || "https://api.minimax.io/anthropic";
-const MINIMAX_MODEL = process.env.MINIMAX_MODEL?.trim() || "MiniMax-M2.5";
+const MINIMAX_MODEL = process.env.MINIMAX_MODEL?.trim() || "MiniMax-M2.7";
 const LIVE = isTruthyEnvValue(process.env.MINIMAX_LIVE_TEST) || isTruthyEnvValue(process.env.LIVE);
 
 const describeLive = LIVE && MINIMAX_KEY ? describe : describe.skip;

--- a/openclaw/src/agents/minimax.live.test.ts
+++ b/openclaw/src/agents/minimax.live.test.ts
@@ -4,7 +4,7 @@ import { isTruthyEnvValue } from "../infra/env.js";
 
 const MINIMAX_KEY = process.env.MINIMAX_API_KEY ?? "";
 const MINIMAX_BASE_URL = process.env.MINIMAX_BASE_URL?.trim() || "https://api.minimax.io/anthropic";
-const MINIMAX_MODEL = process.env.MINIMAX_MODEL?.trim() || "MiniMax-M2.7";
+const MINIMAX_MODEL = process.env.MINIMAX_MODEL?.trim() || "MiniMax-M3";
 const LIVE = isTruthyEnvValue(process.env.MINIMAX_LIVE_TEST) || isTruthyEnvValue(process.env.LIVE);
 
 const describeLive = LIVE && MINIMAX_KEY ? describe : describe.skip;
@@ -17,12 +17,12 @@ describeLive("minimax live", () => {
       api: "anthropic-messages",
       provider: "minimax",
       baseUrl: MINIMAX_BASE_URL,
-      reasoning: false,
-      input: ["text"],
+      reasoning: true,
+      input: ["text", "image"],
       // Pricing: placeholder values (per 1M tokens, multiplied by 1000 for display)
       cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 },
-      contextWindow: 200000,
-      maxTokens: 8192,
+      contextWindow: 512000,
+      maxTokens: 128000,
     };
     const res = await completeSimple(
       model,

--- a/openclaw/src/agents/models-config.providers.ts
+++ b/openclaw/src/agents/models-config.providers.ts
@@ -58,10 +58,10 @@ type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
 export type ProviderConfig = NonNullable<ModelsConfig["providers"]>[string];
 
 const MINIMAX_PORTAL_BASE_URL = "https://api.minimax.io/anthropic";
-const MINIMAX_DEFAULT_MODEL_ID = "MiniMax-M2.5";
+const MINIMAX_DEFAULT_MODEL_ID = "MiniMax-M3";
 const MINIMAX_DEFAULT_VISION_MODEL_ID = "MiniMax-VL-01";
-const MINIMAX_DEFAULT_CONTEXT_WINDOW = 200000;
-const MINIMAX_DEFAULT_MAX_TOKENS = 8192;
+const MINIMAX_DEFAULT_CONTEXT_WINDOW = 512000;
+const MINIMAX_DEFAULT_MAX_TOKENS = 128000;
 const MINIMAX_OAUTH_PLACEHOLDER = "minimax-oauth";
 // Pricing per 1M tokens (USD) — https://platform.minimaxi.com/document/Price
 const MINIMAX_API_COST = {
@@ -586,25 +586,21 @@ function buildMinimaxProvider(): ProviderConfig {
     authHeader: true,
     models: [
       buildMinimaxModel({
+        id: MINIMAX_DEFAULT_MODEL_ID,
+        name: "MiniMax M3",
+        reasoning: true,
+        input: ["text", "image"],
+      }),
+      buildMinimaxTextModel({
+        id: "MiniMax-M2.7",
+        name: "MiniMax M2.7",
+        reasoning: true,
+      }),
+      buildMinimaxModel({
         id: MINIMAX_DEFAULT_VISION_MODEL_ID,
         name: "MiniMax VL 01",
         reasoning: false,
         input: ["text", "image"],
-      }),
-      buildMinimaxTextModel({
-        id: "MiniMax-M2.5",
-        name: "MiniMax M2.5",
-        reasoning: true,
-      }),
-      buildMinimaxTextModel({
-        id: "MiniMax-M2.5-highspeed",
-        name: "MiniMax M2.5 Highspeed",
-        reasoning: true,
-      }),
-      buildMinimaxTextModel({
-        id: "MiniMax-M2.5-Lightning",
-        name: "MiniMax M2.5 Lightning",
-        reasoning: true,
       }),
     ],
   };
@@ -616,19 +612,15 @@ function buildMinimaxPortalProvider(): ProviderConfig {
     api: "anthropic-messages",
     authHeader: true,
     models: [
-      buildMinimaxTextModel({
+      buildMinimaxModel({
         id: MINIMAX_DEFAULT_MODEL_ID,
-        name: "MiniMax M2.5",
+        name: "MiniMax M3",
         reasoning: true,
+        input: ["text", "image"],
       }),
       buildMinimaxTextModel({
-        id: "MiniMax-M2.5-highspeed",
-        name: "MiniMax M2.5 Highspeed",
-        reasoning: true,
-      }),
-      buildMinimaxTextModel({
-        id: "MiniMax-M2.5-Lightning",
-        name: "MiniMax M2.5 Lightning",
+        id: "MiniMax-M2.7",
+        name: "MiniMax M2.7",
         reasoning: true,
       }),
     ],

--- a/openclaw/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
+++ b/openclaw/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
@@ -98,7 +98,7 @@ describe("models-config", () => {
         providerKey: "minimax",
         expectedBaseUrl: "https://api.minimax.io/anthropic",
         expectedApiKeyRef: "MINIMAX_API_KEY",
-        expectedModelIds: ["MiniMax-M2.5", "MiniMax-VL-01"],
+        expectedModelIds: ["MiniMax-M3", "MiniMax-M2.7", "MiniMax-VL-01"],
       });
     });
   });
@@ -111,7 +111,7 @@ describe("models-config", () => {
         providerKey: "synthetic",
         expectedBaseUrl: "https://api.synthetic.new/anthropic",
         expectedApiKeyRef: "SYNTHETIC_API_KEY",
-        expectedModelIds: ["hf:MiniMaxAI/MiniMax-M2.5"],
+        expectedModelIds: ["hf:MiniMaxAI/MiniMax-M3"],
       });
     });
   });

--- a/openclaw/src/agents/synthetic-models.ts
+++ b/openclaw/src/agents/synthetic-models.ts
@@ -1,7 +1,7 @@
 import type { ModelDefinitionConfig } from "../config/types.js";
 
 export const SYNTHETIC_BASE_URL = "https://api.synthetic.new/anthropic";
-export const SYNTHETIC_DEFAULT_MODEL_ID = "hf:MiniMaxAI/MiniMax-M2.5";
+export const SYNTHETIC_DEFAULT_MODEL_ID = "hf:MiniMaxAI/MiniMax-M2.7";
 export const SYNTHETIC_DEFAULT_MODEL_REF = `synthetic/${SYNTHETIC_DEFAULT_MODEL_ID}`;
 export const SYNTHETIC_DEFAULT_COST = {
   input: 0,
@@ -13,6 +13,22 @@ export const SYNTHETIC_DEFAULT_COST = {
 export const SYNTHETIC_MODEL_CATALOG = [
   {
     id: SYNTHETIC_DEFAULT_MODEL_ID,
+    name: "MiniMax M2.7",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 192000,
+    maxTokens: 65536,
+  },
+  {
+    id: "hf:MiniMaxAI/MiniMax-M2.7-highspeed",
+    name: "MiniMax M2.7 Highspeed",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 192000,
+    maxTokens: 65536,
+  },
+  {
+    id: "hf:MiniMaxAI/MiniMax-M2.5",
     name: "MiniMax M2.5",
     reasoning: false,
     input: ["text"],

--- a/openclaw/src/agents/synthetic-models.ts
+++ b/openclaw/src/agents/synthetic-models.ts
@@ -1,7 +1,7 @@
 import type { ModelDefinitionConfig } from "../config/types.js";
 
 export const SYNTHETIC_BASE_URL = "https://api.synthetic.new/anthropic";
-export const SYNTHETIC_DEFAULT_MODEL_ID = "hf:MiniMaxAI/MiniMax-M2.7";
+export const SYNTHETIC_DEFAULT_MODEL_ID = "hf:MiniMaxAI/MiniMax-M3";
 export const SYNTHETIC_DEFAULT_MODEL_REF = `synthetic/${SYNTHETIC_DEFAULT_MODEL_ID}`;
 export const SYNTHETIC_DEFAULT_COST = {
   input: 0,
@@ -13,6 +13,14 @@ export const SYNTHETIC_DEFAULT_COST = {
 export const SYNTHETIC_MODEL_CATALOG = [
   {
     id: SYNTHETIC_DEFAULT_MODEL_ID,
+    name: "MiniMax M3",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 512000,
+    maxTokens: 128000,
+  },
+  {
+    id: "hf:MiniMaxAI/MiniMax-M2.7",
     name: "MiniMax M2.7",
     reasoning: false,
     input: ["text"],
@@ -22,14 +30,6 @@ export const SYNTHETIC_MODEL_CATALOG = [
   {
     id: "hf:MiniMaxAI/MiniMax-M2.7-highspeed",
     name: "MiniMax M2.7 Highspeed",
-    reasoning: false,
-    input: ["text"],
-    contextWindow: 192000,
-    maxTokens: 65536,
-  },
-  {
-    id: "hf:MiniMaxAI/MiniMax-M2.5",
-    name: "MiniMax M2.5",
     reasoning: false,
     input: ["text"],
     contextWindow: 192000,

--- a/openclaw/src/commands/auth-choice-options.ts
+++ b/openclaw/src/commands/auth-choice-options.ts
@@ -286,16 +286,16 @@ const BASE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
     label: "OpenCode Zen (multi-model proxy)",
     hint: "Claude, GPT, Gemini via opencode.ai/zen",
   },
-  { value: "minimax-api", label: "MiniMax M2.5" },
+  { value: "minimax-api", label: "MiniMax M3" },
   {
     value: "minimax-api-key-cn",
-    label: "MiniMax M2.5 (CN)",
+    label: "MiniMax M3 (CN)",
     hint: "China endpoint (api.minimaxi.com)",
   },
   {
     value: "minimax-api-lightning",
-    label: "MiniMax M2.5 Highspeed",
-    hint: "Official fast tier (legacy: Lightning)",
+    label: "MiniMax M2.7",
+    hint: "Fast tier (M2.7)",
   },
   { value: "custom-api-key", label: "Custom Provider" },
 ];

--- a/openclaw/src/commands/auth-choice.apply.minimax.test.ts
+++ b/openclaw/src/commands/auth-choice.apply.minimax.test.ts
@@ -110,7 +110,7 @@ describe("applyAuthChoiceMiniMax", () => {
       token: "mm-opts-token",
       profileId: "minimax:default",
       provider: "minimax",
-      expectedModel: "minimax/MiniMax-M2.5",
+      expectedModel: "minimax/MiniMax-M2.7",
     },
     {
       caseName:
@@ -120,7 +120,7 @@ describe("applyAuthChoiceMiniMax", () => {
       token: "mm-cn-opts-token",
       profileId: "minimax-cn:default",
       provider: "minimax-cn",
-      expectedModel: "minimax-cn/MiniMax-M2.5",
+      expectedModel: "minimax-cn/MiniMax-M2.7",
     },
   ])(
     "$caseName",
@@ -182,7 +182,7 @@ describe("applyAuthChoiceMiniMax", () => {
         mode: "api_key",
       });
       expect(resolveAgentModelPrimaryValue(result?.config.agents?.defaults?.model)).toBe(
-        "minimax-cn/MiniMax-M2.5",
+        "minimax-cn/MiniMax-M2.7",
       );
     }
     expect(text).not.toHaveBeenCalled();
@@ -212,7 +212,7 @@ describe("applyAuthChoiceMiniMax", () => {
       mode: "api_key",
     });
     expect(resolveAgentModelPrimaryValue(result?.config.agents?.defaults?.model)).toBe(
-      "minimax/MiniMax-M2.5-highspeed",
+      "minimax/MiniMax-M2.7-highspeed",
     );
     expect(text).not.toHaveBeenCalled();
     expect(confirm).not.toHaveBeenCalled();

--- a/openclaw/src/commands/auth-choice.apply.minimax.test.ts
+++ b/openclaw/src/commands/auth-choice.apply.minimax.test.ts
@@ -110,7 +110,7 @@ describe("applyAuthChoiceMiniMax", () => {
       token: "mm-opts-token",
       profileId: "minimax:default",
       provider: "minimax",
-      expectedModel: "minimax/MiniMax-M2.7",
+      expectedModel: "minimax/MiniMax-M3",
     },
     {
       caseName:
@@ -120,7 +120,7 @@ describe("applyAuthChoiceMiniMax", () => {
       token: "mm-cn-opts-token",
       profileId: "minimax-cn:default",
       provider: "minimax-cn",
-      expectedModel: "minimax-cn/MiniMax-M2.7",
+      expectedModel: "minimax-cn/MiniMax-M3",
     },
   ])(
     "$caseName",
@@ -182,7 +182,7 @@ describe("applyAuthChoiceMiniMax", () => {
         mode: "api_key",
       });
       expect(resolveAgentModelPrimaryValue(result?.config.agents?.defaults?.model)).toBe(
-        "minimax-cn/MiniMax-M2.7",
+        "minimax-cn/MiniMax-M3",
       );
     }
     expect(text).not.toHaveBeenCalled();
@@ -212,7 +212,7 @@ describe("applyAuthChoiceMiniMax", () => {
       mode: "api_key",
     });
     expect(resolveAgentModelPrimaryValue(result?.config.agents?.defaults?.model)).toBe(
-      "minimax/MiniMax-M2.7-highspeed",
+      "minimax/MiniMax-M2.7",
     );
     expect(text).not.toHaveBeenCalled();
     expect(confirm).not.toHaveBeenCalled();

--- a/openclaw/src/commands/auth-choice.apply.minimax.ts
+++ b/openclaw/src/commands/auth-choice.apply.minimax.ts
@@ -112,7 +112,7 @@ export async function applyAuthChoiceMiniMax(
       promptMessage: "Enter MiniMax API key",
       modelRefPrefix: "minimax",
       modelId:
-        params.authChoice === "minimax-api-lightning" ? "MiniMax-M2.5-highspeed" : "MiniMax-M2.5",
+        params.authChoice === "minimax-api-lightning" ? "MiniMax-M2.7-highspeed" : "MiniMax-M2.7",
       applyDefaultConfig: applyMinimaxApiConfig,
       applyProviderConfig: applyMinimaxApiProviderConfig,
     });
@@ -124,7 +124,7 @@ export async function applyAuthChoiceMiniMax(
       provider: "minimax-cn",
       promptMessage: "Enter MiniMax China API key",
       modelRefPrefix: "minimax-cn",
-      modelId: "MiniMax-M2.5",
+      modelId: "MiniMax-M2.7",
       applyDefaultConfig: applyMinimaxApiConfigCn,
       applyProviderConfig: applyMinimaxApiProviderConfigCn,
     });

--- a/openclaw/src/commands/auth-choice.apply.minimax.ts
+++ b/openclaw/src/commands/auth-choice.apply.minimax.ts
@@ -111,8 +111,7 @@ export async function applyAuthChoiceMiniMax(
       provider: "minimax",
       promptMessage: "Enter MiniMax API key",
       modelRefPrefix: "minimax",
-      modelId:
-        params.authChoice === "minimax-api-lightning" ? "MiniMax-M2.7-highspeed" : "MiniMax-M2.7",
+      modelId: params.authChoice === "minimax-api-lightning" ? "MiniMax-M2.7" : "MiniMax-M3",
       applyDefaultConfig: applyMinimaxApiConfig,
       applyProviderConfig: applyMinimaxApiProviderConfig,
     });
@@ -124,7 +123,7 @@ export async function applyAuthChoiceMiniMax(
       provider: "minimax-cn",
       promptMessage: "Enter MiniMax China API key",
       modelRefPrefix: "minimax-cn",
-      modelId: "MiniMax-M2.7",
+      modelId: "MiniMax-M3",
       applyDefaultConfig: applyMinimaxApiConfigCn,
       applyProviderConfig: applyMinimaxApiProviderConfigCn,
     });

--- a/openclaw/src/commands/auth-choice.test.ts
+++ b/openclaw/src/commands/auth-choice.test.ts
@@ -1230,7 +1230,7 @@ describe("applyAuthChoice", () => {
         profileId: "minimax-portal:default",
         baseUrl: "https://api.minimax.io/anthropic",
         api: "anthropic-messages",
-        defaultModel: "minimax-portal/MiniMax-M2.5",
+        defaultModel: "minimax-portal/MiniMax-M3",
         apiKey: "minimax-oauth",
         selectValue: "oauth",
       },

--- a/openclaw/src/commands/onboard-auth.config-minimax.ts
+++ b/openclaw/src/commands/onboard-auth.config-minimax.ts
@@ -112,7 +112,7 @@ export function applyMinimaxHostedConfig(
 // MiniMax Anthropic-compatible API (platform.minimax.io/anthropic)
 export function applyMinimaxApiProviderConfig(
   cfg: OpenClawConfig,
-  modelId: string = "MiniMax-M2.5",
+  modelId: string = "MiniMax-M2.7",
 ): OpenClawConfig {
   return applyMinimaxApiProviderConfigWithBaseUrl(cfg, {
     providerId: "minimax",
@@ -123,7 +123,7 @@ export function applyMinimaxApiProviderConfig(
 
 export function applyMinimaxApiConfig(
   cfg: OpenClawConfig,
-  modelId: string = "MiniMax-M2.5",
+  modelId: string = "MiniMax-M2.7",
 ): OpenClawConfig {
   return applyMinimaxApiConfigWithBaseUrl(cfg, {
     providerId: "minimax",
@@ -135,7 +135,7 @@ export function applyMinimaxApiConfig(
 // MiniMax China API (api.minimaxi.com)
 export function applyMinimaxApiProviderConfigCn(
   cfg: OpenClawConfig,
-  modelId: string = "MiniMax-M2.5",
+  modelId: string = "MiniMax-M2.7",
 ): OpenClawConfig {
   return applyMinimaxApiProviderConfigWithBaseUrl(cfg, {
     providerId: "minimax-cn",
@@ -146,7 +146,7 @@ export function applyMinimaxApiProviderConfigCn(
 
 export function applyMinimaxApiConfigCn(
   cfg: OpenClawConfig,
-  modelId: string = "MiniMax-M2.5",
+  modelId: string = "MiniMax-M2.7",
 ): OpenClawConfig {
   return applyMinimaxApiConfigWithBaseUrl(cfg, {
     providerId: "minimax-cn",

--- a/openclaw/src/commands/onboard-auth.config-minimax.ts
+++ b/openclaw/src/commands/onboard-auth.config-minimax.ts
@@ -112,7 +112,7 @@ export function applyMinimaxHostedConfig(
 // MiniMax Anthropic-compatible API (platform.minimax.io/anthropic)
 export function applyMinimaxApiProviderConfig(
   cfg: OpenClawConfig,
-  modelId: string = "MiniMax-M2.7",
+  modelId: string = "MiniMax-M3",
 ): OpenClawConfig {
   return applyMinimaxApiProviderConfigWithBaseUrl(cfg, {
     providerId: "minimax",
@@ -123,7 +123,7 @@ export function applyMinimaxApiProviderConfig(
 
 export function applyMinimaxApiConfig(
   cfg: OpenClawConfig,
-  modelId: string = "MiniMax-M2.7",
+  modelId: string = "MiniMax-M3",
 ): OpenClawConfig {
   return applyMinimaxApiConfigWithBaseUrl(cfg, {
     providerId: "minimax",
@@ -135,7 +135,7 @@ export function applyMinimaxApiConfig(
 // MiniMax China API (api.minimaxi.com)
 export function applyMinimaxApiProviderConfigCn(
   cfg: OpenClawConfig,
-  modelId: string = "MiniMax-M2.7",
+  modelId: string = "MiniMax-M3",
 ): OpenClawConfig {
   return applyMinimaxApiProviderConfigWithBaseUrl(cfg, {
     providerId: "minimax-cn",
@@ -146,7 +146,7 @@ export function applyMinimaxApiProviderConfigCn(
 
 export function applyMinimaxApiConfigCn(
   cfg: OpenClawConfig,
-  modelId: string = "MiniMax-M2.7",
+  modelId: string = "MiniMax-M3",
 ): OpenClawConfig {
   return applyMinimaxApiConfigWithBaseUrl(cfg, {
     providerId: "minimax-cn",

--- a/openclaw/src/commands/onboard-auth.models.ts
+++ b/openclaw/src/commands/onboard-auth.models.ts
@@ -17,10 +17,10 @@ export {
 export const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1";
 export const MINIMAX_API_BASE_URL = "https://api.minimax.io/anthropic";
 export const MINIMAX_CN_API_BASE_URL = "https://api.minimaxi.com/anthropic";
-export const MINIMAX_HOSTED_MODEL_ID = "MiniMax-M2.7";
+export const MINIMAX_HOSTED_MODEL_ID = "MiniMax-M3";
 export const MINIMAX_HOSTED_MODEL_REF = `minimax/${MINIMAX_HOSTED_MODEL_ID}`;
-export const DEFAULT_MINIMAX_CONTEXT_WINDOW = 200000;
-export const DEFAULT_MINIMAX_MAX_TOKENS = 8192;
+export const DEFAULT_MINIMAX_CONTEXT_WINDOW = 512000;
+export const DEFAULT_MINIMAX_MAX_TOKENS = 128000;
 
 export const MOONSHOT_BASE_URL = "https://api.moonshot.ai/v1";
 export const MOONSHOT_CN_BASE_URL = "https://api.moonshot.cn/v1";
@@ -89,11 +89,8 @@ export const ZAI_DEFAULT_COST = {
 };
 
 const MINIMAX_MODEL_CATALOG = {
+  "MiniMax-M3": { name: "MiniMax M3", reasoning: true },
   "MiniMax-M2.7": { name: "MiniMax M2.7", reasoning: true },
-  "MiniMax-M2.7-highspeed": { name: "MiniMax M2.7 Highspeed", reasoning: true },
-  "MiniMax-M2.5": { name: "MiniMax M2.5", reasoning: true },
-  "MiniMax-M2.5-highspeed": { name: "MiniMax M2.5 Highspeed", reasoning: true },
-  "MiniMax-M2.5-Lightning": { name: "MiniMax M2.5 Lightning", reasoning: true },
 } as const;
 
 type MinimaxCatalogId = keyof typeof MINIMAX_MODEL_CATALOG;

--- a/openclaw/src/commands/onboard-auth.models.ts
+++ b/openclaw/src/commands/onboard-auth.models.ts
@@ -17,7 +17,7 @@ export {
 export const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1";
 export const MINIMAX_API_BASE_URL = "https://api.minimax.io/anthropic";
 export const MINIMAX_CN_API_BASE_URL = "https://api.minimaxi.com/anthropic";
-export const MINIMAX_HOSTED_MODEL_ID = "MiniMax-M2.5";
+export const MINIMAX_HOSTED_MODEL_ID = "MiniMax-M2.7";
 export const MINIMAX_HOSTED_MODEL_REF = `minimax/${MINIMAX_HOSTED_MODEL_ID}`;
 export const DEFAULT_MINIMAX_CONTEXT_WINDOW = 200000;
 export const DEFAULT_MINIMAX_MAX_TOKENS = 8192;
@@ -89,6 +89,8 @@ export const ZAI_DEFAULT_COST = {
 };
 
 const MINIMAX_MODEL_CATALOG = {
+  "MiniMax-M2.7": { name: "MiniMax M2.7", reasoning: true },
+  "MiniMax-M2.7-highspeed": { name: "MiniMax M2.7 Highspeed", reasoning: true },
   "MiniMax-M2.5": { name: "MiniMax M2.5", reasoning: true },
   "MiniMax-M2.5-highspeed": { name: "MiniMax M2.5 Highspeed", reasoning: true },
   "MiniMax-M2.5-Lightning": { name: "MiniMax M2.5 Lightning", reasoning: true },

--- a/openclaw/src/commands/onboard-non-interactive.provider-auth.test.ts
+++ b/openclaw/src/commands/onboard-non-interactive.provider-auth.test.ts
@@ -190,7 +190,7 @@ describe("onboard (non-interactive): provider auth", () => {
       expect(cfg.auth?.profiles?.["minimax:default"]?.provider).toBe("minimax");
       expect(cfg.auth?.profiles?.["minimax:default"]?.mode).toBe("api_key");
       expect(cfg.models?.providers?.minimax?.baseUrl).toBe(MINIMAX_API_BASE_URL);
-      expect(cfg.agents?.defaults?.model?.primary).toBe("minimax/MiniMax-M2.5");
+      expect(cfg.agents?.defaults?.model?.primary).toBe("minimax/MiniMax-M3");
       await expectApiKeyProfile({
         profileId: "minimax:default",
         provider: "minimax",
@@ -209,7 +209,7 @@ describe("onboard (non-interactive): provider auth", () => {
       expect(cfg.auth?.profiles?.["minimax-cn:default"]?.provider).toBe("minimax-cn");
       expect(cfg.auth?.profiles?.["minimax-cn:default"]?.mode).toBe("api_key");
       expect(cfg.models?.providers?.["minimax-cn"]?.baseUrl).toBe(MINIMAX_CN_API_BASE_URL);
-      expect(cfg.agents?.defaults?.model?.primary).toBe("minimax-cn/MiniMax-M2.5");
+      expect(cfg.agents?.defaults?.model?.primary).toBe("minimax-cn/MiniMax-M3");
       await expectApiKeyProfile({
         profileId: "minimax-cn:default",
         provider: "minimax-cn",

--- a/openclaw/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/openclaw/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -831,7 +831,7 @@ export async function applyNonInteractiveAuthChoice(params: {
       mode: "api_key",
     });
     const modelId =
-      authChoice === "minimax-api-lightning" ? "MiniMax-M2.5-highspeed" : "MiniMax-M2.5";
+      authChoice === "minimax-api-lightning" ? "MiniMax-M2.7" : "MiniMax-M3";
     return isCn
       ? applyMinimaxApiConfigCn(nextConfig, modelId)
       : applyMinimaxApiConfig(nextConfig, modelId);


### PR DESCRIPTION
## Summary

Upgrade MiniMax model configuration to use the latest **M3** flagship model as the new default, with **M2.7** retained as the previous flagship.

## Changes

- Add `MiniMax-M3` to the model catalog and set it as the new default across all configurations:
  - `MINIMAX_HOSTED_MODEL_ID` → `MiniMax-M3`
  - `SYNTHETIC_DEFAULT_MODEL_ID` → `hf:MiniMaxAI/MiniMax-M3`
  - `buildMinimaxProvider()` and `buildMinimaxPortalProvider()` defaults
  - MiniMax OAuth plugin default model
  - Onboard auth choice and config defaults
  - Live model filter prefixes (`minimax-m3`)
  - Bench script default
- M3 spec: **512K context window**, **128K max output**, **native image input**, `reasoning: true`
- Keep `MiniMax-M2.7` as the previous flagship in the catalog and `MiniMax-VL-01` for vision
- Remove earlier models (`MiniMax-M2.5`, `MiniMax-M2.5-highspeed`, `MiniMax-M2.5-Lightning`) from the default catalog and provider definitions
- Update auth-choice labels and lightning tier to point at M2.7 (no more highspeed variant)
- Update English and Chinese provider documentation, configuration reference, FAQ, wizard references, and synthetic-provider docs
- Update related unit tests to expect the new M3 default model IDs

**24 files changed** across source, tests, and documentation.

## Why

MiniMax-M3 is the latest flagship model with enhanced reasoning, coding, and image-input capabilities, larger context (512K vs 192K), and higher max output (128K vs 65K). M3 supersedes both M2.7 and M2.5 as the recommended default. M2.7 is retained for backward compatibility and as a fast tier.

## Testing

- Unit test expectations updated for new M3 default model IDs
- Provider definitions, default model refs, and catalog entries updated consistently across source and docs
- Live test fixture updated to expect M3
- Local-inference references to `lmstudio/minimax-m2.5-gs32` (quantized local model) intentionally left untouched