### PR TITLE
fix: support terminal-bench original-tasks layout

### DIFF
--- a/terminal-rl/data_utils/download.py
+++ b/terminal-rl/data_utils/download.py
@@ -8,6 +8,30 @@ from pathlib import Path
 DATASET_DIR = Path(os.getenv("DATASET_DIR", "./terminal-rl/dataset"))
 
 
+def _git_sparse_checkout(
+    repo_url: str, temp_dir: Path, branch: str, sparse_path: str
+) -> None:
+    subprocess.run(
+        [
+            "git",
+            "clone",
+            "--depth",
+            "1",
+            "--filter=blob:none",
+            "--sparse",
+            repo_url,
+            str(temp_dir),
+            "-b",
+            branch,
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(temp_dir), "sparse-checkout", "set", sparse_path],
+        check=True,
+    )
+
+
 def _download_github_folder(
     repo_url, sparse_path, target_dir, branch="main", temp_suffix="temp"
 ):
@@ -29,30 +53,55 @@ def _download_github_folder(
     temp_dir = DATASET_DIR / f"temp_{temp_suffix}"
 
     try:
-        # Clone with sparse checkout
-        subprocess.run(
-            [
-                "git",
-                "clone",
-                "--depth",
-                "1",
-                "--filter=blob:none",
-                "--sparse",
-                repo_url,
-                str(temp_dir),
-                "-b",
-                branch,
-            ],
-            check=True,
-        )
-        subprocess.run(
-            ["git", "-C", str(temp_dir), "sparse-checkout", "set", sparse_path],
-            check=True,
-        )
+        _git_sparse_checkout(repo_url, temp_dir, branch, sparse_path)
 
         # Move downloaded folder to target location
         shutil.move(str(temp_dir / sparse_path), str(target_dir))
         print(f"Successfully downloaded to {target_dir}")
+    finally:
+        if temp_dir.exists():
+            shutil.rmtree(temp_dir)
+
+
+def _download_github_folder_candidates(
+    repo_url, sparse_paths, target_dir, branch="main", temp_suffix="temp"
+):
+    """
+    Try several sparse checkout paths and keep the first one that exists.
+
+    This helps us remain compatible with upstream repo reorganizations
+    (for example, terminal-bench main moved its task directory from
+    `tasks/` to `original-tasks/`).
+    """
+    if target_dir.exists():
+        print(f"Dataset already exists at {target_dir}. Skipping download.")
+        return
+
+    DATASET_DIR.mkdir(parents=True, exist_ok=True)
+    temp_dir = DATASET_DIR / f"temp_{temp_suffix}"
+    last_error = None
+
+    try:
+        for sparse_path in sparse_paths:
+            if temp_dir.exists():
+                shutil.rmtree(temp_dir)
+
+            try:
+                _git_sparse_checkout(repo_url, temp_dir, branch, sparse_path)
+            except subprocess.CalledProcessError as exc:
+                last_error = exc
+                continue
+
+            source_path = temp_dir / sparse_path
+            if source_path.exists():
+                shutil.move(str(source_path), str(target_dir))
+                print(f"Successfully downloaded to {target_dir} from {sparse_path}")
+                return
+
+        tried = ", ".join(sparse_paths)
+        raise FileNotFoundError(
+            f"Could not find any of the requested paths in {repo_url}@{branch}: {tried}"
+        ) from last_error
     finally:
         if temp_dir.exists():
             shutil.rmtree(temp_dir)
@@ -69,8 +118,12 @@ def download_seta_env():
 def download_tbench_core():
     url = "https://github.com/laude-institute/terminal-bench.git"
     target_dir = DATASET_DIR / "tbench_core"
-    _download_github_folder(
-        url, "tasks", target_dir, branch="main", temp_suffix="tbench_core"
+    _download_github_folder_candidates(
+        url,
+        ["original-tasks", "tasks"],
+        target_dir,
+        branch="main",
+        temp_suffix="tbench_core",
     )
 
 


### PR DESCRIPTION
## Summary
- make `terminal-rl/data_utils/download.py` tolerant to upstream terminal-bench layout changes
- download `tbench_core` from `original-tasks` on current main, while keeping `tasks` as a fallback for older layouts
- refactor the sparse checkout setup into a shared helper to avoid duplicating git clone logic

## Problem
`download_tbench_core()` currently assumes the upstream repo stores core tasks under `tasks/` on `main`.

That path no longer exists on the current `laude-institute/terminal-bench` main branch, which now exposes the core dataset under `original-tasks/`. As a result, the script fails with a missing-path error when users try to download `tbench_core`.

## Verification
- `python3 -m py_compile terminal-rl/data_utils/download.py`
- `DATASET_DIR=/tmp/openclaw_tbench_download_test python3 ... mod.download_tbench_core()`
- confirmed the download succeeds from `original-tasks` and yields 241 task directories
