### PR TITLE
fix: correct Tinker API URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ For detailed environment setup, see [Slime](https://github.com/THUDM/slime) or [
 
 #### Don't have a GPU?
 
-Create a [Tinker API](https://github.com/THUDM/slime). That's all you need. But note that Tinker only supports LoRA, which may not be as effective as full fine-tuning. So we are still testing it.
+Create a [Tinker API](https://thinkingmachines.ai/tinker/). That's all you need. But note that Tinker only supports LoRA, which may not be as effective as full fine-tuning. So we are still testing it.
 
 
 


### PR DESCRIPTION
## Summary
- The "Tinker API" link in the README was incorrectly pointing to `https://github.com/THUDM/slime` (the slime repo) instead of the Tinker platform at `https://thinkingmachines.ai/tinker/`

## Test plan
- [x] Verify the link in the README now points to the correct Tinker platform URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)