### PR TITLE
feat(gui-rl): add qwen3.5 multimodal and AgentNet offline tests

### DIFF
--- a/gui-rl/agents/qwen35_agent.py
+++ b/gui-rl/agents/qwen35_agent.py
@@ -1,0 +1,134 @@
+"""Qwen3.5 agent — adapts Qwen3VLAgentLocal for Qwen3.5's tool call format.
+
+Qwen3.5 uses <function=NAME><parameter=KEY>VALUE</parameter></function> format
+instead of Qwen3-VL's JSON format for tool calls. The chat template also injects
+its own tool format instructions, so the system prompt should not duplicate them.
+"""
+
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from agents.qwen3vl_agent import Qwen3VLAgentLocal
+from slime.rollout.sglang_rollout import GenerateState
+from slime.utils.mask_utils import MultiTurnLossMaskGenerator
+
+
+class Qwen35AgentLocal(Qwen3VLAgentLocal):
+    """Qwen3.5 agent with adapted system prompt and tool call parsing."""
+
+    def get_system_prompt(
+        self,
+        processed_width: Optional[int] = None,
+        processed_height: Optional[int] = None,
+    ) -> str:
+        """Task instructions only; tool format is handled by the Qwen3.5 chat template."""
+        tools_def = self.get_tool_spec(
+            processed_width=processed_width, processed_height=processed_height
+        )
+        description = tools_def["function"]["description"]
+        return (
+            f"{description}\n\n"
+            "# Response format\n\n"
+            "Response format for every step:\n"
+            "1) Action: a short imperative describing what to do in the UI.\n"
+            "2) A single <tool_call>...</tool_call> block with the function call.\n\n"
+            "Rules:\n"
+            "- Output exactly in the order: Action, <tool_call>.\n"
+            "- Be brief: one sentence for Action.\n"
+            "- Do not output anything else outside those parts.\n"
+            "- If finishing, use action=terminate in the tool call."
+        )
+
+    @staticmethod
+    def _parse_qwen35_tool_call(block: str) -> Optional[Dict[str, Any]]:
+        """Parse a Qwen3.5 <function=NAME>...</function> block into JSON dict."""
+        func_match = re.search(r"<function=([^>]+)>", block)
+        if not func_match:
+            return None
+        name = func_match.group(1).strip()
+        arguments: Dict[str, Any] = {}
+        for param_match in re.finditer(
+            r"<parameter=([^>]+)>(.*?)</parameter>", block, re.DOTALL
+        ):
+            key = param_match.group(1).strip()
+            raw_value = param_match.group(2).strip()
+            # Try to parse as JSON (for lists, numbers, etc.)
+            try:
+                arguments[key] = json.loads(raw_value)
+            except (json.JSONDecodeError, ValueError):
+                arguments[key] = raw_value
+        return {"name": name, "arguments": arguments}
+
+    def parse_response(
+        self,
+        response: str,
+        original_width: int,
+        original_height: int,
+        processed_width: Optional[int] = None,
+        processed_height: Optional[int] = None,
+    ) -> Tuple[str, List[str], Dict[str, Any]]:
+        """Parse Qwen3.5 XML tool calls, convert to JSON, then use parent logic."""
+        if response is None or not response.strip():
+            return "", [], {"raw_response": response, "tool_calls":[]}
+
+        # Strip trailing <|im_end|> if present
+        response = response.replace("<|im_end|>", "").strip()
+
+        # Convert Qwen3.5 XML tool calls to Qwen3-VL JSON format
+        converted = response
+        for tc_match in re.finditer(
+            r"<tool_call>(.*?)</tool_call>", response, re.DOTALL
+        ):
+            tc_block = tc_match.group(1)
+            parsed = self._parse_qwen35_tool_call(tc_block)
+            if parsed:
+                json_str = json.dumps(parsed, ensure_ascii=False)
+                converted = converted.replace(
+                    tc_match.group(0),
+                    f"<tool_call>\n{json_str}\n</tool_call>",
+                )
+
+        return super().parse_response(
+            converted,
+            original_width,
+            original_height,
+            processed_width=processed_width,
+            processed_height=processed_height,
+        )
+
+    def build_train_data(
+        self,
+        *,
+        args: Any,
+        state: GenerateState,
+        train_messages: List[Dict[str, Any]],
+        tool_spec: Dict[str, Any] | None = None,
+    ) -> Tuple[List[int], List[int], Dict[str, Any]]:
+        """Override to force qwen3 loss mask type for Qwen3.5 template compatibility."""
+        tokenizer = state.tokenizer
+        processor = state.processor
+        text_prompt = tokenizer.apply_chat_template(
+            train_messages,
+            tokenize=False,
+            add_generation_prompt=False,
+            tools=[tool_spec or self.get_tool_spec()],
+        )
+        if processor:
+            multimodal_inputs = self._extract_multimodal(train_messages, processor)
+            kwargs: Dict[str, Any] = {"text": [text_prompt], "return_tensors": "pt", **multimodal_inputs}
+            proc_out = processor(**kwargs)
+            input_ids = proc_out["input_ids"][0].tolist()
+            
+            ignore_keys = ["input_ids", "attention_mask", "token_type_ids"]
+            mm_train = {k: v for k, v in proc_out.items() if k not in ignore_keys} or None
+        else:
+            input_ids = tokenizer(text_prompt, add_special_tokens=False)["input_ids"]
+            mm_train = None
+
+        # Qwen3.5 template requires user query in messages; "qwen3" mask type handles this
+        mask_generator = MultiTurnLossMaskGenerator(tokenizer, tokenizer_type="qwen3")
+        _, loss_mask = mask_generator.get_loss_mask_with_multimodal_alignment(
+            train_messages, input_ids, tools=[tool_spec or self.get_tool_spec()]
+        )
+        return input_ids, loss_mask, mm_train

--- a/gui-rl/generate_with_agentnet.py
+++ b/gui-rl/generate_with_agentnet.py
@@ -1,0 +1,282 @@
+"""
+Offline trajectory generation using AgentNet pre-recorded dataset.
+
+Replaces generate_with_gui.py for environments without cloud VMs.
+Instead of interacting with a live desktop VM, this module:
+  - Reads pre-recorded screenshots from AgentNet JSONL + image directory
+  - Feeds each screenshot to the policy model (same as online rollout)
+  - Uses the pre-annotated task_completed flag as the reward signal
+
+Usage: set --custom-generate-function-path generate_with_agentnet.generate
+           --custom-rm-path generate_with_agentnet.reward_func
+"""
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import logging
+import os
+import sys
+import traceback
+from pathlib import Path
+from typing import Any
+
+from slime.rollout.sglang_rollout import GenerateState
+from slime.utils.misc import load_function
+from slime.utils.types import Sample
+
+# Re-use helpers from generate_with_gui to avoid duplication
+from generate_with_gui import (
+    _build_dynamic_history_samples,
+    _build_result_dir,
+    _get_gui_trajectory_semaphore,
+    _gui_log,
+    _save_image,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _create_agentnet_agent(args: Any, *, max_steps: int, max_image_history_length: int, result_dir: Path):
+    agent_cls_path = getattr(args, "gui_agent_class_path", None) or os.getenv("GUI_AGENT_CLASS_PATH")
+    if not agent_cls_path:
+        raise RuntimeError("GUI_AGENT_CLASS_PATH is required.")
+    agent_cls = load_function(agent_cls_path)
+    coordinate_type = os.getenv("GUI_COORDINATE_TYPE", "relative")
+    return agent_cls(
+        max_steps=max_steps,
+        max_image_history_length=max_image_history_length,
+        coordinate_type=coordinate_type,
+        example_result_dir=str(result_dir),
+    )
+
+
+async def generate(args, sample: Sample, sampling_params, evaluation: bool = False) -> Sample | list[Sample]:
+    """Offline generate: replay AgentNet screenshots through the policy model."""
+    assert not args.partial_rollout, "Partial rollout is not supported for AgentNet offline rollout."
+
+    metadata = sample.metadata or {}
+    instruction = metadata.get("instruction", "")
+    traj = metadata.get("traj", [])
+    image_dir = metadata.get("image_dir", "")
+    domain = metadata.get("domain", "agentnet")
+    task_id = metadata.get("task_id", "unknown")
+
+    result_dir = _build_result_dir(args, domain, task_id, sample)
+    traj_path = result_dir / "traj.jsonl"
+
+    state = GenerateState(args)
+
+    max_steps_cfg = getattr(args, "gui_max_steps", None)
+    if max_steps_cfg is None:
+        max_steps_cfg = int(os.getenv("GUI_MAX_STEPS", "15"))
+    max_steps = int(max_steps_cfg)
+
+    max_image_history_cfg = getattr(args, "gui_max_image_history_length", None)
+    if max_image_history_cfg is None:
+        max_image_history_cfg = int(os.getenv("GUI_MAX_IMAGE_HISTORY_LENGTH", str(max_steps)))
+    max_image_history_length = int(max_image_history_cfg)
+
+    sampling_params = dict(sampling_params)
+    if evaluation and getattr(args, "eval_temperature", None) is not None:
+        sampling_params["temperature"] = float(args.eval_temperature)
+    elif (not evaluation) and getattr(args, "rollout_temperature", None) is not None:
+        sampling_params["temperature"] = float(args.rollout_temperature)
+
+    parser = _create_agentnet_agent(
+        args,
+        max_steps=max_steps,
+        max_image_history_length=max_image_history_length,
+        result_dir=result_dir,
+    )
+    parser.reset(logging.getLogger("agentnet.rollout"))
+
+    assistant_responses: list[str] = []
+    step_snapshots: list[dict[str, Any]] = []
+    fallback_train_messages: list[dict[str, Any]] = [parser.build_train_system_message()]
+    fallback_tool_spec: dict[str, Any] | None = None
+    last_step_train_messages_for_loss: list[dict[str, Any]] | None = None
+    last_step_tool_spec_for_loss: dict[str, Any] | None = None
+    final_status = Sample.Status.COMPLETED
+
+    trajectory_semaphore = _get_gui_trajectory_semaphore()
+    await trajectory_semaphore.acquire()
+
+    try:
+        _gui_log(
+            "AgentNet offline rollout start sample=%s group=%s domain=%s task_id=%s steps=%d",
+            sample.index,
+            sample.group_index,
+            domain,
+            task_id,
+            len(traj),
+        )
+
+        steps_to_run = traj[:max_steps]
+        if not steps_to_run:
+            final_status = Sample.Status.FAILED
+        else:
+            # Save first screenshot
+            first_img_path = Path(image_dir) / steps_to_run[0]["image"]
+            if first_img_path.exists():
+                _save_image(first_img_path.read_bytes(), result_dir / "step_0.png")
+
+        for step_idx, step in enumerate(steps_to_run):
+            img_path = Path(image_dir) / step["image"]
+            if not img_path.exists():
+                _gui_log("Missing image %s at step %d, stopping", step["image"], step_idx)
+                final_status = Sample.Status.FAILED
+                break
+
+            obs = {"screenshot": img_path.read_bytes()}
+
+            parse_ctx = parser.build_policy_messages(instruction=instruction, obs=obs)
+            policy_messages = parse_ctx["messages"]
+            tool_spec = parse_ctx.get("tool_spec")
+            fallback_train_messages = policy_messages
+            fallback_tool_spec = tool_spec
+
+            response, finish_type = await parser.generate_with_sglang(
+                args=args,
+                state=state,
+                messages=policy_messages,
+                sampling_params=sampling_params,
+                sampling_seed=((int(sample.index or 0) + 1) * 1000003 + step_idx * 9973),
+                tool_spec=tool_spec,
+            )
+
+            _gui_log(
+                "step sample=%s step=%s finish=%s response=%s",
+                sample.index,
+                step_idx,
+                finish_type,
+                repr(response[:]) if response else repr(response),
+            )
+
+            if finish_type == "abort":
+                final_status = Sample.Status.ABORTED
+                break
+
+            # Build training messages for this step (same as generate_with_gui)
+            step_train_messages = copy.deepcopy(policy_messages)
+            for msg in step_train_messages:
+                if msg.get("role") == "assistant":
+                    msg["step_loss_mask"] = 0
+            step_train_messages.append({"role": "assistant", "content": response, "step_loss_mask": 1})
+            last_step_train_messages_for_loss = step_train_messages
+            last_step_tool_spec_for_loss = tool_spec
+            assistant_responses.append(response)
+            step_snapshots.append({
+                "step_idx": step_idx,
+                "train_messages": step_train_messages,
+                "response_text": response,
+                "tool_spec": tool_spec,
+            })
+
+            original_width = int(parse_ctx["original_width"])
+            original_height = int(parse_ctx["original_height"])
+            processed_width = int(parse_ctx["processed_width"])
+            processed_height = int(parse_ctx["processed_height"])
+
+            natural_action, actions, info_dict = parser.parse_response(
+                response=response,
+                original_width=original_width,
+                original_height=original_height,
+                processed_width=processed_width,
+                processed_height=processed_height,
+            )
+            parser.record_policy_turn(
+                action_text=natural_action or "Execute action",
+                response=response,
+                screenshot_bytes=obs["screenshot"],
+            )
+
+            # Save screenshot and trajectory record
+            step_image_path = result_dir / f"step_{step_idx + 1}.png"
+            _save_image(obs["screenshot"], step_image_path)
+            with open(traj_path, "a", encoding="utf-8") as f:
+                f.write(json.dumps({
+                    "step_num": step_idx + 1,
+                    "action": actions[0] if actions else "",
+                    "natural_language_action": info_dict.get("action"),
+                    "response": response,
+                    "agentnet_code": step["value"].get("code", ""),
+                }, ensure_ascii=False) + "\n")
+
+            # Terminate if model outputs DONE/FAIL
+            if actions and str(actions[0]).upper() in {"DONE", "FAIL"}:
+                final_status = Sample.Status.COMPLETED if str(actions[0]).upper() == "DONE" else Sample.Status.FAILED
+                break
+        else:
+            if steps_to_run:
+                final_status = Sample.Status.TRUNCATED
+
+        # Use pre-annotated reward (no live evaluator needed)
+        outcome_reward = float(metadata.get("reward", -1.0))
+        _gui_log("rollout end sample=%s status=%s reward=%.1f", sample.index, final_status.value, outcome_reward)
+
+        with open(result_dir / "result.txt", "w", encoding="utf-8") as f:
+            f.write(f"{outcome_reward}\n")
+
+    except Exception as e:
+        final_status = Sample.Status.ABORTED
+        tb = traceback.format_exc()
+        with open(traj_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps({"Error": str(e), "Traceback": tb}, ensure_ascii=False) + "\n")
+        print(
+            f"[AGENTNET_ROLLOUT_ERROR] sample_index={sample.index} domain={domain} task_id={task_id}\n{tb}",
+            file=sys.stderr,
+            flush=True,
+        )
+        logger.exception("AgentNet rollout failed for sample %s", sample.index)
+        outcome_reward = -1.0
+    finally:
+        trajectory_semaphore.release()
+
+    # Build final training data (identical to generate_with_gui)
+    train_messages_for_loss = last_step_train_messages_for_loss or fallback_train_messages
+    tool_spec_for_loss = last_step_tool_spec_for_loss or fallback_tool_spec
+    input_ids, loss_mask, mm_train = parser.build_train_data(
+        args=args,
+        state=state,
+        train_messages=train_messages_for_loss,
+        tool_spec=tool_spec_for_loss,
+    )
+    active_positions = [i for i in range(len(loss_mask)) if i < len(input_ids) and int(loss_mask[i]) == 1]
+    if active_positions:
+        response_start = active_positions[0]
+        response_length = len(input_ids) - response_start
+        loss_mask = [int(loss_mask[i]) if i < len(loss_mask) else 0 for i in range(response_start, len(input_ids))]
+    else:
+        response_length = 0
+        loss_mask = []
+
+    sample.tokens = input_ids
+    sample.loss_mask = loss_mask
+    sample.response = "\n".join(assistant_responses)
+    sample.response_length = response_length
+    sample.multimodal_train_inputs = mm_train
+    sample.status = final_status
+    sample.metadata = sample.metadata or {}
+    sample.metadata["agentnet_reward"] = outcome_reward
+    sample.reward = {"score": outcome_reward, "acc": float(outcome_reward > 0)}
+
+    if getattr(args, "dynamic_history", False) and not evaluation:
+        dynamic_samples = _build_dynamic_history_samples(
+            args=args,
+            state=state,
+            agent=parser,
+            base_sample=sample,
+            step_snapshots=step_snapshots,
+            outcome_reward=outcome_reward,
+            prm_score_by_step=None,
+        )
+        return dynamic_samples
+
+    return sample
+
+
+async def reward_func(args, samples: list[Sample], **kwargs) -> list[Sample]:
+    """Reward is pre-set in generate(); this is a no-op pass-through."""
+    return samples

--- a/gui-rl/gui_data_source.py
+++ b/gui-rl/gui_data_source.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import json
+import logging
 import os
 from pathlib import Path
 
@@ -9,6 +10,9 @@ import torch
 
 from slime.rollout.data_source import DataSource
 from slime.utils.types import Sample
+
+
+logger = logging.getLogger(__name__)
 
 
 def _pop_first(buffer: list[list[Sample]], num_samples: int) -> list[list[Sample]]:
@@ -129,6 +133,144 @@ class GuiMetaDataSource(DataSource):
             return
         state = torch.load(path)
         self.epoch_id = state.get("epoch_id", 0)
+        self.sample_group_index = state.get("sample_group_index", 0)
+        self.sample_index = state.get("sample_index", 0)
+        self.sample_offset = state.get("sample_offset", 0)
+
+
+class AgentNetDataSource(DataSource):
+    """Offline data source from AgentNet trajectory JSONL dataset.
+
+    Does not require a cloud VM or env pool server.
+    Each trajectory in the JSONL becomes one Sample; screenshots are read
+    from a local directory extracted from the AgentNet zip archives.
+
+    Required environment variables:
+        AGENTNET_JSONL_PATH  Path to agentnet_ubuntu_5k.jsonl (or merged)
+        AGENTNET_IMAGE_DIR   Directory containing extracted PNG screenshots
+    """
+
+    def __init__(self, args):
+        self.args = args
+        self.buffer: list[list[Sample]] = []
+        self.sample_group_index = 0
+        self.sample_index = 0
+        self.sample_offset = 0
+
+        jsonl_path = os.getenv("AGENTNET_JSONL_PATH")
+        if not jsonl_path:
+            raise RuntimeError("AGENTNET_JSONL_PATH env var is required for AgentNetDataSource")
+        image_dir = os.getenv("AGENTNET_IMAGE_DIR")
+        if not image_dir:
+            raise RuntimeError("AGENTNET_IMAGE_DIR env var is required for AgentNetDataSource")
+
+        self.image_dir = image_dir
+        self.tasks: list[dict] = []
+        kept_true = 0
+        kept_false = 0
+        skipped_missing_task_completed = 0
+
+        with open(jsonl_path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                record = json.loads(line)
+                traj = record.get("traj") or []
+                if not traj:
+                    continue
+                if "task_completed" not in record:
+                    skipped_missing_task_completed += 1
+                    continue
+                task_completed = bool(record["task_completed"])
+                if task_completed:
+                    kept_true += 1
+                else:
+                    kept_false += 1
+                self.tasks.append({
+                    "task_id": record.get("task_id", ""),
+                    "instruction": record.get("instruction", ""),
+                    "domain": record.get("domain", "unknown"),
+                    "traj": traj,
+                    "image_dir": image_dir,
+                    # binary reward: 1.0 if completed, -1.0 otherwise (matches gui-rl convention)
+                    "reward": 1.0 if task_completed else -1.0,
+                })
+
+        if not self.tasks:
+            raise RuntimeError(f"No valid trajectories loaded from {jsonl_path}")
+        logger.warning(
+            "AgentNetDataSource loaded %d labeled trajectories from %s "
+            "(task_completed=True: %d, False: %d, skipped missing label: %d)",
+            len(self.tasks),
+            jsonl_path,
+            kept_true,
+            kept_false,
+            skipped_missing_task_completed,
+        )
+
+    def _make_prompt_samples(self, num_samples: int) -> list[Sample]:
+        out: list[Sample] = []
+        for _ in range(num_samples):
+            task = self.tasks[self.sample_offset % len(self.tasks)]
+            self.sample_offset += 1
+
+            sample = Sample(
+                prompt=task["instruction"],
+                label="",
+                metadata={
+                    "task_id": task["task_id"],
+                    "domain": task["domain"],
+                    "instruction": task["instruction"],
+                    "traj": task["traj"],
+                    "image_dir": task["image_dir"],
+                    "reward": task["reward"],
+                },
+            )
+            out.append(sample)
+        return out
+
+    def get_samples(self, num_samples: int) -> list[list[Sample]]:
+        samples = _pop_first(self.buffer, num_samples)
+        num_samples -= len(samples)
+        if num_samples <= 0:
+            return samples
+
+        prompt_samples = self._make_prompt_samples(num_samples)
+        groups: list[list[Sample]] = []
+        for prompt_sample in prompt_samples:
+            group = []
+            for _ in range(self.args.n_samples_per_prompt):
+                s = copy.deepcopy(prompt_sample)
+                s.group_index = self.sample_group_index
+                s.index = self.sample_index
+                self.sample_index += 1
+                group.append(s)
+            self.sample_group_index += 1
+            groups.append(group)
+        return samples + groups
+
+    def add_samples(self, samples: list[list[Sample]]):
+        if samples:
+            self.buffer.extend(samples)
+
+    def save(self, rollout_id):
+        state = {
+            "sample_group_index": self.sample_group_index,
+            "sample_index": self.sample_index,
+            "sample_offset": self.sample_offset,
+        }
+        path = os.path.join(self.args.save, f"rollout/agentnet_state_dict_{rollout_id}.pt")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        torch.save(state, path)
+
+    def load(self, rollout_id=None):
+        if self.args.load is None:
+            return
+        path = os.path.join(self.args.load, f"rollout/agentnet_state_dict_{rollout_id}.pt")
+        if not os.path.exists(path):
+            return
+        state = torch.load(path)
         self.sample_group_index = state.get("sample_group_index", 0)
         self.sample_index = state.get("sample_index", 0)
         self.sample_offset = state.get("sample_offset", 0)

--- a/gui-rl/gui_qwen35_4b_agentnet_rl.sh
+++ b/gui-rl/gui_qwen35_4b_agentnet_rl.sh
@@ -1,0 +1,337 @@
+#!/bin/bash
+# Qwen3.5-4B GUI-RL training with AgentNet offline dataset.
+# No cloud VM or env pool server required.
+#
+# Required environment variables (must be set before running):
+#   AGENTNET_JSONL_PATH   Path to agentnet_ubuntu_5k.jsonl
+#   AGENTNET_IMAGE_DIR    Path to extracted AgentNet PNG screenshots
+#   HF_CKPT              Path to Qwen3.5-4B model
+#
+# Image extraction (run once on the training machine):
+#   cd $AGENTNET_IMAGE_DIR/../
+#   zip -s 0 images.zip --out images-full.zip && unzip images-full.zip -d extracted/
+#   export AGENTNET_IMAGE_DIR=$(pwd)/extracted
+#
+# Run:
+#   cd gui-rl
+#   bash gui_qwen35_4b_agentnet_rl.sh
+
+###############################################################################
+# User config: provide these through environment variables when needed.
+###############################################################################
+
+# Official Megatron-Bridge checkout that contains qwen35_vl_bridge/provider.
+OFFICIAL_MBRIDGE_ROOT="${OFFICIAL_MBRIDGE_ROOT:-}"
+OFFICIAL_MBRIDGE_SRC="${OFFICIAL_MBRIDGE_ROOT}/src"
+MEGATRON_LM_PATH="${OFFICIAL_MBRIDGE_ROOT}/3rdparty/Megatron-LM"
+
+# HuggingFace Qwen3.5-4B checkpoint directory.
+HF_CKPT="${HF_CKPT:-}"
+
+# AgentNet dataset files.
+AGENTNET_JSONL_PATH="${AGENTNET_JSONL_PATH:-}"
+AGENTNET_IMAGE_DIR="${AGENTNET_IMAGE_DIR:-}"
+
+# Optional naming.
+GUI_PROJECT_NAME="${GUI_PROJECT_NAME:-slime_gui-qwen35-4b-agentnet}"
+SAVE_CKPT="${SAVE_CKPT:-}"
+
+# Optional resource settings.
+NUM_GPUS=4
+ACTOR_GPUS=2
+ROLLOUT_GPUS=2
+ROLLOUT_BATCH_SIZE=4
+ROLLOUT_NUM_GPUS_PER_ENGINE=1
+GUI_EVAL_INTERVAL=""
+ENABLE_RESUME_LOAD=0
+RESUME_LOAD=""
+
+pkill -9 sglang || true
+sleep 3
+ray stop --force || true
+pkill -9 ray || true
+pkill -9 python || true
+sleep 3
+pkill -9 ray || true
+pkill -9 python || true
+
+set -ex
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+SLIME_DIR="$(cd -- "${SCRIPT_DIR}/../slime" &>/dev/null && pwd)"
+MODEL_ARGS_ROTARY_BASE=10000000 source "${SLIME_DIR}/scripts/models/qwen3.5-4B-VL.sh"
+
+if [[ -z "${SAVE_CKPT}" ]]; then
+  SAVE_CKPT="${SCRIPT_DIR}/../ckpt/gui-qwen35-4b-agentnet"
+fi
+if [[ -z "${RESUME_LOAD}" ]]; then
+  RESUME_LOAD="${SCRIPT_DIR}/../ckpt/gui-qwen35-4b-agentnet"
+fi
+
+export PYTHONUNBUFFERED=1
+export PYTHONFAULTHANDLER=1
+
+NVIDIA_BIN_DIR=${NVIDIA_BIN_DIR:-/usr/local/nvidia/bin}
+NVIDIA_LIB_DIR=${NVIDIA_LIB_DIR:-/usr/local/nvidia/lib64}
+if [[ -d "${NVIDIA_BIN_DIR}" ]]; then
+  export PATH="${NVIDIA_BIN_DIR}:${PATH}"
+fi
+if [[ -d "${NVIDIA_LIB_DIR}" ]]; then
+  export LD_LIBRARY_PATH="${NVIDIA_LIB_DIR}:${LD_LIBRARY_PATH:-}"
+fi
+
+export RAY_health_check_failure_threshold=${RAY_health_check_failure_threshold:-20}
+export RAY_health_check_period_ms=${RAY_health_check_period_ms:-5000}
+export RAY_health_check_timeout_ms=${RAY_health_check_timeout_ms:-30000}
+export RAY_num_heartbeats_timeout=${RAY_num_heartbeats_timeout:-60}
+
+if (( ACTOR_GPUS + ROLLOUT_GPUS > NUM_GPUS )); then
+  echo "ACTOR_GPUS + ROLLOUT_GPUS must be <= NUM_GPUS"
+  exit 1
+fi
+
+if [[ -z "${OFFICIAL_MBRIDGE_ROOT}" ]]; then
+  echo "ERROR: OFFICIAL_MBRIDGE_ROOT is not set"
+  exit 1
+fi
+if [[ -z "${HF_CKPT}" ]]; then
+  echo "ERROR: HF_CKPT is not set"
+  exit 1
+fi
+if [[ -z "${AGENTNET_JSONL_PATH}" ]]; then
+  echo "ERROR: AGENTNET_JSONL_PATH is not set"
+  exit 1
+fi
+if [[ ! -f "${AGENTNET_JSONL_PATH}" ]]; then
+  echo "ERROR: AGENTNET_JSONL_PATH does not exist: ${AGENTNET_JSONL_PATH}"
+  exit 1
+fi
+if [[ -z "${AGENTNET_IMAGE_DIR}" ]]; then
+  echo "ERROR: AGENTNET_IMAGE_DIR is not set"
+  exit 1
+fi
+if [[ ! -d "${AGENTNET_IMAGE_DIR}" ]]; then
+  echo "ERROR: AGENTNET_IMAGE_DIR does not exist: ${AGENTNET_IMAGE_DIR}"
+  exit 1
+fi
+export AGENTNET_JSONL_PATH
+export AGENTNET_IMAGE_DIR
+
+REF_LOAD=${REF_LOAD:-${HF_CKPT}}
+if [[ ! -e "${HF_CKPT}" ]]; then
+  echo "ERROR: HF_CKPT is not set to a valid path: ${HF_CKPT}"
+  exit 1
+fi
+if [[ ! -d "${OFFICIAL_MBRIDGE_SRC}" ]]; then
+  echo "ERROR: OFFICIAL_MBRIDGE_SRC does not exist: ${OFFICIAL_MBRIDGE_SRC}"
+  exit 1
+fi
+if [[ ! -d "${MEGATRON_LM_PATH}" ]]; then
+  echo "ERROR: MEGATRON_LM_PATH does not exist: ${MEGATRON_LM_PATH}"
+  exit 1
+fi
+export HF_CKPT
+export OFFICIAL_MBRIDGE_ROOT
+export OFFICIAL_MBRIDGE_SRC
+export MEGATRON_LM_PATH
+
+# --- Project naming ---
+export GUI_RESULT_DIR=${GUI_RESULT_DIR:-"${SCRIPT_DIR}/results"}
+export GUI_RESULT_DIR="${GUI_RESULT_DIR}/${GUI_PROJECT_NAME}"
+
+# --- Agent config (reuse Qwen3.5 agent) ---
+export GUI_AGENT_CLASS_PATH=${GUI_AGENT_CLASS_PATH:-"agents.qwen35_agent.Qwen35AgentLocal"}
+export GUI_COORDINATE_TYPE=${GUI_COORDINATE_TYPE:-"relative"}
+export MULTIMODAL_KEYS=${MULTIMODAL_KEYS:-'{"image":"images"}'}
+# Clean result dir
+if [[ -n "${GUI_RESULT_DIR}" && "${GUI_RESULT_DIR}" != "/" ]]; then
+  rm -rf "${GUI_RESULT_DIR}"
+fi
+mkdir -p "${GUI_RESULT_DIR}"
+
+CKPT_ARGS=(
+  --hf-checkpoint ${HF_CKPT}
+  --ref-load ${REF_LOAD}
+  --save "${SAVE_CKPT}"
+  --save-interval 20
+)
+
+if [[ "${ENABLE_RESUME_LOAD}" == "1" ]]; then
+  CKPT_ARGS+=(--load "${RESUME_LOAD}")
+fi
+
+# --- Rollout args ---
+# AgentNet offline + GRPO still needs multiple trajectories per prompt group.
+# With n-samples-per-prompt=1, group-normalized rewards collapse to 0 and
+# policy gradient becomes degenerate. Keep this aligned with other GUI-RL GRPO
+# scripts unless switching to a non-group-based estimator.
+N_SAMPLES_PER_PROMPT=${N_SAMPLES_PER_PROMPT:-8}
+if (( N_SAMPLES_PER_PROMPT < 2 )); then
+  echo "ERROR: gui_qwen35_4b_agentnet_rl.sh requires N_SAMPLES_PER_PROMPT >= 2 for GRPO."
+  echo "If you really want single-sample training, switch estimator or disable reward normalization explicitly."
+  exit 1
+fi
+# dynamic_history can expand one rollout into hundreds of step-wise samples.
+# Keep the train-side dynamic global batch size capped at the script's native
+# global batch size (= rollout_batch_size * n_samples_per_prompt // num_steps_per_rollout = 16).
+# The previous 32-sample cap fixed Ray OOM in data_preprocess, but still made
+# the first actor_train step numerically unstable (grad norm exploded to ~7.8e14
+# and then Megatron's bucket grad check observed NaN). Staying at 16 keeps the
+# per-step gradient scale aligned with the base script while avoiding the old
+# unbounded dynamic_gbs expansion.
+SLIME_MAX_DYNAMIC_GLOBAL_BATCH_SIZE=${SLIME_MAX_DYNAMIC_GLOBAL_BATCH_SIZE:-16}
+
+ROLLOUT_ARGS=(
+  --data-source-path gui_data_source.AgentNetDataSource
+  --reward-key score
+  --num-rollout 1000
+  --rollout-batch-size ${ROLLOUT_BATCH_SIZE}
+  --n-samples-per-prompt ${N_SAMPLES_PER_PROMPT}
+  --rollout-max-response-len 512
+  --rollout-temperature 1.0
+  --gui-max-steps 10
+  --gui-max-image-history-length 3
+  --num-steps-per-rollout 2
+)
+
+IN_FLIGHT_SAMPLES_ESTIMATE=$(( ROLLOUT_BATCH_SIZE * N_SAMPLES_PER_PROMPT ))
+echo "Configured rollout-batch-size x n-samples-per-prompt = ${IN_FLIGHT_SAMPLES_ESTIMATE}"
+
+EVAL_ARGS=(
+  --eval-temperature 0.0
+  --gui-eval-max-steps 10
+  --n-samples-per-eval-prompt 1
+)
+if [ -n "${GUI_EVAL_INTERVAL}" ]; then
+  EVAL_ARGS+=(--eval-interval "${GUI_EVAL_INTERVAL}")
+fi
+
+OPTIMIZER_ARGS=(
+  --optimizer adam
+  --lr 1e-6
+  --lr-decay-style constant
+  --weight-decay 0.1
+  --adam-beta1 0.9
+  --adam-beta2 0.95
+  --optimizer-cpu-offload
+  --overlap-cpu-optimizer-d2h-h2d
+  --use-precision-aware-optimizer
+)
+
+PERF_ARGS=(
+  --tensor-model-parallel-size 2
+  --sequence-parallel
+  --pipeline-model-parallel-size 1
+  # CP must be 1: VLM multimodal tensors are not sliced across CP ranks
+  --context-parallel-size 1
+  --expert-model-parallel-size 1
+  --expert-tensor-parallel-size 1
+  --recompute-granularity full
+  --recompute-method uniform
+  --recompute-num-layers 32
+  --megatron-to-hf-mode bridge
+  --use-dynamic-batch-size
+  --max-tokens-per-gpu 1024
+)
+
+GRPO_ARGS=(
+  --advantage-estimator grpo
+  # AgentNet offline reward is task-level static metadata, not an online
+  # rollout-dependent preference signal. Samples duplicated from the same task
+  # therefore share the same scalar reward, so group reward normalization would
+  # collapse the whole group to zero advantage.
+  --disable-rewards-normalization
+  --dynamic_history
+  --use-kl-loss
+  --kl-loss-type low_var_kl
+  --kl-loss-coef 0.01
+)
+
+SGLANG_ARGS=(
+  --rollout-num-gpus-per-engine ${ROLLOUT_NUM_GPUS_PER_ENGINE}
+  --sglang-mem-fraction-static 0.85
+)
+
+# Offline generate: no env pool server needed
+CUSTOM_ARGS=(
+  --custom-generate-function-path generate_with_agentnet.generate
+  --custom-rm-path generate_with_agentnet.reward_func
+)
+
+WANDB_ARGS=()
+
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+HAS_NVLINK=$( [ "$NVLINK_COUNT" -gt 0 ] && echo 1 || echo 0 )
+echo "HAS_NVLINK: $HAS_NVLINK"
+
+export PYTORCH_ALLOC_CONF=expandable_segments:True,max_split_size_mb:2048
+
+ray start --head --node-ip-address 127.0.0.1 --num-gpus ${NUM_GPUS} --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"${OFFICIAL_MBRIDGE_SRC}:${MEGATRON_LM_PATH}:${SCRIPT_DIR}:${SLIME_DIR}\",
+    \"PYTHONUNBUFFERED\": \"${PYTHONUNBUFFERED}\",
+    \"PYTHONFAULTHANDLER\": \"${PYTHONFAULTHANDLER}\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"NCCL_NVLS_ENABLE\": \"${HAS_NVLINK}\",
+    \"PYTORCH_ALLOC_CONF\": \"${PYTORCH_ALLOC_CONF}\",
+    \"PATH\": \"${PATH}\",
+    \"LD_LIBRARY_PATH\": \"${LD_LIBRARY_PATH:-}\",
+    \"OFFICIAL_MBRIDGE_ROOT\": \"${OFFICIAL_MBRIDGE_ROOT}\",
+    \"OFFICIAL_MBRIDGE_SRC\": \"${OFFICIAL_MBRIDGE_SRC}\",
+    \"MEGATRON_LM_PATH\": \"${MEGATRON_LM_PATH}\",
+    \"HF_CKPT\": \"${HF_CKPT}\",
+    \"SLIME_DEBUG_QWEN35_EXPORT\": \"${SLIME_DEBUG_QWEN35_EXPORT:-0}\",
+    \"SLIME_QWEN35_DISABLE_LINEAR_FC1_RECHUNK\": \"${SLIME_QWEN35_DISABLE_LINEAR_FC1_RECHUNK:-1}\",
+    \"SLIME_QWEN35_DEBUG_EMPTY_TRAIN_TENSORS\": \"${SLIME_QWEN35_DEBUG_EMPTY_TRAIN_TENSORS:-1}\",
+    \"SLIME_QWEN35_DEBUG_TRAIN_ANOMALY\": \"${SLIME_QWEN35_DEBUG_TRAIN_ANOMALY:-0}\",
+    \"SLIME_QWEN35_DEBUG_LOSS_METRICS\": \"${SLIME_QWEN35_DEBUG_LOSS_METRICS:-0}\",
+    \"SLIME_MAX_DYNAMIC_GLOBAL_BATCH_SIZE\": \"${SLIME_MAX_DYNAMIC_GLOBAL_BATCH_SIZE}\",
+    \"AGENTNET_JSONL_PATH\": \"${AGENTNET_JSONL_PATH}\",
+    \"AGENTNET_IMAGE_DIR\": \"${AGENTNET_IMAGE_DIR}\",
+    \"GUI_AGENT_CLASS_PATH\": \"${GUI_AGENT_CLASS_PATH}\",
+    \"GUI_COORDINATE_TYPE\": \"${GUI_COORDINATE_TYPE}\",
+    \"GUI_RESULT_DIR\": \"${GUI_RESULT_DIR}\"
+  }
+}"
+
+echo "===== RUNTIME_ENV_JSON ====="
+echo "${RUNTIME_ENV_JSON}" | python3 -m json.tool
+
+RAY_JOB_SUBMISSION_ID=${RAY_JOB_SUBMISSION_ID:-"gui_qwen35_agentnet_$(date +%Y%m%d_%H%M%S)"}
+
+ray job submit --address="http://127.0.0.1:8265" \
+  --submission-id "${RAY_JOB_SUBMISSION_ID}" \
+  --no-wait \
+  --runtime-env-json="${RUNTIME_ENV_JSON}" \
+  -- python3 -u "${SLIME_DIR}/train.py" \
+  --actor-num-nodes 1 \
+  --actor-num-gpus-per-node ${ACTOR_GPUS} \
+  --rollout-num-gpus ${ROLLOUT_GPUS} \
+  --multimodal-keys "${MULTIMODAL_KEYS}" \
+  ${MODEL_ARGS[@]} \
+  ${CKPT_ARGS[@]} \
+  ${ROLLOUT_ARGS[@]} \
+  ${EVAL_ARGS[@]} \
+  ${PERF_ARGS[@]} \
+  ${OPTIMIZER_ARGS[@]} \
+  ${GRPO_ARGS[@]} \
+  ${SGLANG_ARGS[@]} \
+  ${WANDB_ARGS[@]} \
+  ${CUSTOM_ARGS[@]}
+
+echo "Following live Ray logs for ${RAY_JOB_SUBMISSION_ID}"
+set +e
+ray job logs --address="http://127.0.0.1:8265" "${RAY_JOB_SUBMISSION_ID}" -f --log-style=record
+RAY_LOG_EXIT=$?
+RAY_STATUS_OUTPUT=$(ray job status --address="http://127.0.0.1:8265" "${RAY_JOB_SUBMISSION_ID}" --log-style=record 2>&1)
+echo "${RAY_STATUS_OUTPUT}"
+set -e
+
+if [[ "${RAY_STATUS_OUTPUT}" == *"SUCCEEDED"* ]]; then
+  exit 0
+fi
+
+echo "Ray job failed (submission id: ${RAY_JOB_SUBMISSION_ID}, logs exit: ${RAY_LOG_EXIT})"
+exit 1

--- a/gui-rl/gui_qwen35_4b_prm_rl.sh
+++ b/gui-rl/gui_qwen35_4b_prm_rl.sh
@@ -1,0 +1,389 @@
+#!/bin/bash
+
+pkill -9 sglang || true
+sleep 3
+ray stop --force || true
+pkill -9 ray || true
+pkill -9 python || true
+sleep 3
+pkill -9 ray || true
+pkill -9 python || true
+
+set -ex
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+SLIME_DIR="$(cd -- "${SCRIPT_DIR}/../slime" &>/dev/null && pwd)"
+
+OFFICIAL_MBRIDGE_ROOT=${OFFICIAL_MBRIDGE_ROOT:-}
+OFFICIAL_MBRIDGE_SRC="${OFFICIAL_MBRIDGE_ROOT}/src"
+MEGATRON_LM_PATH=${MEGATRON_LM_PATH:-"${OFFICIAL_MBRIDGE_ROOT}/3rdparty/Megatron-LM"}
+
+MODEL_ARGS_ROTARY_BASE=10000000 source "${SLIME_DIR}/scripts/models/qwen3.5-4B-VL.sh"
+
+export PYTHONUNBUFFERED=1
+export PYTHONFAULTHANDLER=1
+
+NVIDIA_BIN_DIR=${NVIDIA_BIN_DIR:-/usr/local/nvidia/bin}
+NVIDIA_LIB_DIR=${NVIDIA_LIB_DIR:-/usr/local/nvidia/lib64}
+if [[ -d "${NVIDIA_BIN_DIR}" ]]; then
+  export PATH="${NVIDIA_BIN_DIR}:${PATH}"
+fi
+if [[ -d "${NVIDIA_LIB_DIR}" ]]; then
+  export LD_LIBRARY_PATH="${NVIDIA_LIB_DIR}:${LD_LIBRARY_PATH:-}"
+fi
+
+export RAY_health_check_failure_threshold=${RAY_health_check_failure_threshold:-20}
+export RAY_health_check_period_ms=${RAY_health_check_period_ms:-5000}
+export RAY_health_check_timeout_ms=${RAY_health_check_timeout_ms:-30000}
+export RAY_num_heartbeats_timeout=${RAY_num_heartbeats_timeout:-60}
+
+NUM_GPUS=${NUM_GPUS:-8}
+ACTOR_GPUS=${ACTOR_GPUS:-4}
+ROLLOUT_GPUS=${ROLLOUT_GPUS:-3}
+PRM_GPUS=${PRM_GPUS:-1}
+ROLLOUT_NUM_GPUS_PER_ENGINE=${ROLLOUT_NUM_GPUS_PER_ENGINE:-1}
+PRM_GPUS_PER_ENGINE=${PRM_GPUS_PER_ENGINE:-1}
+PRM_ENABLE=${PRM_ENABLE:-1}
+
+if (( ACTOR_GPUS + ROLLOUT_GPUS > NUM_GPUS )); then
+  echo "ACTOR_GPUS + ROLLOUT_GPUS must be <= NUM_GPUS"
+  exit 1
+fi
+if [[ "${PRM_ENABLE}" == "1" ]]; then
+  TOTAL_REQ=$((ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS))
+  if (( TOTAL_REQ != NUM_GPUS )); then
+    echo "ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS must equal NUM_GPUS when PRM is enabled"
+    exit 1
+  fi
+fi
+
+export GUI_ENV_SERVER_HOST=${GUI_ENV_SERVER_HOST:-127.0.0.1}
+export GUI_ENV_SERVER_PORT=${GUI_ENV_SERVER_PORT:-18080}
+export GUI_ENV_SERVER_URL=${GUI_ENV_SERVER_URL:-"http://${GUI_ENV_SERVER_HOST}:${GUI_ENV_SERVER_PORT}"}
+export GUI_ENV_SERVER_MAX_ENVS=${GUI_ENV_SERVER_MAX_ENVS:-64}
+export GUI_PREWARM_CONCURRENCY=${GUI_PREWARM_CONCURRENCY:-64}
+export GUI_POOL_MAX_ENVS=${GUI_POOL_MAX_ENVS:-${GUI_ENV_SERVER_MAX_ENVS}}
+export GUI_PREWARM_ENVS=${GUI_PREWARM_ENVS:-${GUI_POOL_MAX_ENVS}}
+export GUI_FORCE_PREWARM_ALL=${GUI_FORCE_PREWARM_ALL:-1}
+if [[ "${GUI_FORCE_PREWARM_ALL}" == "1" ]]; then
+  export GUI_PREWARM_ENVS=${GUI_POOL_MAX_ENVS}
+fi
+export GUI_TRAJECTORY_CONCURRENCY=${GUI_TRAJECTORY_CONCURRENCY:-${GUI_POOL_MAX_ENVS}}
+export GUI_POOL_IDLE_TTL_SECONDS=${GUI_POOL_IDLE_TTL_SECONDS:-600}
+export GUI_PROVIDER_NAME=${GUI_PROVIDER_NAME:-volcengine}
+export GUI_REGION=${GUI_REGION:-cn-beijing}
+export GUI_PATH_TO_VM=${GUI_PATH_TO_VM:-""}
+export GUI_ACTION_SPACE=${GUI_ACTION_SPACE:-pyautogui}
+export GUI_OBSERVATION_TYPE=${GUI_OBSERVATION_TYPE:-screenshot}
+export GUI_COORDINATE_TYPE=${GUI_COORDINATE_TYPE:-relative}
+export GUI_AGENT_CLASS_PATH=${GUI_AGENT_CLASS_PATH:-agents.qwen35_agent.Qwen35AgentLocal}
+export GUI_REWARD_AGENT_CLASS_PATH=${GUI_REWARD_AGENT_CLASS_PATH:-agents.qwen3vl_reward_agent.Qwen3VLRewardAgent}
+export GUI_REUSE_VM_ON_RESET=${GUI_REUSE_VM_ON_RESET:-0}
+export GUI_RESET_ON_CLOSE=${GUI_RESET_ON_CLOSE:-1}
+export GUI_CLIENT_PASSWORD=${GUI_CLIENT_PASSWORD:-WWbbb8b7b6314}
+export GUI_SCREEN_WIDTH=${GUI_SCREEN_WIDTH:-1920}
+export GUI_SCREEN_HEIGHT=${GUI_SCREEN_HEIGHT:-1080}
+
+WANDB_PROJECT=${WANDB_PROJECT:-slime_gui}
+GUI_PROJECT_NAME=${GUI_PROJECT_NAME:-slime_gui_qwen35_4b_prm_rl}
+export OSWORLD_PROJECT="${GUI_PROJECT_NAME}"
+export GUI_RESULT_DIR=${GUI_RESULT_DIR:-"${SCRIPT_DIR}/results"}
+export GUI_RESULT_DIR="${GUI_RESULT_DIR}/${GUI_PROJECT_NAME}"
+export GUI_TEST_CONFIG_BASE_DIR=${GUI_TEST_CONFIG_BASE_DIR:-"${SCRIPT_DIR}/evaluation_examples"}
+export GUI_TRAIN_META_PATH=${GUI_TRAIN_META_PATH:-"${GUI_TEST_CONFIG_BASE_DIR}/train_nochrome.json"}
+export GUI_EVAL_META_PATH=${GUI_EVAL_META_PATH:-"${GUI_TEST_CONFIG_BASE_DIR}/test_nochrome.json"}
+MULTIMODAL_KEYS=${MULTIMODAL_KEYS:-'{"image":"images"}'}
+
+if [[ -n "${GUI_RESULT_DIR}" && "${GUI_RESULT_DIR}" != "/" ]]; then
+  rm -rf "${GUI_RESULT_DIR}"
+fi
+mkdir -p "${GUI_RESULT_DIR}"
+
+export VOLCENGINE_REGION=${VOLCENGINE_REGION:-cn-beijing}
+export VOLCENGINE_IMAGE_ID=${VOLCENGINE_IMAGE_ID:-image-ye7p6rwcel9q7e1x1evg}
+export VOLCENGINE_SUBNET_ID=${VOLCENGINE_SUBNET_ID:-subnet-mjddx72qnklc5smt1b752ytw}
+export VOLCENGINE_SECURITY_GROUP_ID=${VOLCENGINE_SECURITY_GROUP_ID:-sg-3hirj05a13v9c3nkipjb1mhm5}
+export VOLCENGINE_ZONE_ID=${VOLCENGINE_ZONE_ID:-cn-beijing-a}
+export VOLCENGINE_DEFAULT_PASSWORD=${VOLCENGINE_DEFAULT_PASSWORD:-WWbbb180314}
+export VOLCENGINE_RUNINST_MIN_INTERVAL=${VOLCENGINE_RUNINST_MIN_INTERVAL:-0.1}
+export VOLCENGINE_DELINST_MIN_INTERVAL=${VOLCENGINE_DELINST_MIN_INTERVAL:-0.1}
+export VOLCENGINE_INSTANCE_TYPE=${VOLCENGINE_INSTANCE_TYPE:-"ecs.e-c1m2.large,ecs.e-c1m4.large,ecs.e-c1m8.large,ecs.e-c1m1.large,ecs.c3al.large,ecs.c3a.large,ecs.c3il.large,ecs.g3il.large,ecs.r3il.large,ecs.c3a.large,ecs.g3a.large,ecs.r3a.large,ecs.c3i.large,ecs.g3i.large,ecs.r3i.large,ecs.g3al.large,ecs.r3al.large,ecs.r1ie.large,ecs.g1ie.large,ecs.c1ie.large,ecs.g3ine.large"}
+export download_proxy=${download_proxy:-}
+
+if [[ -z "${OFFICIAL_MBRIDGE_ROOT}" ]]; then
+  echo "Set OFFICIAL_MBRIDGE_ROOT to your Megatron-Bridge-qwen35 checkout"
+  exit 1
+fi
+if [[ ! -d "${OFFICIAL_MBRIDGE_SRC}" ]]; then
+  echo "OFFICIAL_MBRIDGE_SRC does not exist: ${OFFICIAL_MBRIDGE_SRC}"
+  exit 1
+fi
+if [[ ! -d "${MEGATRON_LM_PATH}" ]]; then
+  echo "MEGATRON_LM_PATH does not exist: ${MEGATRON_LM_PATH}"
+  exit 1
+fi
+
+HF_CKPT=${HF_CKPT:-}
+if [[ -z "${HF_CKPT}" ]]; then
+  echo "Set HF_CKPT to your Qwen3.5-4B checkpoint path"
+  exit 1
+fi
+if [[ ! -e "${HF_CKPT}" ]]; then
+  echo "HF_CKPT does not exist: ${HF_CKPT}"
+  exit 1
+fi
+REF_LOAD=${REF_LOAD:-${HF_CKPT}}
+PRM_MODEL_PATH=${PRM_MODEL_PATH:-${HF_CKPT}}
+
+CKPT_ARGS=(
+  --hf-checkpoint "${HF_CKPT}"
+  --ref-load "${REF_LOAD}"
+  --save "${SAVE_CKPT:-${SCRIPT_DIR}/../ckpt/gui-qwen35-4b-prm-rl}"
+  --save-interval 20
+)
+
+ENABLE_RESUME_LOAD=${ENABLE_RESUME_LOAD:-0}
+RESUME_LOAD=${RESUME_LOAD:-"${SCRIPT_DIR}/../ckpt/gui-qwen35-4b-prm-rl"}
+if [[ "${ENABLE_RESUME_LOAD}" == "1" ]]; then
+  CKPT_ARGS+=(--load "${RESUME_LOAD}")
+fi
+
+ROLLOUT_BATCH_SIZE=${ROLLOUT_BATCH_SIZE:-8}
+N_SAMPLES_PER_PROMPT=${N_SAMPLES_PER_PROMPT:-8}
+
+ROLLOUT_ARGS=(
+  --data-source-path gui_data_source.GuiMetaDataSource
+  --reward-key score
+  --num-rollout 1000
+  --rollout-batch-size "${ROLLOUT_BATCH_SIZE}"
+  --n-samples-per-prompt "${N_SAMPLES_PER_PROMPT}"
+  --rollout-max-response-len 1024
+  --rollout-temperature 1.0
+  --gui-max-steps 30
+  --gui-wait-after-reset 60
+  --gui-sleep-after-execution 0.5
+  --gui-max-image-history-length 3
+  --gui-max-reward-image-history-length 1
+  --num-steps-per-rollout 2
+)
+
+EVAL_ARGS=(
+  --eval-temperature 0.0
+  --gui-eval-max-steps 30
+  --gui-eval-sleep-after-execution 5.0
+  --gui-eval-wait-after-reset 60
+  --n-samples-per-eval-prompt 1
+  --eval-interval 20
+  --eval-reward-key acc
+  --eval-function-path generate_with_gui.gui_generate_rollout
+)
+if [[ -n "${GUI_EVAL_INTERVAL:-}" ]]; then
+  EVAL_ARGS+=(--eval-interval "${GUI_EVAL_INTERVAL}")
+fi
+
+OPTIMIZER_ARGS=(
+  --optimizer adam
+  --lr 1e-6
+  --lr-decay-style constant
+  --weight-decay 0.1
+  --adam-beta1 0.9
+  --adam-beta2 0.95
+  --optimizer-cpu-offload
+  --overlap-cpu-optimizer-d2h-h2d
+  --use-precision-aware-optimizer
+)
+
+PERF_ARGS=(
+  --tensor-model-parallel-size 2
+  --sequence-parallel
+  --pipeline-model-parallel-size 1
+  --context-parallel-size 1
+  --expert-model-parallel-size 1
+  --expert-tensor-parallel-size 1
+  --recompute-granularity full
+  --recompute-method uniform
+  --recompute-num-layers 32
+  --megatron-to-hf-mode bridge
+  --use-dynamic-batch-size
+  --max-tokens-per-gpu 1024
+)
+
+GRPO_ARGS=(
+  --advantage-estimator step_wise
+  --dynamic_history
+  --use-kl-loss
+  --kl-loss-coef 0.01
+  --kl-loss-type k3
+)
+
+SGLANG_ARGS=(
+  --rollout-num-gpus-per-engine "${ROLLOUT_NUM_GPUS_PER_ENGINE}"
+  --sglang-mem-fraction-static 0.85
+)
+
+CUSTOM_ARGS=(
+  --custom-generate-function-path generate_with_gui.generate
+  --custom-rm-path generate_with_gui.reward_func
+)
+
+PRM_ARGS=(
+  --prm-m "${PRM_M:-1}"
+  --prm-num-gpus "${PRM_GPUS}"
+  --prm-num-gpus-per-engine "${PRM_GPUS_PER_ENGINE}"
+  --prm-step-coef "${PRM_STEP_COEF:-1.0}"
+  --prm-temperature "${PRM_TEMPERATURE:-0.6}"
+  --prm-max-new-tokens "${PRM_MAX_NEW_TOKENS:-4096}"
+)
+if [[ "${PRM_ENABLE}" == "1" ]]; then
+  PRM_ARGS+=(--prm-enable)
+  PRM_ARGS+=(--prm-model-path "${PRM_MODEL_PATH}")
+fi
+
+WANDB_KEY_VALUE=${WANDB_KEY:-${WANDB_API_KEY:-}}
+if [[ -n "${WANDB_KEY_VALUE}" ]]; then
+  WANDB_ARGS=(
+    --use-wandb
+    --wandb-project "${WANDB_PROJECT}"
+    --wandb-group qwen35-4b-prm-rl
+    --wandb-key "${WANDB_KEY_VALUE}"
+  )
+else
+  WANDB_ARGS=()
+fi
+
+mkdir -p logs
+ENV_SERVER_LOG=${ENV_SERVER_LOG:-"./logs/gui_env_pool_server_qwen35_4b_prm.log"}
+PYTHONPATH="${SLIME_DIR}:${SCRIPT_DIR}:${PYTHONPATH}" \
+  python3 -m env_pool_server \
+  --host "${GUI_ENV_SERVER_HOST}" \
+  --port "${GUI_ENV_SERVER_PORT}" \
+  --max-envs "${GUI_POOL_MAX_ENVS}" \
+  --prewarm-envs "${GUI_PREWARM_ENVS}" \
+  --prewarm-concurrency "${GUI_PREWARM_CONCURRENCY}" \
+  --idle-ttl-seconds "${GUI_POOL_IDLE_TTL_SECONDS}" \
+  --provider-name "${GUI_PROVIDER_NAME}" \
+  --region "${GUI_REGION}" \
+  --action-space "${GUI_ACTION_SPACE}" \
+  --observation-type "${GUI_OBSERVATION_TYPE}" \
+  --reset-on-close "${GUI_RESET_ON_CLOSE}" \
+  --client-password "${GUI_CLIENT_PASSWORD}" \
+  --screen-width "${GUI_SCREEN_WIDTH}" \
+  --screen-height "${GUI_SCREEN_HEIGHT}" \
+  > "${ENV_SERVER_LOG}" 2>&1 &
+GUI_ENV_SERVER_PID=$!
+
+cleanup() {
+  set +e
+  if [[ -n "${GUI_ENV_SERVER_PID}" ]] && kill -0 "${GUI_ENV_SERVER_PID}" 2>/dev/null; then
+    kill "${GUI_ENV_SERVER_PID}" || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+for i in {1..60}; do
+  if curl -fsS "${GUI_ENV_SERVER_URL}/healthz" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+
+if (( GUI_PREWARM_ENVS > 0 )); then
+  for i in {1..600}; do
+    if python3 - "${GUI_ENV_SERVER_URL}" "${GUI_PREWARM_ENVS}" <<'PY'
+import json
+import sys
+import urllib.request
+status_url = sys.argv[1].rstrip("/") + "/status"
+target = int(sys.argv[2])
+with urllib.request.urlopen(status_url, timeout=5) as resp:
+    data = json.loads(resp.read().decode("utf-8"))
+pool = data.get("pool", {})
+total_envs = int(pool.get("total_envs", 0))
+ok = bool(data.get("ok", False))
+raise SystemExit(0 if ok and total_envs >= target else 1)
+PY
+    then
+      break
+    fi
+    sleep 2
+  done
+fi
+
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+HAS_NVLINK=0
+if [[ "${NVLINK_COUNT}" -gt 0 ]]; then
+  HAS_NVLINK=1
+fi
+
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True,max_split_size_mb:2048
+
+ray start --head --node-ip-address 127.0.0.1 --num-gpus "${NUM_GPUS}" --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"${OFFICIAL_MBRIDGE_SRC}:${MEGATRON_LM_PATH}:${SCRIPT_DIR}:${SLIME_DIR}\",
+    \"PYTHONUNBUFFERED\": \"${PYTHONUNBUFFERED}\",
+    \"PYTHONFAULTHANDLER\": \"${PYTHONFAULTHANDLER}\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"NCCL_NVLS_ENABLE\": \"${HAS_NVLINK}\",
+    \"PYTORCH_CUDA_ALLOC_CONF\": \"${PYTORCH_CUDA_ALLOC_CONF}\",
+    \"GUI_ENV_SERVER_URL\": \"${GUI_ENV_SERVER_URL}\",
+    \"GUI_POOL_MAX_ENVS\": \"${GUI_POOL_MAX_ENVS}\",
+    \"GUI_TRAJECTORY_CONCURRENCY\": \"${GUI_TRAJECTORY_CONCURRENCY}\",
+    \"GUI_RESULT_DIR\": \"${GUI_RESULT_DIR}\",
+    \"GUI_COORDINATE_TYPE\": \"${GUI_COORDINATE_TYPE}\",
+    \"GUI_ACTION_SPACE\": \"${GUI_ACTION_SPACE}\",
+    \"GUI_OBSERVATION_TYPE\": \"${GUI_OBSERVATION_TYPE}\",
+    \"GUI_REUSE_VM_ON_RESET\": \"${GUI_REUSE_VM_ON_RESET}\",
+    \"GUI_TEST_CONFIG_BASE_DIR\": \"${GUI_TEST_CONFIG_BASE_DIR}\",
+    \"GUI_TRAIN_META_PATH\": \"${GUI_TRAIN_META_PATH}\",
+    \"GUI_EVAL_META_PATH\": \"${GUI_EVAL_META_PATH}\",
+    \"OSWORLD_PROJECT\": \"${OSWORLD_PROJECT}\",
+    \"download_proxy\": \"${download_proxy}\",
+    \"OFFICIAL_MBRIDGE_ROOT\": \"${OFFICIAL_MBRIDGE_ROOT}\",
+    \"OFFICIAL_MBRIDGE_SRC\": \"${OFFICIAL_MBRIDGE_SRC}\",
+    \"MEGATRON_LM_PATH\": \"${MEGATRON_LM_PATH}\",
+    \"HF_CKPT\": \"${HF_CKPT}\",
+    \"GUI_AGENT_CLASS_PATH\": \"${GUI_AGENT_CLASS_PATH}\",
+    \"GUI_REWARD_AGENT_CLASS_PATH\": \"${GUI_REWARD_AGENT_CLASS_PATH}\",
+    \"SLIME_QWEN35_DISABLE_LINEAR_FC1_RECHUNK\": \"${SLIME_QWEN35_DISABLE_LINEAR_FC1_RECHUNK:-1}\"
+  }
+}"
+
+TRAIN_ENTRY=${TRAIN_ENTRY:-"${SLIME_DIR}/train_async.py"}
+RAY_JOB_SUBMISSION_ID=${RAY_JOB_SUBMISSION_ID:-"gui_qwen35_4b_prm_rl_$(date +%Y%m%d_%H%M%S)"}
+
+ray job submit --address="http://127.0.0.1:8265" \
+  --submission-id "${RAY_JOB_SUBMISSION_ID}" \
+  --no-wait \
+  --runtime-env-json="${RUNTIME_ENV_JSON}" \
+  -- python3 -u "${TRAIN_ENTRY}" \
+  --actor-num-nodes 1 \
+  --actor-num-gpus-per-node "${ACTOR_GPUS}" \
+  --rollout-num-gpus "${ROLLOUT_GPUS}" \
+  --multimodal-keys "${MULTIMODAL_KEYS}" \
+  ${MODEL_ARGS[@]} \
+  ${CKPT_ARGS[@]} \
+  ${ROLLOUT_ARGS[@]} \
+  ${EVAL_ARGS[@]} \
+  ${PERF_ARGS[@]} \
+  ${OPTIMIZER_ARGS[@]} \
+  ${GRPO_ARGS[@]} \
+  ${SGLANG_ARGS[@]} \
+  ${WANDB_ARGS[@]} \
+  ${CUSTOM_ARGS[@]} \
+  ${PRM_ARGS[@]}
+
+set +e
+ray job logs --address="http://127.0.0.1:8265" "${RAY_JOB_SUBMISSION_ID}" -f --log-style=record
+RAY_LOG_EXIT=$?
+RAY_STATUS_OUTPUT=$(ray job status --address="http://127.0.0.1:8265" "${RAY_JOB_SUBMISSION_ID}" --log-style=record 2>&1)
+echo "${RAY_STATUS_OUTPUT}"
+set -e
+
+if [[ "${RAY_STATUS_OUTPUT}" == *"SUCCEEDED"* ]]; then
+  exit 0
+fi
+
+echo "Ray job failed (submission id: ${RAY_JOB_SUBMISSION_ID}, logs exit: ${RAY_LOG_EXIT})"
+exit 1

--- a/gui-rl/gui_qwen35_4b_rl.sh
+++ b/gui-rl/gui_qwen35_4b_rl.sh
@@ -1,0 +1,357 @@
+#!/bin/bash
+
+pkill -9 sglang || true
+sleep 3
+ray stop --force || true
+pkill -9 ray || true
+pkill -9 python || true
+sleep 3
+pkill -9 ray || true
+pkill -9 python || true
+
+set -ex
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+SLIME_DIR="$(cd -- "${SCRIPT_DIR}/../slime" &>/dev/null && pwd)"
+
+OFFICIAL_MBRIDGE_ROOT=${OFFICIAL_MBRIDGE_ROOT:-}
+OFFICIAL_MBRIDGE_SRC="${OFFICIAL_MBRIDGE_ROOT}/src"
+MEGATRON_LM_PATH=${MEGATRON_LM_PATH:-"${OFFICIAL_MBRIDGE_ROOT}/3rdparty/Megatron-LM"}
+
+MODEL_ARGS_ROTARY_BASE=10000000 source "${SLIME_DIR}/scripts/models/qwen3.5-4B-VL.sh"
+
+export PYTHONUNBUFFERED=1
+export PYTHONFAULTHANDLER=1
+
+NVIDIA_BIN_DIR=${NVIDIA_BIN_DIR:-/usr/local/nvidia/bin}
+NVIDIA_LIB_DIR=${NVIDIA_LIB_DIR:-/usr/local/nvidia/lib64}
+if [[ -d "${NVIDIA_BIN_DIR}" ]]; then
+  export PATH="${NVIDIA_BIN_DIR}:${PATH}"
+fi
+if [[ -d "${NVIDIA_LIB_DIR}" ]]; then
+  export LD_LIBRARY_PATH="${NVIDIA_LIB_DIR}:${LD_LIBRARY_PATH:-}"
+fi
+
+export RAY_health_check_failure_threshold=${RAY_health_check_failure_threshold:-20}
+export RAY_health_check_period_ms=${RAY_health_check_period_ms:-5000}
+export RAY_health_check_timeout_ms=${RAY_health_check_timeout_ms:-30000}
+export RAY_num_heartbeats_timeout=${RAY_num_heartbeats_timeout:-60}
+
+NUM_GPUS=${NUM_GPUS:-8}
+ACTOR_GPUS=${ACTOR_GPUS:-4}
+ROLLOUT_GPUS=${ROLLOUT_GPUS:-4}
+ROLLOUT_BATCH_SIZE=${ROLLOUT_BATCH_SIZE:-4}
+ROLLOUT_NUM_GPUS_PER_ENGINE=${ROLLOUT_NUM_GPUS_PER_ENGINE:-1}
+
+if (( ACTOR_GPUS + ROLLOUT_GPUS > NUM_GPUS )); then
+  echo "ACTOR_GPUS + ROLLOUT_GPUS must be <= NUM_GPUS"
+  exit 1
+fi
+
+export GUI_ENV_SERVER_HOST=${GUI_ENV_SERVER_HOST:-127.0.0.1}
+export GUI_ENV_SERVER_PORT=${GUI_ENV_SERVER_PORT:-18080}
+export GUI_ENV_SERVER_URL=${GUI_ENV_SERVER_URL:-"http://${GUI_ENV_SERVER_HOST}:${GUI_ENV_SERVER_PORT}"}
+export GUI_ENV_SERVER_MAX_ENVS=${GUI_ENV_SERVER_MAX_ENVS:-32}
+export GUI_PREWARM_CONCURRENCY=${GUI_PREWARM_CONCURRENCY:-32}
+export GUI_POOL_MAX_ENVS=${GUI_POOL_MAX_ENVS:-${GUI_ENV_SERVER_MAX_ENVS}}
+export GUI_PREWARM_ENVS=${GUI_PREWARM_ENVS:-${GUI_POOL_MAX_ENVS}}
+export GUI_FORCE_PREWARM_ALL=${GUI_FORCE_PREWARM_ALL:-1}
+if [[ "${GUI_FORCE_PREWARM_ALL}" == "1" ]]; then
+  export GUI_PREWARM_ENVS=${GUI_POOL_MAX_ENVS}
+fi
+export GUI_TRAJECTORY_CONCURRENCY=${GUI_TRAJECTORY_CONCURRENCY:-${GUI_POOL_MAX_ENVS}}
+export GUI_POOL_IDLE_TTL_SECONDS=${GUI_POOL_IDLE_TTL_SECONDS:-600}
+export GUI_PROVIDER_NAME=${GUI_PROVIDER_NAME:-volcengine}
+export GUI_REGION=${GUI_REGION:-cn-beijing}
+export GUI_PATH_TO_VM=${GUI_PATH_TO_VM:-""}
+export GUI_ACTION_SPACE=${GUI_ACTION_SPACE:-pyautogui}
+export GUI_OBSERVATION_TYPE=${GUI_OBSERVATION_TYPE:-screenshot}
+export GUI_COORDINATE_TYPE=${GUI_COORDINATE_TYPE:-relative}
+export GUI_AGENT_CLASS_PATH=${GUI_AGENT_CLASS_PATH:-agents.qwen35_agent.Qwen35AgentLocal}
+export GUI_REUSE_VM_ON_RESET=${GUI_REUSE_VM_ON_RESET:-0}
+export GUI_RESET_ON_CLOSE=${GUI_RESET_ON_CLOSE:-1}
+export GUI_CLIENT_PASSWORD=${GUI_CLIENT_PASSWORD:-WWbbb8b7b6314}
+export GUI_SCREEN_WIDTH=${GUI_SCREEN_WIDTH:-1920}
+export GUI_SCREEN_HEIGHT=${GUI_SCREEN_HEIGHT:-1080}
+
+WANDB_PROJECT=${WANDB_PROJECT:-slime_gui}
+GUI_PROJECT_NAME=${GUI_PROJECT_NAME:-slime_gui_qwen35_4b_rl}
+export OSWORLD_PROJECT="${GUI_PROJECT_NAME}"
+export GUI_RESULT_DIR=${GUI_RESULT_DIR:-"${SCRIPT_DIR}/results"}
+export GUI_RESULT_DIR="${GUI_RESULT_DIR}/${GUI_PROJECT_NAME}"
+export GUI_TEST_CONFIG_BASE_DIR=${GUI_TEST_CONFIG_BASE_DIR:-"${SCRIPT_DIR}/evaluation_examples"}
+export GUI_TRAIN_META_PATH=${GUI_TRAIN_META_PATH:-"${GUI_TEST_CONFIG_BASE_DIR}/train_nochrome.json"}
+export GUI_EVAL_META_PATH=${GUI_EVAL_META_PATH:-"${GUI_TEST_CONFIG_BASE_DIR}/test_multinode.json"}
+MULTIMODAL_KEYS=${MULTIMODAL_KEYS:-'{"image":"images"}'}
+
+if [[ -n "${GUI_RESULT_DIR}" && "${GUI_RESULT_DIR}" != "/" ]]; then
+  rm -rf "${GUI_RESULT_DIR}"
+fi
+mkdir -p "${GUI_RESULT_DIR}"
+
+export VOLCENGINE_REGION=${VOLCENGINE_REGION:-cn-beijing}
+export VOLCENGINE_IMAGE_ID=${VOLCENGINE_IMAGE_ID:-image-ye7p6rwcel9q7e1x1evg}
+export VOLCENGINE_SUBNET_ID=${VOLCENGINE_SUBNET_ID:-subnet-mjddx72qnklc5smt1b752ytw}
+export VOLCENGINE_SECURITY_GROUP_ID=${VOLCENGINE_SECURITY_GROUP_ID:-sg-3hirj05a13v9c3nkipjb1mhm5}
+export VOLCENGINE_ZONE_ID=${VOLCENGINE_ZONE_ID:-cn-beijing-a}
+export VOLCENGINE_DEFAULT_PASSWORD=${VOLCENGINE_DEFAULT_PASSWORD:-WWbbb180314}
+export VOLCENGINE_RUNINST_MIN_INTERVAL=${VOLCENGINE_RUNINST_MIN_INTERVAL:-0.1}
+export VOLCENGINE_DELINST_MIN_INTERVAL=${VOLCENGINE_DELINST_MIN_INTERVAL:-0.1}
+export VOLCENGINE_INSTANCE_TYPE=${VOLCENGINE_INSTANCE_TYPE:-"ecs.e-c1m2.large,ecs.e-c1m4.large,ecs.e-c1m8.large,ecs.e-c1m1.large,ecs.c3al.large,ecs.c3a.large,ecs.c3il.large,ecs.g3il.large,ecs.r3il.large,ecs.c3a.large,ecs.g3a.large,ecs.r3a.large,ecs.c3i.large,ecs.g3i.large,ecs.r3i.large,ecs.g3al.large,ecs.r3al.large,ecs.r1ie.large,ecs.g1ie.large,ecs.c1ie.large,ecs.g3ine.large"}
+export download_proxy=${download_proxy:-}
+
+if [[ -z "${OFFICIAL_MBRIDGE_ROOT}" ]]; then
+  echo "Set OFFICIAL_MBRIDGE_ROOT to your Megatron-Bridge-qwen35 checkout"
+  exit 1
+fi
+if [[ ! -d "${OFFICIAL_MBRIDGE_SRC}" ]]; then
+  echo "OFFICIAL_MBRIDGE_SRC does not exist: ${OFFICIAL_MBRIDGE_SRC}"
+  exit 1
+fi
+if [[ ! -d "${MEGATRON_LM_PATH}" ]]; then
+  echo "MEGATRON_LM_PATH does not exist: ${MEGATRON_LM_PATH}"
+  exit 1
+fi
+
+HF_CKPT=${HF_CKPT:-}
+if [[ -z "${HF_CKPT}" ]]; then
+  echo "Set HF_CKPT to your Qwen3.5-4B checkpoint path"
+  exit 1
+fi
+if [[ ! -e "${HF_CKPT}" ]]; then
+  echo "HF_CKPT does not exist: ${HF_CKPT}"
+  exit 1
+fi
+REF_LOAD=${REF_LOAD:-${HF_CKPT}}
+
+CKPT_ARGS=(
+  --hf-checkpoint "${HF_CKPT}"
+  --ref-load "${REF_LOAD}"
+  --save "${SAVE_CKPT:-${SCRIPT_DIR}/../ckpt/gui-qwen35-4b-rl}"
+  --save-interval 20
+)
+
+ENABLE_RESUME_LOAD=${ENABLE_RESUME_LOAD:-0}
+RESUME_LOAD=${RESUME_LOAD:-"${SCRIPT_DIR}/../ckpt/gui-qwen35-4b-rl"}
+if [[ "${ENABLE_RESUME_LOAD}" == "1" ]]; then
+  CKPT_ARGS+=(--load "${RESUME_LOAD}")
+fi
+
+N_SAMPLES_PER_PROMPT=${N_SAMPLES_PER_PROMPT:-8}
+
+ROLLOUT_ARGS=(
+  --data-source-path gui_data_source.GuiMetaDataSource
+  --reward-key score
+  --num-rollout 1000
+  --rollout-batch-size "${ROLLOUT_BATCH_SIZE}"
+  --n-samples-per-prompt "${N_SAMPLES_PER_PROMPT}"
+  --rollout-max-response-len 512
+  --rollout-temperature 1.0
+  --gui-max-steps 30
+  --gui-wait-after-reset 60
+  --gui-sleep-after-execution 0.0
+  --gui-max-image-history-length 3
+  --gui-max-reward-image-history-length 2
+  --num-steps-per-rollout 2
+)
+
+EVAL_ARGS=(
+  --eval-temperature 0.0
+  --gui-eval-max-steps 30
+  --gui-eval-sleep-after-execution 0.0
+  --gui-eval-wait-after-reset 60
+  --n-samples-per-eval-prompt 1
+)
+if [[ -n "${GUI_EVAL_INTERVAL:-}" ]]; then
+  EVAL_ARGS+=(--eval-interval "${GUI_EVAL_INTERVAL}")
+fi
+
+OPTIMIZER_ARGS=(
+  --optimizer adam
+  --lr 1e-6
+  --lr-decay-style constant
+  --weight-decay 0.1
+  --adam-beta1 0.9
+  --adam-beta2 0.95
+  --optimizer-cpu-offload
+  --overlap-cpu-optimizer-d2h-h2d
+  --use-precision-aware-optimizer
+)
+
+PERF_ARGS=(
+  --tensor-model-parallel-size 2
+  --sequence-parallel
+  --pipeline-model-parallel-size 1
+  --context-parallel-size 1
+  --expert-model-parallel-size 1
+  --expert-tensor-parallel-size 1
+  --recompute-granularity full
+  --recompute-method uniform
+  --recompute-num-layers 32
+  --megatron-to-hf-mode bridge
+  --use-dynamic-batch-size
+  --max-tokens-per-gpu 1024
+)
+
+GRPO_ARGS=(
+  --advantage-estimator grpo
+  --dynamic_history
+  --use-kl-loss
+  --kl-loss-coef 0.0
+)
+
+SGLANG_ARGS=(
+  --rollout-num-gpus-per-engine "${ROLLOUT_NUM_GPUS_PER_ENGINE}"
+  --sglang-mem-fraction-static 0.85
+)
+
+CUSTOM_ARGS=(
+  --custom-generate-function-path generate_with_gui.generate
+  --custom-rm-path generate_with_gui.reward_func
+)
+
+WANDB_KEY_VALUE=${WANDB_KEY:-${WANDB_API_KEY:-}}
+if [[ -n "${WANDB_KEY_VALUE}" ]]; then
+  WANDB_ARGS=(
+    --use-wandb
+    --wandb-project "${WANDB_PROJECT}"
+    --wandb-group qwen35-4b-rl
+    --wandb-key "${WANDB_KEY_VALUE}"
+  )
+else
+  WANDB_ARGS=()
+fi
+
+mkdir -p logs
+ENV_SERVER_LOG=${ENV_SERVER_LOG:-"./logs/gui_env_pool_server_qwen35_4b.log"}
+PYTHONPATH="${SLIME_DIR}:${SCRIPT_DIR}:${PYTHONPATH}" \
+  python3 -m env_pool_server \
+  --host "${GUI_ENV_SERVER_HOST}" \
+  --port "${GUI_ENV_SERVER_PORT}" \
+  --max-envs "${GUI_POOL_MAX_ENVS}" \
+  --prewarm-envs "${GUI_PREWARM_ENVS}" \
+  --prewarm-concurrency "${GUI_PREWARM_CONCURRENCY}" \
+  --idle-ttl-seconds "${GUI_POOL_IDLE_TTL_SECONDS}" \
+  --provider-name "${GUI_PROVIDER_NAME}" \
+  --region "${GUI_REGION}" \
+  --action-space "${GUI_ACTION_SPACE}" \
+  --observation-type "${GUI_OBSERVATION_TYPE}" \
+  --reset-on-close "${GUI_RESET_ON_CLOSE}" \
+  --client-password "${GUI_CLIENT_PASSWORD}" \
+  --screen-width "${GUI_SCREEN_WIDTH}" \
+  --screen-height "${GUI_SCREEN_HEIGHT}" \
+  > "${ENV_SERVER_LOG}" 2>&1 &
+GUI_ENV_SERVER_PID=$!
+
+cleanup() {
+  set +e
+  if [[ -n "${GUI_ENV_SERVER_PID}" ]] && kill -0 "${GUI_ENV_SERVER_PID}" 2>/dev/null; then
+    kill "${GUI_ENV_SERVER_PID}" || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+for i in {1..60}; do
+  if curl -fsS "${GUI_ENV_SERVER_URL}/healthz" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+
+if (( GUI_PREWARM_ENVS > 0 )); then
+  for i in {1..600}; do
+    if python3 - "${GUI_ENV_SERVER_URL}" "${GUI_PREWARM_ENVS}" <<'PY'
+import json
+import sys
+import urllib.request
+status_url = sys.argv[1].rstrip("/") + "/status"
+target = int(sys.argv[2])
+with urllib.request.urlopen(status_url, timeout=5) as resp:
+    data = json.loads(resp.read().decode("utf-8"))
+pool = data.get("pool", {})
+total_envs = int(pool.get("total_envs", 0))
+ok = bool(data.get("ok", False))
+raise SystemExit(0 if ok and total_envs >= target else 1)
+PY
+    then
+      break
+    fi
+    sleep 2
+  done
+fi
+
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+HAS_NVLINK=0
+if [[ "${NVLINK_COUNT}" -gt 0 ]]; then
+  HAS_NVLINK=1
+fi
+
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True,max_split_size_mb:2048
+
+ray start --head --node-ip-address 127.0.0.1 --num-gpus "${NUM_GPUS}" --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"${OFFICIAL_MBRIDGE_SRC}:${MEGATRON_LM_PATH}:${SCRIPT_DIR}:${SLIME_DIR}\",
+    \"PYTHONUNBUFFERED\": \"${PYTHONUNBUFFERED}\",
+    \"PYTHONFAULTHANDLER\": \"${PYTHONFAULTHANDLER}\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"NCCL_NVLS_ENABLE\": \"${HAS_NVLINK}\",
+    \"PYTORCH_CUDA_ALLOC_CONF\": \"${PYTORCH_CUDA_ALLOC_CONF}\",
+    \"GUI_ENV_SERVER_URL\": \"${GUI_ENV_SERVER_URL}\",
+    \"GUI_POOL_MAX_ENVS\": \"${GUI_POOL_MAX_ENVS}\",
+    \"GUI_TRAJECTORY_CONCURRENCY\": \"${GUI_TRAJECTORY_CONCURRENCY}\",
+    \"GUI_RESULT_DIR\": \"${GUI_RESULT_DIR}\",
+    \"GUI_COORDINATE_TYPE\": \"${GUI_COORDINATE_TYPE}\",
+    \"GUI_ACTION_SPACE\": \"${GUI_ACTION_SPACE}\",
+    \"GUI_OBSERVATION_TYPE\": \"${GUI_OBSERVATION_TYPE}\",
+    \"GUI_REUSE_VM_ON_RESET\": \"${GUI_REUSE_VM_ON_RESET}\",
+    \"GUI_TEST_CONFIG_BASE_DIR\": \"${GUI_TEST_CONFIG_BASE_DIR}\",
+    \"GUI_TRAIN_META_PATH\": \"${GUI_TRAIN_META_PATH}\",
+    \"GUI_EVAL_META_PATH\": \"${GUI_EVAL_META_PATH}\",
+    \"OSWORLD_PROJECT\": \"${OSWORLD_PROJECT}\",
+    \"download_proxy\": \"${download_proxy}\",
+    \"OFFICIAL_MBRIDGE_ROOT\": \"${OFFICIAL_MBRIDGE_ROOT}\",
+    \"OFFICIAL_MBRIDGE_SRC\": \"${OFFICIAL_MBRIDGE_SRC}\",
+    \"MEGATRON_LM_PATH\": \"${MEGATRON_LM_PATH}\",
+    \"HF_CKPT\": \"${HF_CKPT}\",
+    \"GUI_AGENT_CLASS_PATH\": \"${GUI_AGENT_CLASS_PATH}\",
+    \"SLIME_QWEN35_DISABLE_LINEAR_FC1_RECHUNK\": \"${SLIME_QWEN35_DISABLE_LINEAR_FC1_RECHUNK:-1}\"
+  }
+}"
+
+RAY_JOB_SUBMISSION_ID=${RAY_JOB_SUBMISSION_ID:-"gui_qwen35_4b_rl_$(date +%Y%m%d_%H%M%S)"}
+
+ray job submit --address="http://127.0.0.1:8265" \
+  --submission-id "${RAY_JOB_SUBMISSION_ID}" \
+  --no-wait \
+  --runtime-env-json="${RUNTIME_ENV_JSON}" \
+  -- python3 -u "${SLIME_DIR}/train.py" \
+  --actor-num-nodes 1 \
+  --actor-num-gpus-per-node "${ACTOR_GPUS}" \
+  --rollout-num-gpus "${ROLLOUT_GPUS}" \
+  --multimodal-keys "${MULTIMODAL_KEYS}" \
+  ${MODEL_ARGS[@]} \
+  ${CKPT_ARGS[@]} \
+  ${ROLLOUT_ARGS[@]} \
+  ${EVAL_ARGS[@]} \
+  ${PERF_ARGS[@]} \
+  ${OPTIMIZER_ARGS[@]} \
+  ${GRPO_ARGS[@]} \
+  ${SGLANG_ARGS[@]} \
+  ${WANDB_ARGS[@]} \
+  ${CUSTOM_ARGS[@]}
+
+set +e
+ray job logs --address="http://127.0.0.1:8265" "${RAY_JOB_SUBMISSION_ID}" -f --log-style=record
+RAY_LOG_EXIT=$?
+RAY_STATUS_OUTPUT=$(ray job status --address="http://127.0.0.1:8265" "${RAY_JOB_SUBMISSION_ID}" --log-style=record 2>&1)
+echo "${RAY_STATUS_OUTPUT}"
+set -e
+
+if [[ "${RAY_STATUS_OUTPUT}" == *"SUCCEEDED"* ]]; then
+  exit 0
+fi
+
+echo "Ray job failed (submission id: ${RAY_JOB_SUBMISSION_ID}, logs exit: ${RAY_LOG_EXIT})"
+exit 1

--- a/slime/scripts/models/qwen3.5-4B-VL.sh
+++ b/slime/scripts/models/qwen3.5-4B-VL.sh
@@ -1,0 +1,27 @@
+MODEL_ARGS=(
+   --spec "slime_plugins.models.qwen3_5" "get_qwen3_5_spec"
+
+   --disable-bias-linear
+   --qk-layernorm
+   --group-query-attention
+   --num-attention-heads 16
+   --num-query-groups 4
+   --kv-channels 256
+   --num-layers 32
+   --hidden-size 2560
+   --ffn-hidden-size 9216
+   # Dedicated to newer official Megatron-Core where gated delta attention is
+   # configured through the generic experimental attention variant flag.
+   --experimental-attention-variant gated_delta_net
+   --attention-output-gate
+
+   --normalization RMSNorm
+   --apply-layernorm-1p
+   --position-embedding-type rope
+   --norm-epsilon 1e-6
+   --rotary-percent 0.25
+   --swiglu
+   --vocab-size 248320
+
+   --rotary-base "${MODEL_ARGS_ROTARY_BASE:-10000000}"
+)

--- a/slime/slime/backends/megatron_utils/arguments.py
+++ b/slime/slime/backends/megatron_utils/arguments.py
@@ -1,7 +1,24 @@
 import logging
+import math
 
 from megatron.training.arguments import parse_args, validate_args
-from megatron.training.tokenizer.tokenizer import _vocab_size_with_padding
+
+try:
+    from megatron.training.tokenizer.tokenizer import _vocab_size_with_padding
+except ModuleNotFoundError:
+
+    def _vocab_size_with_padding(orig_vocab_size, args, logging_enabled=True):
+        """Fallback for newer Megatron-Core layouts without legacy tokenizer module."""
+        after = orig_vocab_size
+        multiple = args.make_vocab_size_divisible_by * args.tensor_model_parallel_size
+        after = int(math.ceil(after / multiple) * multiple)
+        if getattr(args, "rank", 0) == 0 and logging_enabled:
+            print(
+                f" > padded vocab (size: {orig_vocab_size}) with {after - orig_vocab_size} dummy tokens "
+                f"(new size: {after})",
+                flush=True,
+            )
+        return after
 
 __all__ = ["validate_args", "parse_args", "set_default_megatron_args"]
 
@@ -9,6 +26,15 @@ logger = logging.getLogger(__name__)
 
 
 def set_default_megatron_args(args):
+    # Newer Megatron-Core uses layernorm_epsilon as the argparse destination
+    # for --norm-epsilon. Keep the older alias for downstream code.
+    if not hasattr(args, "norm_epsilon") and hasattr(args, "layernorm_epsilon"):
+        args.norm_epsilon = args.layernorm_epsilon
+    # Newer Megatron-Core exposes use_gloo_process_groups while this repo still
+    # reads enable_gloo_process_groups in a few places.
+    if not hasattr(args, "enable_gloo_process_groups") and hasattr(args, "use_gloo_process_groups"):
+        args.enable_gloo_process_groups = args.use_gloo_process_groups
+
     # always use zero optimizer
     args.use_distributed_optimizer = True
     # TODO: maybe change this after megatron has good fp8 support

--- a/slime/slime/backends/megatron_utils/checkpoint.py
+++ b/slime/slime/backends/megatron_utils/checkpoint.py
@@ -10,6 +10,10 @@ from megatron.training.global_vars import get_args
 
 from slime.utils import megatron_bridge_utils
 
+
+def _should_log_qwen35_bridge_debug() -> bool:
+    return os.getenv("SLIME_DEBUG_QWEN35_BRIDGE", "").lower() in {"1", "true", "yes", "on"}
+
 try:
     # Here we patch out the `validate_non_overlapping_shards_metadata` in both functions
     # because it is really slow for large models with many shards.
@@ -128,15 +132,29 @@ def _is_megatron_checkpoint(path: str | Path) -> bool:
 
 def _load_checkpoint_hf(ddp_model, optimizer, args, load_path: str):
     assert args.megatron_to_hf_mode == "bridge", "Only bridge mode is supported for loading HF checkpoint"
-    from megatron.bridge import AutoBridge
-
-    import slime_plugins.megatron_bridge  # noqa: F401
 
     logger.info(f"Load checkpoint from HuggingFace model into Megatron (path={load_path})")
 
     with megatron_bridge_utils.patch_megatron_model(ddp_model):
-        bridge = AutoBridge.from_hf_pretrained(args.hf_checkpoint, trust_remote_code=True)
-        bridge.load_hf_weights(ddp_model)
+        bridge, hf_pretrained, is_local_bridge = megatron_bridge_utils.build_bridge_for_hf_checkpoint(
+            args.hf_checkpoint,
+            load_weights=True,
+        )
+        if _should_log_qwen35_bridge_debug():
+            logger.info(
+                "Qwen35 bridge debug checkpoint: bridge=%s provider_mode=%s is_local_bridge=%s",
+                f"{type(bridge).__module__}.{type(bridge).__name__}",
+                "load_weights_hf_to_megatron" if is_local_bridge else "load_hf_weights",
+                is_local_bridge,
+        )
+        if is_local_bridge:
+            dump_path = megatron_bridge_utils.maybe_dump_bridge_runtime_layout(bridge, ddp_model)
+            if dump_path:
+                logger.info("Qwen35 bridge debug checkpoint: dumped runtime layout to %s", dump_path)
+        if is_local_bridge:
+            bridge.load_weights_hf_to_megatron(hf_pretrained, ddp_model)
+        else:
+            bridge.load_hf_weights(ddp_model)
 
     # Copied from Megatron-core :: load_checkpoint (with simplifications)
     if (args.fp16 or args.bf16) and optimizer is not None:

--- a/slime/slime/backends/megatron_utils/megatron_to_hf/qwen3_5.py
+++ b/slime/slime/backends/megatron_utils/megatron_to_hf/qwen3_5.py
@@ -1,11 +1,82 @@
 import re
-
 import torch
+
+
+_LINEAR_ATTN_DIRECT_TO_HF = {
+    "input_layernorm.weight": "input_layernorm.weight",
+    "A_log": "linear_attn.A_log",
+    "conv1d.weight": "linear_attn.conv1d.weight",
+    "dt_bias": "linear_attn.dt_bias",
+    "in_proj_a.weight": "linear_attn.in_proj_a.weight",
+    "in_proj_b.weight": "linear_attn.in_proj_b.weight",
+    "in_proj_qkv.weight": "linear_attn.in_proj_qkv.weight",
+    "in_proj_z.weight": "linear_attn.in_proj_z.weight",
+    "norm.weight": "linear_attn.norm.weight",
+    "out_norm.weight": "linear_attn.norm.weight",
+    "out_proj.weight": "linear_attn.out_proj.weight",
+}
+
+
+_VISION_DIRECT_TO_HF = {
+    "patch_embed.proj.weight": "model.visual.patch_embed.proj.weight",
+    "patch_embed.proj.bias": "model.visual.patch_embed.proj.bias",
+    "pos_embed.weight": "model.visual.pos_embed.weight",
+    "merger.linear_fc1.weight": "model.visual.merger.linear_fc1.weight",
+    "merger.linear_fc1.bias": "model.visual.merger.linear_fc1.bias",
+    "merger.linear_fc2.weight": "model.visual.merger.linear_fc2.weight",
+    "merger.linear_fc2.bias": "model.visual.merger.linear_fc2.bias",
+    "merger.norm.weight": "model.visual.merger.norm.weight",
+    "merger.norm.bias": "model.visual.merger.norm.bias",
+    "merger.patch_norm.weight": "model.visual.merger.norm.weight",
+    "merger.patch_norm.bias": "model.visual.merger.norm.bias",
+}
+
+
+def _convert_vision_model_to_hf(name, param):
+    vision_name = name[len("module.module.vision_model.") :]
+    if vision_name in _VISION_DIRECT_TO_HF:
+        return [(_VISION_DIRECT_TO_HF[vision_name], param)]
+
+    decoder_layers_pattern = r"decoder\.layers\.(\d+)\.(.+)"
+    match = re.match(decoder_layers_pattern, vision_name)
+    if match:
+        layer_idx, rest = match.groups()
+        base = f"model.visual.blocks.{layer_idx}"
+
+        if rest == "self_attention.linear_proj.weight":
+            return [(f"{base}.attn.proj.weight", param)]
+        if rest == "self_attention.linear_proj.bias":
+            return [(f"{base}.attn.proj.bias", param)]
+        if rest == "self_attention.linear_qkv.weight":
+            return [(f"{base}.attn.qkv.weight", param)]
+        if rest == "self_attention.linear_qkv.bias":
+            return [(f"{base}.attn.qkv.bias", param)]
+        if rest in ("input_layernorm.weight", "self_attention.linear_qkv.layer_norm_weight"):
+            return [(f"{base}.norm1.weight", param)]
+        if rest in ("input_layernorm.bias", "self_attention.linear_qkv.layer_norm_bias"):
+            return [(f"{base}.norm1.bias", param)]
+        if rest == "mlp.linear_fc1.weight":
+            return [(f"{base}.mlp.linear_fc1.weight", param)]
+        if rest == "mlp.linear_fc1.bias":
+            return [(f"{base}.mlp.linear_fc1.bias", param)]
+        if rest == "mlp.linear_fc2.weight":
+            return [(f"{base}.mlp.linear_fc2.weight", param)]
+        if rest == "mlp.linear_fc2.bias":
+            return [(f"{base}.mlp.linear_fc2.bias", param)]
+        if rest in ("pre_mlp_layernorm.weight", "mlp.linear_fc1.layer_norm_weight"):
+            return [(f"{base}.norm2.weight", param)]
+        if rest in ("pre_mlp_layernorm.bias", "mlp.linear_fc1.layer_norm_bias"):
+            return [(f"{base}.norm2.bias", param)]
+
+    if vision_name.startswith("blocks.") or vision_name.startswith("patch_embed.") or vision_name.startswith("merger."):
+        return [(f"model.visual.{vision_name}", param)]
+
+    raise ValueError(f"Unknown vision parameter name: {name}")
 
 
 def _convert_mtp_layer(args, name, param, layer_idx):
     if "enorm.weight" in name:
-        return [("mtp.pre_fc_norm_embedding.weight", param)]
+        return[("mtp.pre_fc_norm_embedding.weight", param)]
     if "hnorm.weight" in name:
         return [("mtp.pre_fc_norm_hidden.weight", param)]
     if "final_layernorm.weight" in name:
@@ -15,26 +86,77 @@ def _convert_mtp_layer(args, name, param, layer_idx):
             raise ValueError(f"eh_proj weight expects 2D tensor, got {param.shape}")
         first_half, second_half = param.chunk(2, dim=1)
         new_param = torch.cat([second_half, first_half], dim=1)
-        return [("mtp.fc.weight", new_param)]
+        return[("mtp.fc.weight", new_param)]
 
-    if "transformer_layer" in name:
-        proxy_name = name.replace(f"mtp.layers.{layer_idx}.transformer_layer", f"decoder.layers.{layer_idx}")
-        mapped_params = convert_qwen3_5_to_hf(args, proxy_name, param)
+    for inner_layer_name in ("transformer_layer", "mtp_model_layer"):
+        mtp_prefix = f"mtp.layers.{layer_idx}.{inner_layer_name}"
+        if mtp_prefix in name:
+            proxy_name = name.replace(mtp_prefix, f"decoder.layers.{layer_idx}")
+            mapped_params = convert_qwen3_5_to_hf(args, proxy_name, param)
 
-        final_params = []
-        for hf_name, tensor in mapped_params:
-            target_prefix = f"mtp.layers.{layer_idx}"
-            if f"model.layers.{layer_idx}" in hf_name:
-                new_hf_name = hf_name.replace(f"model.layers.{layer_idx}", target_prefix)
-                final_params.append((new_hf_name, tensor))
-            else:
-                final_params.append((hf_name, tensor))
-        return final_params
+            final_params = []
+            for hf_name, tensor in mapped_params:
+                target_prefix = f"mtp.layers.{layer_idx}"
+                if f"model.language_model.layers.{layer_idx}" in hf_name:
+                    new_hf_name = hf_name.replace(
+                        f"model.language_model.layers.{layer_idx}", target_prefix
+                    )
+                    final_params.append((new_hf_name, tensor))
+                else:
+                    final_params.append((hf_name, tensor))
+            return final_params
 
     return None
 
 
+def _split_qkv_weight(args, param, head_dim, value_num_per_group):
+    param = param.view(args.num_query_groups, -1, head_dim, args.hidden_size)
+    q_param, k_param, v_param = torch.split(
+        param, split_size_or_sections=[2 * value_num_per_group, 1, 1], dim=1
+    )
+    q_param = (
+        q_param.reshape(args.num_query_groups, 2, value_num_per_group, head_dim, args.hidden_size)
+        .transpose(1, 2)
+        .reshape(-1, args.hidden_size)
+    )
+    k_param = k_param.reshape(-1, args.hidden_size)
+    v_param = v_param.reshape(-1, args.hidden_size)
+    return q_param, k_param, v_param
+
+
+def _split_qkv_bias(args, param, head_dim, value_num_per_group):
+    param = param.view(args.num_query_groups, -1)
+    q_bias, k_bias, v_bias = torch.split(
+        param,
+        split_size_or_sections=[value_num_per_group * head_dim * 2, head_dim, head_dim],
+        dim=1,
+    )
+    q_bias = q_bias.contiguous().flatten()
+    k_bias = k_bias.contiguous().flatten()
+    v_bias = v_bias.contiguous().flatten()
+    return q_bias, k_bias, v_bias
+
+
+def _split_linear_attn_in_proj_weight(args, param):
+    key_dim = args.linear_num_key_heads * args.linear_key_head_dim
+    value_dim = args.linear_num_value_heads * args.linear_value_head_dim
+    num_v_heads = args.linear_num_value_heads
+
+    split_sizes = [key_dim * 2 + value_dim, value_dim, num_v_heads, num_v_heads]
+    in_proj_qkv, in_proj_z, in_proj_b, in_proj_a = torch.split(param, split_sizes, dim=0)
+    return in_proj_qkv, in_proj_z, in_proj_b, in_proj_a
+
+
 def convert_qwen3_5_to_hf(args, name, param):
+    if name.startswith("module.module.language_model."):
+        name = "module.module." + name[len("module.module.language_model.") :]
+
+    while name.startswith("module.module.module."):
+        name = name.replace("module.module.module.", "module.module.", 1)
+
+    if name.startswith("module.module.vision_model."):
+        return _convert_vision_model_to_hf(name, param)
+
     if "mtp.layers" in name:
         parts = name.split(".")
         try:
@@ -47,12 +169,13 @@ def convert_qwen3_5_to_hf(args, name, param):
         if result is not None:
             return result
 
+    # 基础组件添加 model.language_model 前缀
     if name == "module.module.embedding.word_embeddings.weight":
-        return [("model.embed_tokens.weight", param)]
+        return[("model.language_model.embed_tokens.weight", param)]
     if name == "module.module.output_layer.weight":
         return [("lm_head.weight", param)]
     if name == "module.module.decoder.final_layernorm.weight":
-        return [("model.norm.weight", param)]
+        return[("model.language_model.norm.weight", param)]
 
     try:
         head_dim = args.kv_channels if args.kv_channels is not None else args.hidden_size // args.num_attention_heads
@@ -65,72 +188,74 @@ def convert_qwen3_5_to_hf(args, name, param):
     if match:
         layer_idx, rest = match.groups()
 
+        # 层级组件全部添加 model.language_model.layers 前缀
         if rest == "self_attention.linear_proj.weight":
-            return [(f"model.layers.{layer_idx}.self_attn.o_proj.weight", param)]
+            return[(f"model.language_model.layers.{layer_idx}.self_attn.o_proj.weight", param)]
         elif rest == "self_attention.linear_qkv.weight":
-            param = param.view(args.num_query_groups, -1, head_dim, args.hidden_size)
-            q_param, k_param, v_param = torch.split(
-                param, split_size_or_sections=[2 * value_num_per_group, 1, 1], dim=1
-            )
-            q_param = (
-                q_param.reshape(args.num_query_groups, 2, value_num_per_group, head_dim, args.hidden_size)
-                .transpose(1, 2)
-                .reshape(-1, args.hidden_size)
-            )
-            k_param = k_param.reshape(-1, args.hidden_size)
-            v_param = v_param.reshape(-1, args.hidden_size)
-            return [
-                (f"model.layers.{layer_idx}.self_attn.q_proj.weight", q_param),
-                (f"model.layers.{layer_idx}.self_attn.k_proj.weight", k_param),
-                (f"model.layers.{layer_idx}.self_attn.v_proj.weight", v_param),
+            q_param, k_param, v_param = _split_qkv_weight(args, param, head_dim, value_num_per_group)
+            return[
+                (f"model.language_model.layers.{layer_idx}.self_attn.q_proj.weight", q_param),
+                (f"model.language_model.layers.{layer_idx}.self_attn.k_proj.weight", k_param),
+                (f"model.language_model.layers.{layer_idx}.self_attn.v_proj.weight", v_param),
+            ]
+        elif rest == "self_attention.in_proj.weight":
+            in_proj_qkv, in_proj_z, in_proj_b, in_proj_a = _split_linear_attn_in_proj_weight(args, param)
+            return[
+                (f"model.language_model.layers.{layer_idx}.linear_attn.in_proj_qkv.weight", in_proj_qkv),
+                (f"model.language_model.layers.{layer_idx}.linear_attn.in_proj_z.weight", in_proj_z),
+                (f"model.language_model.layers.{layer_idx}.linear_attn.in_proj_b.weight", in_proj_b),
+                (f"model.language_model.layers.{layer_idx}.linear_attn.in_proj_a.weight", in_proj_a),
             ]
         elif rest == "self_attention.linear_qkv.bias":
-            param = param.view(args.num_query_groups, -1)
-            q_bias, k_bias, v_bias = torch.split(
-                param,
-                split_size_or_sections=[value_num_per_group * head_dim * 2, head_dim, head_dim],
-                dim=1,
-            )
-            q_bias = q_bias.contiguous().flatten()
-            k_bias = k_bias.contiguous().flatten()
-            v_bias = v_bias.contiguous().flatten()
-            return [
-                (f"model.layers.{layer_idx}.self_attn.q_proj.bias", q_bias),
-                (f"model.layers.{layer_idx}.self_attn.k_proj.bias", k_bias),
-                (f"model.layers.{layer_idx}.self_attn.v_proj.bias", v_bias),
+            q_bias, k_bias, v_bias = _split_qkv_bias(args, param, head_dim, value_num_per_group)
+            return[
+                (f"model.language_model.layers.{layer_idx}.self_attn.q_proj.bias", q_bias),
+                (f"model.language_model.layers.{layer_idx}.self_attn.k_proj.bias", k_bias),
+                (f"model.language_model.layers.{layer_idx}.self_attn.v_proj.bias", v_bias),
             ]
+        elif rest == "self_attention.in_proj.bias":
+            return []
         elif rest == "mlp.linear_fc1.weight":
             gate_weight, up_weight = param.chunk(2, dim=0)
-            return [
-                (f"model.layers.{layer_idx}.mlp.gate_proj.weight", gate_weight),
-                (f"model.layers.{layer_idx}.mlp.up_proj.weight", up_weight),
+            return[
+                (f"model.language_model.layers.{layer_idx}.mlp.gate_proj.weight", gate_weight),
+                (f"model.language_model.layers.{layer_idx}.mlp.up_proj.weight", up_weight),
             ]
         elif rest == "mlp.linear_fc2.weight":
-            return [(f"model.layers.{layer_idx}.mlp.down_proj.weight", param)]
-        elif rest == "self_attention.linear_qkv.layer_norm_weight":
-            return [(f"model.layers.{layer_idx}.input_layernorm.weight", param)]
+            return[(f"model.language_model.layers.{layer_idx}.mlp.down_proj.weight", param)]
+        elif rest in ["self_attention.linear_qkv.layer_norm_weight", "self_attention.in_proj.layer_norm_weight"]:
+            return[(f"model.language_model.layers.{layer_idx}.input_layernorm.weight", param)]
+        elif rest == "self_attention.in_proj.layer_norm_bias":
+            return []
+        elif rest == "self_attention.out_norm.weight":
+            return [(f"model.language_model.layers.{layer_idx}.linear_attn.norm.weight", param)]
+        elif rest == "self_attention.out_norm.bias":
+            return []
         elif rest == "mlp.linear_fc1.layer_norm_weight":
-            return [(f"model.layers.{layer_idx}.post_attention_layernorm.weight", param)]
+            return[(f"model.language_model.layers.{layer_idx}.post_attention_layernorm.weight", param)]
         elif rest == "pre_mlp_layernorm.weight":
-            return [(f"model.layers.{layer_idx}.post_attention_layernorm.weight", param)]
-
+            return[(f"model.language_model.layers.{layer_idx}.post_attention_layernorm.weight", param)]
         elif rest == "self_attention.q_layernorm.weight":
-            return [(f"model.layers.{layer_idx}.self_attn.q_norm.weight", param)]
+            return[(f"model.language_model.layers.{layer_idx}.self_attn.q_norm.weight", param)]
         elif rest == "self_attention.k_layernorm.weight":
-            return [(f"model.layers.{layer_idx}.self_attn.k_norm.weight", param)]
-        elif rest.startswith("self_attention.") and rest[len("self_attention.") :] in [
-            "input_layernorm.weight",
-            "linear_attn.A_log",
-            "linear_attn.conv1d.weight",
-            "linear_attn.dt_bias",
-            "linear_attn.in_proj_a.weight",
-            "linear_attn.in_proj_b.weight",
-            "linear_attn.in_proj_qkv.weight",
-            "linear_attn.in_proj_z.weight",
-            "linear_attn.norm.weight",
-            "linear_attn.out_proj.weight",
-        ]:
-            rest = rest[len("self_attention.") :]
-            return [(f"model.layers.{layer_idx}.{rest}", param)]
+            return[(f"model.language_model.layers.{layer_idx}.self_attn.k_norm.weight", param)]
+        elif rest.startswith("self_attention."):
+            attn_rest = rest[len("self_attention.") :]
+            if attn_rest in [
+                "input_layernorm.weight",
+                "linear_attn.A_log",
+                "linear_attn.conv1d.weight",
+                "linear_attn.dt_bias",
+                "linear_attn.in_proj_a.weight",
+                "linear_attn.in_proj_b.weight",
+                "linear_attn.in_proj_qkv.weight",
+                "linear_attn.in_proj_z.weight",
+                "linear_attn.norm.weight",
+                "linear_attn.out_proj.weight",
+            ]:
+                return[(f"model.language_model.layers.{layer_idx}.{attn_rest}", param)]
+            if attn_rest in _LINEAR_ATTN_DIRECT_TO_HF:
+                hf_suffix = _LINEAR_ATTN_DIRECT_TO_HF[attn_rest]
+                return[(f"model.language_model.layers.{layer_idx}.{hf_suffix}", param)]
 
     raise ValueError(f"Unknown parameter name: {name}")

--- a/slime/slime/backends/megatron_utils/model_provider.py
+++ b/slime/slime/backends/megatron_utils/model_provider.py
@@ -81,12 +81,19 @@ def get_model_provider_func(
         return wrapped_model_provider
 
     if args.megatron_to_hf_mode == "bridge":
-        from megatron.bridge import AutoBridge
-
-        import slime_plugins.megatron_bridge  # noqa: F401  # register custom bridges
-
-        bridge = AutoBridge.from_hf_pretrained(args.hf_checkpoint, trust_remote_code=True)
-        provider = bridge.to_megatron_provider(load_weights=False)
+        bridge, hf_pretrained, is_local_bridge = load_function(
+            "slime.utils.megatron_bridge_utils.build_bridge_for_hf_checkpoint"
+        )(args.hf_checkpoint, load_weights=False)
+        if is_local_bridge:
+            provider = bridge.provider_bridge(hf_pretrained)
+        else:
+            provider = bridge.to_megatron_provider(load_weights=False)
+        print(
+            "Qwen35 bridge debug: "
+            f"bridge={type(bridge).__module__}.{type(bridge).__name__} "
+            f"provider={type(provider).__module__}.{type(provider).__name__} "
+            f"is_local_bridge={is_local_bridge}"
+        )
         # TODO: we should not manually set this...
         provider.tensor_model_parallel_size = args.tensor_model_parallel_size
         provider.pipeline_model_parallel_size = args.pipeline_model_parallel_size
@@ -211,12 +218,22 @@ def get_model_provider_func(
 
 
 def wrap_model_provider_with_freeze(original_provider, args):
-    def wrapped_provider(pre_process=True, post_process=True, vp_stage=None):
+    def wrapped_provider(pre_process=True, post_process=True, vp_stage=None, **extra_kwargs):
         sig = inspect.signature(original_provider)
+        provider_kwargs = {
+            "pre_process": pre_process,
+            "post_process": post_process,
+        }
         if "vp_stage" in sig.parameters:
-            model = original_provider(pre_process=pre_process, post_process=post_process, vp_stage=vp_stage)
-        else:
-            model = original_provider(pre_process=pre_process, post_process=post_process)
+            provider_kwargs["vp_stage"] = vp_stage
+
+        # Newer Megatron-LM may pass extra provider kwargs such as config.
+        # Forward only the kwargs the wrapped provider actually declares.
+        for name, value in extra_kwargs.items():
+            if name in sig.parameters:
+                provider_kwargs[name] = value
+
+        model = original_provider(**provider_kwargs)
 
         freeze_model_params(model, args)
 

--- a/slime/slime/backends/megatron_utils/update_weight/common.py
+++ b/slime/slime/backends/megatron_utils/update_weight/common.py
@@ -1,4 +1,5 @@
 import inspect
+import os
 import re
 from argparse import Namespace
 from collections.abc import Iterator, Sequence
@@ -10,6 +11,40 @@ from megatron.core.transformer.transformer_layer import get_transformer_layer_of
 
 from slime.backends.megatron_utils.misc_utils import strip_param_name_prefix
 from slime.utils.types import ParamInfo
+
+_DISABLE_LINEAR_FC1_RECHUNK = os.getenv("SLIME_QWEN35_DISABLE_LINEAR_FC1_RECHUNK", "0") == "1"
+
+
+def _merge_tp_partitions(
+    name: str,
+    param_partitions: list[torch.Tensor],
+    partition_dim: int,
+    partition_stride: int,
+) -> torch.Tensor:
+    if partition_stride > 1:
+        local_partition_size = param_partitions[0].size(partition_dim)
+        assert (
+            local_partition_size % partition_stride == 0
+        ), f"{name} has local size {local_partition_size} not divisible by partition_stride={partition_stride}"
+        per_partition_per_stride_size = local_partition_size // partition_stride
+        split_param_partitions = [
+            torch.split(partition, per_partition_per_stride_size, dim=partition_dim) for partition in param_partitions
+        ]
+        param_partitions = [
+            split_param_partitions[rank][stride_idx]
+            for stride_idx in range(partition_stride)
+            for rank in range(len(split_param_partitions))
+        ]
+
+    # TODO: here we did an extra copy during concat, maybe merge this with convert_to_hf is better?
+    # TODO: check only GLU is used.
+    if "linear_fc1.weight" in name and not _DISABLE_LINEAR_FC1_RECHUNK:
+        param_partitions = [p.chunk(2, dim=0) for p in param_partitions]
+        param_partitions = [p[0] for p in param_partitions] + [p[1] for p in param_partitions]
+    # this is bug in megatron's grouped moe.
+    if "linear_fc2.weight" in name and partition_dim == 0:
+        partition_dim = 1
+    return torch.cat(param_partitions, dim=partition_dim)
 
 
 def all_gather_param(name: str, param: torch.nn.Parameter) -> torch.Tensor:
@@ -34,18 +69,8 @@ def all_gather_param(name: str, param: torch.nn.Parameter) -> torch.Tensor:
     param_partitions = [torch.empty_like(param.data) for _ in range(tp_size)]
     dist.all_gather(param_partitions, param.data, group=tp_group)
     partition_dim = param.partition_dim
-    assert param.partition_stride == 1, "partition_stride != 1 is not supported"
-    # TODO: here we did an extra copy during concat, maybe merge this with convert_to_hf is better?
-    # TODO: check only GLU is used.
-    if "linear_fc1.weight" in name:
-        param_partitions = [p.chunk(2, dim=0) for p in param_partitions]
-        param_partitions = [p[0] for p in param_partitions] + [p[1] for p in param_partitions]
-    # this is bug in megatron's grouped moe.
-    if "linear_fc2.weight" in name:
-        if partition_dim == 0:
-            partition_dim = 1
-    param = torch.cat(param_partitions, dim=partition_dim)
-    return param
+    partition_stride = getattr(param, "partition_stride", 1)
+    return _merge_tp_partitions(name, param_partitions, partition_dim, partition_stride)
 
 
 def all_gather_params_async(
@@ -63,10 +88,10 @@ def all_gather_params_async(
     for info, param in param_infos_and_params:
         # Prepare async all_gather
         if "expert_bias" in info.name:
-            gather_tasks.append((info, param, None, None, None))
+            gather_tasks.append((info, param, None, None, None, None))
             handles.append(None)
         elif not param.tensor_model_parallel or getattr(param, "parallel_mode", None) == "duplicated":
-            gather_tasks.append((info, param.data, None, None, None))
+            gather_tasks.append((info, param.data, None, None, None, None))
             handles.append(None)
         else:
             # Start async all_gather
@@ -79,7 +104,9 @@ def all_gather_params_async(
 
             param_partitions = [torch.empty_like(param.data) for _ in range(tp_size)]
             handle = dist.all_gather(param_partitions, param.data, group=tp_group, async_op=True)
-            gather_tasks.append((info, None, handle, param_partitions, param.partition_dim))
+            gather_tasks.append(
+                (info, None, handle, param_partitions, param.partition_dim, getattr(param, "partition_stride", 1))
+            )
             handles.append(handle)
 
     # Phase 2: Wait for ALL async operations to complete at once
@@ -90,23 +117,12 @@ def all_gather_params_async(
 
     # Phase 3: Process all results after all communications are done
     gathered_params = []
-    for info, direct_param, handle, param_partitions, partition_dim in gather_tasks:
+    for info, direct_param, handle, param_partitions, partition_dim, partition_stride in gather_tasks:
         if handle is None:
             # No all_gather needed
             param = direct_param
         else:
-            # Process the gathered partitions (same logic as original all_gather_param)
-            assert partition_dim is not None, "partition_stride != 1 is not supported"
-            # TODO: here we did an extra copy during concat, maybe merge this with convert_to_hf is better?
-            # TODO: check only GLU is used.
-            if "linear_fc1.weight" in info.name:
-                param_partitions = [p.chunk(2, dim=0) for p in param_partitions]
-                param_partitions = [p[0] for p in param_partitions] + [p[1] for p in param_partitions]
-            # this is bug in megatron's grouped moe.
-            if "linear_fc2.weight" in info.name:
-                if partition_dim == 0:
-                    partition_dim = 1
-            param = torch.cat(param_partitions, dim=partition_dim)
+            param = _merge_tp_partitions(info.name, param_partitions, partition_dim, partition_stride)
 
         gathered_params.append(param)
 

--- a/slime/slime/utils/arguments.py
+++ b/slime/slime/utils/arguments.py
@@ -1889,6 +1889,17 @@ def hf_validate_args(args, hf_config):
     def equal(x, y):
         return x == y
 
+    def get_arg_value(name):
+        # Newer Megatron-Core renamed some argparse destinations while keeping
+        # the same CLI flags. Accept both spellings here.
+        alias_map = {
+            "norm_epsilon": ("norm_epsilon", "layernorm_epsilon"),
+        }
+        for candidate in alias_map.get(name, (name,)):
+            if hasattr(args, candidate):
+                return getattr(args, candidate)
+        raise AttributeError(f"'Namespace' object has no attribute '{name}'")
+
     errors = []
 
     # multimodal models have different config structure
@@ -1916,10 +1927,11 @@ def hf_validate_args(args, hf_config):
             hf_value = getattr(hf_config, hf_config_name)
 
         if hf_value is not None:
-            if not compare_fn(hf_value, getattr(args, megatron_config_name)):
+            arg_value = get_arg_value(megatron_config_name)
+            if not compare_fn(hf_value, arg_value):
                 errors.append(
                     f"{hf_config_name} in hf config {hf_value} is not equal to "
-                    f"{megatron_config_name} {getattr(args, megatron_config_name)}, please check the config."
+                    f"{megatron_config_name} {arg_value}, please check the config."
                 )
 
     if len(errors) > 0:

--- a/slime/slime/utils/megatron_bridge_utils.py
+++ b/slime/slime/utils/megatron_bridge_utils.py
@@ -1,4 +1,8 @@
 from contextlib import contextmanager
+import itertools
+import json
+import os
+from pathlib import Path
 
 try:
     from megatron.core.utils import unwrap_model
@@ -20,3 +24,69 @@ def patch_megatron_model(model):
     finally:
         if attribute_was_added:
             delattr(model_config, "share_embeddings_and_output_weights")
+
+
+def maybe_dump_bridge_runtime_layout(bridge, megatron_model):
+    dump_path = os.getenv("SLIME_DEBUG_QWEN35_DUMP_PATH")
+    if not dump_path:
+        return None
+
+    from megatron.bridge.models.conversion.model_bridge import _megatron_local_name_to_global
+    from megatron.bridge.models.conversion.utils import get_module_and_param_from_name, persistent_buffers
+
+    model_chunks = megatron_model if isinstance(megatron_model, list) else [megatron_model]
+    unwrapped_model = unwrap_model(model_chunks)[0]
+    model_config = unwrapped_model.config
+    mapping_registry = bridge.mapping_registry()
+
+    rows = []
+    for vp_stage, model_chunk in enumerate(model_chunks):
+        for local_name, _ in itertools.chain(model_chunk.named_parameters(), persistent_buffers(model_chunk)):
+            if "_extra_state" in local_name or bridge._is_adapter_param_name(local_name):
+                continue
+
+            local_name = bridge._unwrap_name(local_name)
+            global_name = _megatron_local_name_to_global(model_chunks, model_config, local_name, vp_stage)
+            local_module, local_weights = get_module_and_param_from_name(model_chunks, local_name, vp_stage)
+            mapping = mapping_registry.megatron_to_hf_lookup(bridge._get_lora_unwrapped_name(global_name))
+
+            rows.append(
+                {
+                    "vp_stage": vp_stage,
+                    "global_param_name": global_name,
+                    "local_param_name": local_name,
+                    "owner_module_class": type(local_module).__name__ if local_module is not None else None,
+                    "owner_module_module": type(local_module).__module__ if local_module is not None else None,
+                    "param_shape": list(local_weights.shape) if local_weights is not None else None,
+                    "mapping_class": type(mapping).__name__ if mapping is not None else None,
+                    "hf_param": getattr(mapping, "hf_param", None) if mapping is not None else None,
+                }
+            )
+
+    output_path = Path(dump_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(rows, ensure_ascii=True, indent=2))
+    return str(output_path)
+
+
+def build_bridge_for_hf_checkpoint(hf_checkpoint: str, *, load_weights: bool):
+    import slime_plugins.megatron_bridge  # noqa: F401
+    from transformers import AutoConfig
+    from megatron.bridge import AutoBridge
+
+    hf_config = AutoConfig.from_pretrained(hf_checkpoint, trust_remote_code=True)
+    model_type = getattr(hf_config, "model_type", None)
+
+    if model_type == "qwen3_5" and hasattr(hf_config, "text_config"):
+        from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
+        from slime_plugins.megatron_bridge.qwen3_5 import MegatronQwen35VLBridge
+
+        bridge = MegatronQwen35VLBridge()
+        hf_pretrained = PreTrainedCausalLM.from_pretrained(
+            hf_checkpoint,
+            trust_remote_code=True,
+        )
+        return bridge, hf_pretrained, True
+
+    auto_bridge = AutoBridge.from_hf_pretrained(hf_checkpoint, trust_remote_code=True)
+    return auto_bridge, None, False

--- a/slime/slime_plugins/megatron_bridge/qwen35_vl.py
+++ b/slime/slime_plugins/megatron_bridge/qwen35_vl.py
@@ -1,0 +1,862 @@
+from __future__ import annotations
+
+import copy
+import itertools
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from megatron.core import mpu, tensor_parallel
+from megatron.core.inference.contexts import BaseInferenceContext
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
+from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.models.common.embeddings.rope_utils import get_pos_emb_on_this_cp_rank
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.transformer.transformer_block import get_num_layers_to_build
+from megatron.core.transformer.transformer_layer import get_transformer_layer_offset
+from megatron.core.utils import deprecate_inference_params
+from torch import Tensor
+
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.transformer_block import Qwen3VLTransformerBlock
+try:
+    from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.utils import (
+        get_rope_index as get_qwen3vl_rope_index,
+    )
+except ImportError:
+    # Megatron-Bridge changed the exported rope helper name/signature across versions.
+    # The local Qwen3.5 rope path below can handle multimodal batches without it.
+    get_qwen3vl_rope_index = None
+from megatron.bridge.models.qwen_vl.qwen3_vl_provider import Qwen3VLModelProvider
+from megatron.bridge.utils.common_utils import hook_hf_module_setattr_for_tp_grad_sync
+from slime_plugins.models.qwen3_5 import Qwen3_5GatedDeltaNet
+
+from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5VisionModel
+
+logger = logging.getLogger(__name__)
+_QWEN35_BRIDGE_FORWARD_LOGGED = False
+_QWEN35_SEQPAR_LOGITS_GATHER_LOGGED = False
+
+
+def _should_log_qwen35_bridge_debug() -> bool:
+    return os.getenv("SLIME_DEBUG_QWEN35_BRIDGE", "").lower() in {"1", "true", "yes", "on"}
+
+
+def _should_gather_qwen35_sequence_parallel_logits() -> bool:
+    return os.getenv("SLIME_QWEN35_GATHER_SEQPAR_LOGITS", "1").lower() in {"1", "true", "yes", "on"}
+
+
+def _build_attention_mask_from_cu_seqlens(
+    cu_seqlens: torch.Tensor,
+    *,
+    max_seq_len: int,
+    batch_size: int,
+    device: torch.device,
+) -> torch.Tensor:
+    attention_mask = torch.zeros((batch_size, max_seq_len), dtype=torch.long, device=device)
+    seq_lens = cu_seqlens[1 : batch_size + 1] - cu_seqlens[:batch_size]
+    for i, seq_len in enumerate(seq_lens.tolist()):
+        valid = min(int(seq_len), max_seq_len)
+        attention_mask[i, :valid] = 1
+    return attention_mask
+
+
+def _thd_to_bshd(
+    packed_values: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    *,
+    batch_size: int,
+) -> torch.Tensor:
+    seq_lens = cu_seqlens[1 : batch_size + 1] - cu_seqlens[:batch_size]
+    max_seq_len = int(seq_lens.max().item()) if batch_size > 0 else 0
+    trailing_shape = packed_values.shape[2:]
+    results = packed_values.new_zeros((batch_size, max_seq_len, *trailing_shape))
+    for i, seq_len in enumerate(seq_lens.tolist()):
+        results[i, :seq_len] = packed_values[0, cu_seqlens[i] : cu_seqlens[i] + seq_len]
+    return results
+
+
+def _bshd_to_thd(
+    unpacked_values: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    *,
+    batch_size: int,
+) -> torch.Tensor:
+    trailing_shape = unpacked_values.shape[2:]
+    total_len = int(cu_seqlens[-1].item())
+    results = unpacked_values.new_zeros((1, total_len, *trailing_shape))
+    seq_lens = cu_seqlens[1 : batch_size + 1] - cu_seqlens[:batch_size]
+    for i, seq_len in enumerate(seq_lens.tolist()):
+        results[0, cu_seqlens[i] : cu_seqlens[i] + seq_len] = unpacked_values[i, :seq_len]
+    return results
+
+
+class Qwen35BridgeAttention(MegatronModule):
+    def __init__(
+        self,
+        config,
+        layer_number: int,
+        hf_config,
+        sequence_parallel: bool = False,
+        cp_comm_type: str = "p2p",
+        pg_collection=None,
+    ):
+        super().__init__(config=config)
+        self.config = config
+        self.layer_number = layer_number
+        self.hf_layer_idx = layer_number - 1
+        self.sequence_parallel = sequence_parallel
+        self.hf_config = copy.deepcopy(hf_config)
+        dtype_name = getattr(self.hf_config, "dtype", None)
+        if isinstance(dtype_name, str):
+            self.hf_config.dtype = getattr(torch, dtype_name, dtype_name)
+        self.hf_config._attn_implementation = "flash_attention_2"
+        self.linear_attn = Qwen3_5GatedDeltaNet(self.hf_config, self.hf_layer_idx)
+
+        try:
+            from transformers.models.qwen3_next.modeling_qwen3_next import Qwen3NextRMSNorm
+
+            self.input_layernorm = Qwen3NextRMSNorm(
+                self.hf_config.hidden_size,
+                eps=self.hf_config.rms_norm_eps,
+            )
+        except ImportError:
+            from torch.nn import RMSNorm
+
+            self.input_layernorm = RMSNorm(self.hf_config.hidden_size, eps=self.hf_config.rms_norm_eps)
+
+    def hf_forward(self, hidden_states: torch.Tensor, packed_seq_params: PackedSeqParams) -> torch.Tensor:
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.linear_attn(
+            hidden_states=hidden_states,
+            cu_seqlens=packed_seq_params.cu_seqlens_q,
+        )
+        return hidden_states
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        key_value_states: torch.Tensor | None = None,
+        inference_context: BaseInferenceContext | None = None,
+        rotary_pos_emb: torch.Tensor | tuple[torch.Tensor, torch.Tensor] | None = None,
+        rotary_pos_cos: torch.Tensor | None = None,
+        rotary_pos_sin: torch.Tensor | None = None,
+        rotary_pos_cos_sin: torch.Tensor | None = None,
+        attention_bias: torch.Tensor | None = None,
+        packed_seq_params: PackedSeqParams | None = None,
+        sequence_len_offset: int | None = None,
+        *,
+        inference_params: BaseInferenceContext | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        global _QWEN35_BRIDGE_FORWARD_LOGGED
+        if _should_log_qwen35_bridge_debug() and not _QWEN35_BRIDGE_FORWARD_LOGGED:
+            _QWEN35_BRIDGE_FORWARD_LOGGED = True
+            logger.warning(
+                "Qwen35 bridge debug: entered Qwen35BridgeAttention.forward "
+                "file=%s layer_number=%s packed_seq=%s hidden_states_shape=%s",
+                self.forward.__code__.co_filename,
+                self.layer_number,
+                packed_seq_params is not None,
+                tuple(hidden_states.shape),
+            )
+        assert packed_seq_params is not None
+        cu_seqlens = packed_seq_params.cu_seqlens_q
+
+        if self.sequence_parallel:
+            hidden_states = tensor_parallel.gather_from_sequence_parallel_region(
+                hidden_states,
+                group=mpu.get_tensor_model_parallel_group(),
+            )
+
+        if mpu.get_context_parallel_world_size() > 1:
+            cp_size = mpu.get_context_parallel_world_size()
+            hidden_states_list = dist.nn.all_gather(
+                hidden_states,
+                group=mpu.get_context_parallel_group(),
+            )
+
+            whole_hidden_states_list = []
+            local_cu_seqlens = cu_seqlens // cp_size
+            for i in range(len(cu_seqlens) - 1):
+                seqlen = cu_seqlens[i + 1] - cu_seqlens[i]
+                chunk_size = seqlen // 2 // cp_size
+                whole_hidden_states_list.extend(
+                    [
+                        hidden_states_list[cp_rank][local_cu_seqlens[i] : local_cu_seqlens[i] + chunk_size]
+                        for cp_rank in range(cp_size)
+                    ]
+                    + [
+                        hidden_states_list[cp_rank][local_cu_seqlens[i] + chunk_size : local_cu_seqlens[i + 1]]
+                        for cp_rank in range(cp_size)
+                    ][::-1],
+                )
+            hidden_states = torch.cat(whole_hidden_states_list, dim=0)
+
+        hidden_states = hidden_states.permute(1, 0, 2)
+        output = self.hf_forward(hidden_states, packed_seq_params)
+        bias = None
+        output = output.permute(1, 0, 2)
+
+        if mpu.get_context_parallel_world_size() > 1:
+            cp_rank = mpu.get_context_parallel_rank()
+            output_list = []
+            for i in range(len(cu_seqlens) - 1):
+                seqlen = cu_seqlens[i + 1] - cu_seqlens[i]
+                chunk_size = seqlen // 2 // mpu.get_context_parallel_world_size()
+                seq = output[cu_seqlens[i] : cu_seqlens[i + 1]]
+                chunks = torch.chunk(seq, 2 * mpu.get_context_parallel_world_size(), dim=0)
+                output_list.append(chunks[cp_rank])
+                output_list.append(chunks[2 * mpu.get_context_parallel_world_size() - 1 - cp_rank])
+            output = torch.cat(output_list, dim=0)
+
+        if self.sequence_parallel:
+            output = tensor_parallel.scatter_to_sequence_parallel_region(
+                output,
+                group=mpu.get_tensor_model_parallel_group(),
+            )
+
+        return output, bias
+
+
+class Qwen35TextRotaryEmbedding(nn.Module):
+    inv_freq: torch.Tensor
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.mrope_section = list(config.rope_parameters.get("mrope_section", [11, 11, 10]))
+        inv_freq, _ = self.compute_default_rope_parameters(config)
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    @staticmethod
+    def compute_default_rope_parameters(config) -> tuple[torch.Tensor, float]:
+        base = config.rope_parameters["rope_theta"]
+        partial_rotary_factor = config.rope_parameters.get("partial_rotary_factor", 1.0)
+        head_dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+        dim = int(head_dim * partial_rotary_factor)
+        inv_freq = 1.0 / (
+            base ** (torch.arange(0, dim, 2, dtype=torch.int64, device=None).float() / dim)
+        )
+        return inv_freq, 1.0
+
+    @staticmethod
+    def apply_interleaved_mrope(freqs: torch.Tensor, mrope_section: List[int]) -> torch.Tensor:
+        freqs_t = freqs[0]
+        for dim, offset in enumerate((1, 2), start=1):
+            length = mrope_section[dim] * 3
+            idx = slice(offset, length, 3)
+            freqs_t[..., idx] = freqs[dim, ..., idx]
+        return freqs_t
+
+    def forward(
+        self,
+        position_ids: torch.Tensor,
+        mrope_section: List[int] | None = None,
+        packed_seq_params: PackedSeqParams | None = None,
+        cp_group: torch.distributed.ProcessGroup | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        del packed_seq_params, kwargs
+        if mrope_section is None:
+            mrope_section = self.mrope_section
+        if position_ids.ndim == 2:
+            position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
+
+        inv_freq_expanded = self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1)
+        position_ids_expanded = position_ids[:, :, None, :].float()
+        freqs = (inv_freq_expanded @ position_ids_expanded).transpose(2, 3)
+        freqs = self.apply_interleaved_mrope(freqs, mrope_section)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        emb = emb[..., None, :].transpose(0, 1).contiguous()
+        if cp_group is not None and dist.is_available() and dist.is_initialized():
+            try:
+                if dist.get_world_size(cp_group) > 1:
+                    emb = get_pos_emb_on_this_cp_rank(emb, 0, cp_group)
+            except Exception:
+                # Bridge/runtime versions differ in when CP groups are initialized.
+                # Ignore the hint rather than failing on single-CP jobs.
+                pass
+        return emb
+
+
+class Qwen35VLGPTModel(GPTModel):
+    def __init__(
+        self,
+        config,
+        transformer_layer_spec: ModuleSpec,
+        vocab_size: int,
+        max_sequence_length: int,
+        pre_process: bool = True,
+        post_process: bool = True,
+        fp16_lm_cross_entropy: bool = False,
+        parallel_output: bool = True,
+        share_embeddings_and_output_weights: bool = False,
+        position_embedding_type: str = "learned_absolute",
+        rotary_percent: float = 1.0,
+        rotary_base: int = 10000,
+        rope_scaling: bool = False,
+        rope_scaling_factor: float = 8.0,
+        scatter_embedding_sequence_parallel: bool = True,
+        seq_len_interpolation_factor: Optional[float] = None,
+        mtp_block_spec: Optional[ModuleSpec] = None,
+        vp_stage: Optional[int] = None,
+    ) -> None:
+        super().__init__(
+            config=config,
+            transformer_layer_spec=transformer_layer_spec,
+            vocab_size=vocab_size,
+            max_sequence_length=max_sequence_length,
+            pre_process=pre_process,
+            post_process=post_process,
+            fp16_lm_cross_entropy=fp16_lm_cross_entropy,
+            parallel_output=parallel_output,
+            share_embeddings_and_output_weights=share_embeddings_and_output_weights,
+            position_embedding_type=position_embedding_type,
+            rotary_percent=rotary_percent,
+            rotary_base=rotary_base,
+            rope_scaling=rope_scaling,
+            rope_scaling_factor=rope_scaling_factor,
+            scatter_embedding_sequence_parallel=scatter_embedding_sequence_parallel,
+            seq_len_interpolation_factor=seq_len_interpolation_factor,
+            mtp_block_spec=mtp_block_spec,
+            vp_stage=vp_stage,
+        )
+
+        self.rotary_pos_emb = Qwen35TextRotaryEmbedding(config.hf_text_config)
+        self.mrope_section = self.config.mrope_section
+        assert self.mrope_section is not None, "mrope requires mrope_section in the transformer config"
+
+        self.decoder = Qwen3VLTransformerBlock(
+            config=self.config,
+            spec=transformer_layer_spec,
+            pre_process=self.pre_process,
+            post_process=self.post_process,
+            vp_stage=vp_stage,
+        )
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        position_ids: Tensor,
+        attention_mask: Tensor,
+        decoder_input: Tensor = None,
+        labels: Tensor = None,
+        inference_context: BaseInferenceContext = None,
+        packed_seq_params: PackedSeqParams = None,
+        extra_block_kwargs: dict = None,
+        runtime_gather_output: Optional[bool] = None,
+        *,
+        inference_params: Optional[BaseInferenceContext] = None,
+        loss_mask: Optional[Tensor] = None,
+        visual_pos_masks: Optional[torch.Tensor] = None,
+        deepstack_visual_embeds: Optional[list[torch.Tensor]] = None,
+    ) -> Tensor:
+        global _QWEN35_SEQPAR_LOGITS_GATHER_LOGGED
+        inference_context = deprecate_inference_params(inference_context, inference_params)
+
+        preproc_output = self._preprocess(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            decoder_input=decoder_input,
+            inference_context=inference_context,
+            packed_seq_params=packed_seq_params,
+        )
+        decoder_input, rotary_pos_emb, rotary_pos_cos, rotary_pos_sin, sequence_len_offset = preproc_output[:5]
+
+        hidden_states = self.decoder(
+            hidden_states=decoder_input,
+            attention_mask=attention_mask,
+            inference_context=inference_context,
+            rotary_pos_emb=rotary_pos_emb,
+            rotary_pos_cos=rotary_pos_cos,
+            rotary_pos_sin=rotary_pos_sin,
+            packed_seq_params=packed_seq_params,
+            sequence_len_offset=sequence_len_offset,
+            visual_pos_masks=visual_pos_masks,
+            deepstack_visual_embeds=deepstack_visual_embeds,
+            **(extra_block_kwargs or {}),
+        )
+
+        outputs = self._postprocess(
+            hidden_states=hidden_states,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            labels=labels,
+            rotary_pos_emb=rotary_pos_emb,
+            rotary_pos_cos=rotary_pos_cos,
+            rotary_pos_sin=rotary_pos_sin,
+            mtp_in_postprocess=self.mtp_process,
+            loss_mask=loss_mask,
+            decoder_input=decoder_input,
+            attention_mask=attention_mask,
+            inference_params=inference_params,
+            packed_seq_params=packed_seq_params,
+            sequence_len_offset=sequence_len_offset,
+            runtime_gather_output=runtime_gather_output,
+            extra_block_kwargs=extra_block_kwargs,
+            inference_context=inference_context,
+        )
+
+        should_gather_seqpar_logits = (
+            labels is None
+            and self.config.sequence_parallel
+            and _should_gather_qwen35_sequence_parallel_logits()
+            and isinstance(outputs, torch.Tensor)
+            and outputs.ndim == 3
+            and packed_seq_params is not None
+            and packed_seq_params.qkv_format == "thd"
+            and packed_seq_params.cu_seqlens_q is not None
+        )
+        if should_gather_seqpar_logits:
+            expected_tokens = int(packed_seq_params.cu_seqlens_q[-1].item())
+            local_tokens = int(outputs.size(1))
+            tp_world_size = mpu.get_tensor_model_parallel_world_size()
+            if local_tokens != expected_tokens and local_tokens * tp_world_size == expected_tokens:
+                gathered_outputs = tensor_parallel.gather_from_sequence_parallel_region(
+                    outputs.transpose(0, 1).contiguous(),
+                    tensor_parallel_output_grad=False,
+                    group=mpu.get_tensor_model_parallel_group(),
+                )
+                outputs = gathered_outputs.transpose(0, 1).contiguous()
+                if _should_log_qwen35_bridge_debug() and not _QWEN35_SEQPAR_LOGITS_GATHER_LOGGED:
+                    _QWEN35_SEQPAR_LOGITS_GATHER_LOGGED = True
+                    logger.warning(
+                        "Qwen35 bridge debug: gathered sequence-parallel logits "
+                        "local_tokens=%s expected_tokens=%s tp_world_size=%s output_shape=%s",
+                        local_tokens,
+                        expected_tokens,
+                        tp_world_size,
+                        tuple(outputs.shape),
+                    )
+
+        return outputs
+
+
+def get_qwen35_rope_index(
+    spatial_merge_size: int,
+    image_token_id: int,
+    video_token_id: int,
+    vision_start_token_id: int,
+    input_ids: torch.LongTensor,
+    mm_token_type_ids: torch.IntTensor | None = None,
+    image_grid_thw: torch.LongTensor | None = None,
+    video_grid_thw: torch.LongTensor | None = None,
+    attention_mask: torch.Tensor | None = None,
+    packed_seq_params: PackedSeqParams | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if mm_token_type_ids is None:
+        if get_qwen3vl_rope_index is None:
+            raise RuntimeError(
+                "Megatron-Bridge does not export qwen3_vl.get_rope_index in this environment, "
+                "and mm_token_type_ids was not provided for the local Qwen3.5 rope fallback."
+            )
+        return get_qwen3vl_rope_index(
+            spatial_merge_size=spatial_merge_size,
+            image_token_id=image_token_id,
+            video_token_id=video_token_id,
+            vision_start_token_id=vision_start_token_id,
+            input_ids=input_ids,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=video_grid_thw,
+            attention_mask=attention_mask,
+            packed_seq_params=packed_seq_params,
+        )
+
+    if video_grid_thw is not None:
+        video_grid_thw = torch.repeat_interleave(video_grid_thw, video_grid_thw[:, 0], dim=0)
+        video_grid_thw[:, 0] = 1
+
+    if packed_seq_params is not None and attention_mask is None:
+        attention_mask = _build_attention_mask_from_cu_seqlens(
+            packed_seq_params.cu_seqlens_q,
+            max_seq_len=input_ids.shape[1],
+            batch_size=mm_token_type_ids.shape[0],
+            device=input_ids.device,
+        )
+
+    mrope_position_deltas = []
+    position_ids = torch.zeros(
+        3,
+        input_ids.shape[0],
+        input_ids.shape[1],
+        dtype=input_ids.dtype,
+        device=input_ids.device,
+    )
+    grid_iters = {
+        1: iter(image_grid_thw) if image_grid_thw is not None else None,
+        2: iter(video_grid_thw) if video_grid_thw is not None else None,
+    }
+
+    for batch_idx, current_input_ids in enumerate(input_ids):
+        input_token_type = mm_token_type_ids[batch_idx]
+        if attention_mask is not None:
+            current_input_ids = current_input_ids[attention_mask[batch_idx].bool()]
+            input_token_type = input_token_type[attention_mask[batch_idx].bool()]
+
+        input_type_group = []
+        for key, group in itertools.groupby(enumerate(input_token_type.tolist()), lambda x: x[1]):
+            group = list(group)
+            start_index = group[0][0]
+            end_index = group[-1][0] + 1
+            input_type_group.append((key, start_index, end_index))
+
+        current_pos = 0
+        llm_pos_ids_list = []
+        for modality_type, start_idx, end_idx in input_type_group:
+            if modality_type == 0:
+                text_len = end_idx - start_idx
+                llm_pos_ids_list.append(
+                    torch.arange(text_len, device=input_ids.device).view(1, -1).expand(3, -1) + current_pos
+                )
+                current_pos += text_len
+                continue
+
+            grid_iter = grid_iters.get(modality_type)
+            if grid_iter is None:
+                raise ValueError(f"Missing grid_thw iterator for modality_type={modality_type}")
+            grid_thw = next(grid_iter)
+            llm_grid_t = grid_thw[0].item()
+            llm_grid_h = grid_thw[1].item() // spatial_merge_size
+            llm_grid_w = grid_thw[2].item() // spatial_merge_size
+
+            text_len = end_idx - start_idx - (llm_grid_t * llm_grid_h * llm_grid_w)
+            if text_len > 0:
+                llm_pos_ids_list.append(
+                    torch.arange(text_len, device=input_ids.device).view(1, -1).expand(3, -1) + current_pos
+                )
+                current_pos += text_len
+
+            t_index = torch.arange(llm_grid_t, device=input_ids.device).view(-1, 1).expand(-1, llm_grid_h * llm_grid_w).flatten()
+            h_index = torch.arange(llm_grid_h, device=input_ids.device).view(1, -1, 1).expand(llm_grid_t, -1, llm_grid_w).flatten()
+            w_index = torch.arange(llm_grid_w, device=input_ids.device).view(1, 1, -1).expand(llm_grid_t, llm_grid_h, -1).flatten()
+            llm_pos_ids_list.append(torch.stack([t_index, h_index, w_index]) + current_pos)
+            current_pos += max(llm_grid_h, llm_grid_w)
+
+        llm_positions = torch.cat(llm_pos_ids_list, dim=1).reshape(3, -1)
+        if attention_mask is not None:
+            position_ids[:, batch_idx, attention_mask[batch_idx].bool()] = llm_positions.to(position_ids.device)
+        else:
+            position_ids[:, batch_idx] = llm_positions.to(position_ids.device)
+        mrope_position_deltas.append(llm_positions.max() + 1 - len(current_input_ids))
+
+    mrope_position_deltas = torch.tensor(mrope_position_deltas, device=input_ids.device).unsqueeze(1)
+    return position_ids, mrope_position_deltas
+
+
+class Qwen35VLModel(MegatronModule):
+    def __init__(
+        self,
+        language_transformer_config,
+        language_transformer_layer_spec: ModuleSpec,
+        vision_transformer_config,
+        parallel_output: bool = True,
+        pre_process: bool = True,
+        post_process: bool = True,
+        add_encoder: bool = True,
+        add_decoder: bool = True,
+    ) -> None:
+        super().__init__(config=language_transformer_config)
+
+        self.pre_process = pre_process
+        self.post_process = post_process
+        self.add_encoder = add_encoder
+        self.add_decoder = add_decoder
+        self.encoder_hidden_state = None
+        self.vision_model = None
+        self.language_model = None
+        self.image_token_id = language_transformer_config.image_token_id
+        self.video_token_id = language_transformer_config.video_token_id
+        self.vision_start_token_id = language_transformer_config.vision_start_token_id
+        self.share_embeddings_and_output_weights = False
+
+        deepstack_visual_indexes = getattr(vision_transformer_config, "deepstack_visual_indexes", [])
+        assert not deepstack_visual_indexes, "Qwen3.5 local bridge does not support deepstack visual features"
+
+        if self.pre_process:
+            self.vision_model = Qwen3_5VisionModel._from_config(vision_transformer_config)
+            hook_hf_module_setattr_for_tp_grad_sync(self.vision_model)
+            if torch.cuda.is_available():
+                self.vision_model = self.vision_model.to("cuda")
+
+        self.language_model = Qwen35VLGPTModel(
+            config=language_transformer_config,
+            transformer_layer_spec=language_transformer_layer_spec,
+            vocab_size=language_transformer_config.vocab_size,
+            max_sequence_length=language_transformer_config.language_max_sequence_length,
+            parallel_output=parallel_output,
+            position_embedding_type="mrope",
+            rotary_percent=language_transformer_config.rotary_percent,
+            pre_process=self.pre_process,
+            post_process=self.post_process,
+            rotary_base=language_transformer_config.rotary_base,
+            fp16_lm_cross_entropy=language_transformer_config.fp16_lm_cross_entropy,
+            share_embeddings_and_output_weights=language_transformer_config.share_embeddings_and_output_weights,
+            scatter_embedding_sequence_parallel=False,
+        )
+        self.share_embeddings_and_output_weights = self.language_model.share_embeddings_and_output_weights
+
+    def shared_embedding_or_output_weight(self):
+        if self.add_decoder:
+            return self.language_model.shared_embedding_or_output_weight()
+        return None
+
+    def set_input_tensor(self, input_tensor) -> None:
+        if not isinstance(input_tensor, list):
+            input_tensor = [input_tensor]
+        assert len(input_tensor) == 1, "input_tensor should only be length 1 for Qwen3.5 VL"
+
+        if self.pre_process:
+            self.encoder_hidden_state = input_tensor[0]
+        else:
+            self.language_model.set_input_tensor(input_tensor[0])
+
+    def freeze(
+        self,
+        freeze_language_model: bool,
+        freeze_vision_model: bool,
+        freeze_vision_projection: bool,
+    ):
+        modules = []
+        if freeze_language_model and self.language_model is not None:
+            modules.append(self.language_model)
+        if freeze_vision_model and self.vision_model is not None:
+            if hasattr(self.vision_model, "patch_embed"):
+                modules.append(self.vision_model.patch_embed)
+            if hasattr(self.vision_model, "blocks"):
+                modules.append(self.vision_model.blocks)
+            if hasattr(self.vision_model, "pos_embed"):
+                modules.append(self.vision_model.pos_embed)
+            if hasattr(self.vision_model, "rotary_pos_emb"):
+                modules.append(self.vision_model.rotary_pos_emb)
+        if freeze_vision_projection and self.vision_model is not None and hasattr(self.vision_model, "merger"):
+            modules.append(self.vision_model.merger)
+        for module in modules:
+            for param in module.parameters():
+                param.requires_grad = False
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor = None,
+        attention_mask: torch.Tensor = None,
+        labels: torch.Tensor = None,
+        loss_mask: torch.Tensor = None,
+        inference_params: BaseInferenceContext = None,
+        packed_seq_params: PackedSeqParams = None,
+        extra_block_kwargs: dict = None,
+        pixel_values: torch.Tensor = None,
+        pixel_values_videos: torch.Tensor = None,
+        image_grid_thw: torch.Tensor = None,
+        video_grid_thw: torch.Tensor = None,
+        image_input_mask: torch.Tensor = None,
+        mm_token_type_ids: torch.Tensor = None,
+    ) -> torch.Tensor:
+        assert pixel_values_videos is None and video_grid_thw is None, "Qwen3.5 local bridge does not support video"
+        assert inference_params is None, "Qwen3.5 local bridge does not support inference"
+
+        position_ids = None
+        image_mask = None
+
+        if self.pre_process:
+            if image_grid_thw is not None:
+                image_mask = image_input_mask
+                if image_mask is None:
+                    image_mask = (input_ids == self.image_token_id).contiguous()
+
+            vision_embeds = None
+            if image_grid_thw is not None and image_grid_thw.shape[0] > 0:
+                vision_output = self.vision_model(
+                    hidden_states=pixel_values,
+                    grid_thw=image_grid_thw,
+                )
+                vision_embeds = vision_output.pooler_output
+
+            combined_embeddings = self.language_model.embedding(
+                input_ids=input_ids,
+                position_ids=None,
+            ).clone()
+
+            if vision_embeds is not None:
+                if image_mask is None:
+                    raise ValueError("image_mask is required when image embeddings are present")
+                if int(image_mask.sum().item()) != int(vision_embeds.shape[0]):
+                    raise ValueError(
+                        f"Image placeholder count ({int(image_mask.sum().item())}) does not match image embeds "
+                        f"({int(vision_embeds.shape[0])})"
+                    )
+                combined_embeddings = combined_embeddings.transpose(0, 1).contiguous()
+                combined_embeddings[image_mask] = vision_embeds.to(
+                    device=combined_embeddings.device,
+                    dtype=combined_embeddings.dtype,
+                )
+                combined_embeddings = combined_embeddings.transpose(0, 1).contiguous()
+
+            if self.config.sequence_parallel:
+                combined_embeddings = tensor_parallel.scatter_to_sequence_parallel_region(combined_embeddings)
+                combined_embeddings = combined_embeddings.contiguous()
+        else:
+            combined_embeddings = None
+
+        if mm_token_type_ids is not None and mm_token_type_ids.dim() == 1:
+            mm_token_type_ids = mm_token_type_ids.unsqueeze(0)
+
+        cu_seqlens_padded = None
+        if packed_seq_params is not None:
+            if packed_seq_params.cu_seqlens_q_padded is not None:
+                cu_seqlens_padded = packed_seq_params.cu_seqlens_q_padded
+            else:
+                cu_seqlens_padded = packed_seq_params.cu_seqlens_q
+
+        if position_ids is None:
+            if mm_token_type_ids is None or cu_seqlens_padded is None:
+                position_ids, _ = get_qwen35_rope_index(
+                    self.config.spatial_merge_size,
+                    self.image_token_id,
+                    self.video_token_id,
+                    self.vision_start_token_id,
+                    input_ids,
+                    mm_token_type_ids=mm_token_type_ids,
+                    image_grid_thw=image_grid_thw,
+                    video_grid_thw=video_grid_thw,
+                    attention_mask=attention_mask,
+                    packed_seq_params=packed_seq_params,
+                )
+            else:
+                batch_size = mm_token_type_ids.shape[0]
+                input_ids_for_rope_index = _thd_to_bshd(
+                    input_ids,
+                    cu_seqlens_padded,
+                    batch_size=batch_size,
+                )
+                position_ids, _ = get_qwen35_rope_index(
+                    self.config.spatial_merge_size,
+                    self.image_token_id,
+                    self.video_token_id,
+                    self.vision_start_token_id,
+                    input_ids_for_rope_index,
+                    mm_token_type_ids=mm_token_type_ids,
+                    image_grid_thw=image_grid_thw,
+                    video_grid_thw=video_grid_thw,
+                    attention_mask=None,
+                    packed_seq_params=packed_seq_params,
+                )
+                position_ids = _bshd_to_thd(
+                    position_ids.permute(1, 2, 0),
+                    cu_seqlens_padded,
+                    batch_size=batch_size,
+                ).permute(2, 0, 1)
+
+        return self.language_model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            labels=labels,
+            decoder_input=combined_embeddings,
+            packed_seq_params=packed_seq_params,
+            loss_mask=loss_mask,
+            extra_block_kwargs=extra_block_kwargs,
+            visual_pos_masks=None,
+            deepstack_visual_embeds=None,
+        )
+
+
+def _get_qwen35_layer_spec(provider: "Qwen35VLModelProvider", vp_stage=None):
+    config = provider
+    if not getattr(config, "num_experts", None):
+        config.moe_layer_freq = [0] * config.num_layers
+
+    kwargs = {"use_transformer_engine": True}
+    if vp_stage is not None:
+        kwargs["vp_stage"] = vp_stage
+    transformer_layer_spec = get_gpt_decoder_block_spec(config, **kwargs)
+
+    assert config.pipeline_model_parallel_layout is None, "pipeline layout override is not supported"
+
+    num_layers_to_build = get_num_layers_to_build(config, vp_stage=vp_stage)
+    offset = get_transformer_layer_offset(config, vp_stage=vp_stage)
+    layer_types = list(getattr(provider.hf_text_config, "layer_types", []))
+    if not layer_types:
+        interval = getattr(provider.hf_text_config, "full_attention_interval", 4)
+        layer_types = [
+            "full_attention" if (i + 1) % interval == 0 else "linear_attention"
+            for i in range(provider.hf_text_config.num_hidden_layers)
+        ]
+
+    replaced_linear_layers = []
+    for layer_id in range(num_layers_to_build):
+        if layer_types[layer_id + offset] == "linear_attention":
+            layer_specs = copy.deepcopy(transformer_layer_spec.layer_specs[layer_id])
+            layer_specs.submodules.self_attention = ModuleSpec(
+                module=Qwen35BridgeAttention,
+                params={
+                    "hf_config": provider.hf_text_config,
+                    "sequence_parallel": provider.sequence_parallel,
+                },
+            )
+            transformer_layer_spec.layer_specs[layer_id] = layer_specs
+            replaced_linear_layers.append(layer_id + offset)
+
+    if _should_log_qwen35_bridge_debug():
+        logger.warning(
+            "Qwen35 bridge debug: _get_qwen35_layer_spec file=%s vp_stage=%s "
+            "offset=%s num_layers_to_build=%s layer_types_head=%s replaced_linear_layers=%s",
+            _get_qwen35_layer_spec.__code__.co_filename,
+            vp_stage,
+            offset,
+            num_layers_to_build,
+            layer_types[:32],
+            replaced_linear_layers,
+        )
+
+    return transformer_layer_spec
+
+
+@dataclass
+class Qwen35VLModelProvider(Qwen3VLModelProvider):
+    hf_checkpoint_path: Optional[str] = None
+    deepstack_visual_indexes: List[int] = field(default_factory=list)
+
+    def provide(self, pre_process=None, post_process=None, vp_stage=None):
+        language_transformer_layer_spec = _get_qwen35_layer_spec(self, vp_stage=vp_stage)
+
+        model = Qwen35VLModel(
+            language_transformer_config=self,
+            language_transformer_layer_spec=language_transformer_layer_spec,
+            vision_transformer_config=self.vision_config,
+            pre_process=pre_process,
+            post_process=post_process,
+        )
+
+        if self.freeze_language_model or self.freeze_vision_model or self.freeze_vision_projection:
+            model.freeze(
+                freeze_language_model=self.freeze_language_model,
+                freeze_vision_model=self.freeze_vision_model,
+                freeze_vision_projection=self.freeze_vision_projection,
+            )
+
+        return model
+
+    def provide_language_model(self, pre_process=None, post_process=None, vp_stage=None):
+        language_transformer_layer_spec = _get_qwen35_layer_spec(self, vp_stage=vp_stage)
+        return Qwen35VLGPTModel(
+            config=self,
+            transformer_layer_spec=language_transformer_layer_spec,
+            vocab_size=self.vocab_size,
+            max_sequence_length=self.language_max_sequence_length,
+            parallel_output=True,
+            position_embedding_type="mrope",
+            rotary_percent=self.rotary_percent,
+            pre_process=pre_process,
+            post_process=post_process,
+            rotary_base=self.rotary_base,
+            fp16_lm_cross_entropy=self.fp16_lm_cross_entropy,
+            share_embeddings_and_output_weights=self.share_embeddings_and_output_weights,
+            scatter_embedding_sequence_parallel=False,
+            vp_stage=vp_stage,
+        )

--- a/slime/slime_plugins/megatron_bridge/qwen3_5.py
+++ b/slime/slime_plugins/megatron_bridge/qwen3_5.py
@@ -1,15 +1,3 @@
-"""
-Qwen3.5 bridge for megatron.bridge.
-
-Registers `Qwen3_5ForConditionalGeneration` so that `AutoBridge.from_hf_pretrained`
-recognises Qwen3.5 checkpoints and can provide a Megatron-compatible GPT model +
-weight mappings.
-
-Qwen3.5 is a VLM with a hybrid (linear + full attention) text backbone.
-For training we only use the text backbone, so this bridge delegates to the
-existing Qwen3 provider infrastructure and adds linear-attention weight passthrough.
-"""
-
 from __future__ import annotations
 
 import logging
@@ -17,152 +5,190 @@ import logging
 import torch
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
-from megatron.bridge.models.conversion.param_mapping import AutoMapping, GatedMLPMapping, QKVMapping
-from megatron.core.models.gpt import GPTModel
+from megatron.bridge.models.conversion.param_mapping import (
+    AutoMapping,
+    GatedMLPMapping,
+    QKVMapping,
+    ReplicatedMapping,
+)
+
+from slime_plugins.megatron_bridge.qwen35_vl import Qwen35VLModel, Qwen35VLModelProvider
 
 logger = logging.getLogger(__name__)
 
-# Use a string so we don't need transformers to have Qwen3.5 at import time
-_Qwen3_5HF = "Qwen3_5ForConditionalGeneration"
+try:
+    from transformers import Qwen3_5ForConditionalGeneration
+except ImportError:
+    Qwen3_5ForConditionalGeneration = "Qwen3_5ForConditionalGeneration"
 
 
-def _get_text_config(hf_config):
-    """Unwrap text_config from VLM config if present."""
-    return getattr(hf_config, "text_config", hf_config)
-
-
-@MegatronModelBridge.register_bridge(source=_Qwen3_5HF, target=GPTModel)
-class MegatronQwen35Bridge(MegatronModelBridge):
-    """Bridge between HuggingFace Qwen3.5 and Megatron GPTModel."""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+@MegatronModelBridge.register_bridge(source=Qwen3_5ForConditionalGeneration, target=Qwen35VLModel)
+class MegatronQwen35VLBridge(MegatronModelBridge):
+    def __init__(self):
+        super().__init__()
         self.hf_pretrained = None
 
     def load_weights_hf_to_megatron(self, hf_pretrained, model):
-        """Store hf_pretrained before calling parent's load method."""
         self.hf_pretrained = hf_pretrained
         return super().load_weights_hf_to_megatron(hf_pretrained, model)
 
-    def provider_bridge(self, hf_pretrained):
-        """Create a GPT ModelProvider from Qwen3.5 HF config."""
-        from megatron.bridge.models.qwen.qwen_provider import Qwen3ModelProvider
-
+    def provider_bridge(self, hf_pretrained) -> Qwen35VLModelProvider:
         hf_config = hf_pretrained.config
-        text_config = _get_text_config(hf_config)
+        text_config = hf_config.text_config
+        vision_config = hf_config.vision_config
+        provider_kwargs = self.hf_config_to_provider_kwargs(text_config)
+        vision_config.torch_dtype = provider_kwargs.get("params_dtype", torch.float32)
 
-        model_dtype = self.dtype_from_hf(text_config, default=torch.bfloat16)
+        provider = Qwen35VLModelProvider(**provider_kwargs)
 
-        rope_params = getattr(text_config, "rope_parameters", {}) or {}
-        rope_theta = rope_params.get("rope_theta", getattr(text_config, "rope_theta", 10000000))
-        partial_rotary_factor = rope_params.get(
-            "partial_rotary_factor", getattr(text_config, "partial_rotary_factor", 0.25)
-        )
+        # For VLMs, tie_word_embeddings lives on the top-level config, not text_config.
+        provider.share_embeddings_and_output_weights = getattr(hf_config, "tie_word_embeddings", False)
 
-        provider = Qwen3ModelProvider(
-            num_layers=text_config.num_hidden_layers,
-            hidden_size=text_config.hidden_size,
-            ffn_hidden_size=text_config.intermediate_size,
-            num_attention_heads=text_config.num_attention_heads,
-            num_query_groups=text_config.num_key_value_heads,
-            kv_channels=getattr(text_config, "head_dim", 256),
-            init_method_std=getattr(text_config, "initializer_range", 0.02),
-            layernorm_epsilon=text_config.rms_norm_eps,
-            gated_linear_unit=True,
-            make_vocab_size_divisible_by=self.make_vocab_size_divisible_by(text_config.vocab_size),
-            rotary_base=rope_theta,
-            rotary_percent=partial_rotary_factor,
-            share_embeddings_and_output_weights=getattr(text_config, "tie_word_embeddings", True),
-            vocab_size=text_config.vocab_size,
-            seq_length=getattr(text_config, "max_position_embeddings", 262144),
-            fp16=(model_dtype == torch.float16),
-            bf16=(model_dtype == torch.bfloat16),
-            params_dtype=model_dtype,
-            # Qwen3.5 specific
-            qk_layernorm=True,
-            attention_output_gate=True,
-        )
+        provider.normalization = "RMSNorm"
+        provider.gated_linear_unit = True
+        provider.add_qkv_bias = getattr(text_config, "attention_bias", False)
+        provider.add_bias_linear = False
+        provider.qk_layernorm = True
+        provider.hidden_dropout = 0.0
 
+        provider.layernorm_zero_centered_gamma = True
+        provider.attention_output_gate = True
+        provider.experimental_attention_variant = "gated_delta_net"
+        provider.linear_attention_freq = getattr(text_config, "full_attention_interval", 4)
+        provider.rotary_percent = getattr(text_config, "rope_parameters", {}).get("partial_rotary_factor", 0.25)
+
+        provider.linear_conv_kernel_dim = getattr(text_config, "linear_conv_kernel_dim", 4)
+        provider.linear_key_head_dim = getattr(text_config, "linear_key_head_dim", 128)
+        provider.linear_value_head_dim = getattr(text_config, "linear_value_head_dim", 128)
+        provider.linear_num_key_heads = getattr(text_config, "linear_num_key_heads", 16)
+        provider.linear_num_value_heads = getattr(text_config, "linear_num_value_heads", 48)
+
+        provider.position_embedding_type = "mrope"
+        provider.vision_config = vision_config
+        provider.hf_text_config = text_config
+        provider.head_dim = getattr(text_config, "head_dim", 256)
+        provider.bos_token_id = getattr(text_config, "bos_token_id", 248045)
+        provider.eos_token_id = getattr(text_config, "eos_token_id", 248044)
+        provider.vision_start_token_id = getattr(hf_config, "vision_start_token_id", 248053)
+        provider.vision_end_token_id = getattr(hf_config, "vision_end_token_id", 248054)
+        provider.image_token_id = getattr(hf_config, "image_token_id", 248056)
+        provider.video_token_id = getattr(hf_config, "video_token_id", 248057)
+        provider.mrope_section = getattr(text_config, "rope_scaling", {}).get("mrope_section", [11, 11, 10])
+
+        if provider.mtp_num_layers:
+            provider.mtp_loss_scaling_factor = 0.1
+
+        provider.hf_checkpoint_path = getattr(hf_pretrained, "name_or_path", getattr(hf_config, "_name_or_path", None))
+        provider.deepstack_visual_indexes = list(getattr(vision_config, "deepstack_visual_indexes", []))
         return provider
 
     def mapping_registry(self) -> MegatronMappingRegistry:
-        """Weight mappings from HF Qwen3.5 to Megatron format.
-
-        Qwen3.5 uses model.language_model.layers prefix (VLM structure) for weights,
-        but when loaded as text-only it may use model.layers prefix.
-        We handle both via the passthrough linear attention mappings.
-        """
-        # Determine prefix: VLM uses model.language_model, text-only uses model
-        if self.hf_pretrained is None:
-            raise RuntimeError(
-                "hf_pretrained is not set. Ensure load_weights_hf_to_megatron() "
-                "is called before mapping_registry()."
-            )
-        hf_config = self.hf_pretrained.config
-        text_config = _get_text_config(hf_config)
-        # Check if it's a VLM config (has text_config attribute)
-        is_vlm = hasattr(hf_config, "text_config")
-        pfx = "model.language_model" if is_vlm else "model"
-
-        param_mappings = {
-            # Embeddings and output
-            f"embedding.word_embeddings.weight": f"{pfx}.embed_tokens.weight",
-            f"output_layer.weight": "lm_head.weight",
-            f"decoder.final_layernorm.weight": f"{pfx}.norm.weight",
-            # Attention: input layernorm (TE fused)
-            f"decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": f"{pfx}.layers.*.input_layernorm.weight",
-            # Attention: separate input layernorm
-            f"decoder.layers.*.input_layernorm.weight": f"{pfx}.layers.*.input_layernorm.weight",
-            # Attention output projection
-            f"decoder.layers.*.self_attention.linear_proj.weight": f"{pfx}.layers.*.self_attn.o_proj.weight",
-            # QK norms
-            f"decoder.layers.*.self_attention.q_layernorm.weight": f"{pfx}.layers.*.self_attn.q_norm.weight",
-            f"decoder.layers.*.self_attention.k_layernorm.weight": f"{pfx}.layers.*.self_attn.k_norm.weight",
-            # Post-attention layernorm
-            f"decoder.layers.*.mlp.linear_fc1.layer_norm_weight": f"{pfx}.layers.*.post_attention_layernorm.weight",
-            f"decoder.layers.*.pre_mlp_layernorm.weight": f"{pfx}.layers.*.post_attention_layernorm.weight",
-            # Dense MLP output
-            f"decoder.layers.*.mlp.linear_fc2.weight": f"{pfx}.layers.*.mlp.down_proj.weight",
+        auto_param_mappings = {
+            "language_model.embedding.word_embeddings.weight": "model.language_model.embed_tokens.weight",
+            "language_model.output_layer.weight": "lm_head.weight",
+            "language_model.decoder.final_layernorm.weight": "model.language_model.norm.weight",
+            "language_model.decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "model.language_model.layers.*.post_attention_layernorm.weight",
+            "language_model.decoder.layers.*.mlp.linear_fc2.weight": "model.language_model.layers.*.mlp.down_proj.weight",
+            "language_model.decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": "model.language_model.layers.*.input_layernorm.weight",
+            "language_model.decoder.layers.*.self_attention.q_layernorm.weight": "model.language_model.layers.*.self_attn.q_norm.weight",
+            "language_model.decoder.layers.*.self_attention.k_layernorm.weight": "model.language_model.layers.*.self_attn.k_norm.weight",
+            "language_model.decoder.layers.*.self_attention.linear_proj.weight": "model.language_model.layers.*.self_attn.o_proj.weight",
         }
 
-        # Linear attention weights (passthrough — these live on the custom HF attention module)
-        linear_attn_weights = [
-            "input_layernorm.weight",
-            "linear_attn.A_log",
-            "linear_attn.conv1d.weight",
-            "linear_attn.dt_bias",
-            "linear_attn.in_proj_a.weight",
-            "linear_attn.in_proj_b.weight",
-            "linear_attn.in_proj_qkv.weight",
-            "linear_attn.in_proj_z.weight",
-            "linear_attn.norm.weight",
-            "linear_attn.out_proj.weight",
+        # These parameters belong to local HF-style submodules embedded in the Megatron model
+        # (`Qwen35BridgeAttention.linear_attn` and `Qwen3_5VisionModel`), not TP-aware
+        # Megatron layers. They should therefore be treated as replicated weights.
+        replicated_param_mappings = {
+            # Local bridge linear-attention layers use HF-style submodules, not Megatron GDN names.
+            "language_model.decoder.layers.*.self_attention.input_layernorm.weight": "model.language_model.layers.*.input_layernorm.weight",
+            "language_model.decoder.layers.*.self_attention.linear_attn.dt_bias": "model.language_model.layers.*.linear_attn.dt_bias",
+            "language_model.decoder.layers.*.self_attention.linear_attn.A_log": "model.language_model.layers.*.linear_attn.A_log",
+            "language_model.decoder.layers.*.self_attention.linear_attn.conv1d.weight": "model.language_model.layers.*.linear_attn.conv1d.weight",
+            "language_model.decoder.layers.*.self_attention.linear_attn.in_proj_qkv.weight": "model.language_model.layers.*.linear_attn.in_proj_qkv.weight",
+            "language_model.decoder.layers.*.self_attention.linear_attn.in_proj_z.weight": "model.language_model.layers.*.linear_attn.in_proj_z.weight",
+            "language_model.decoder.layers.*.self_attention.linear_attn.in_proj_b.weight": "model.language_model.layers.*.linear_attn.in_proj_b.weight",
+            "language_model.decoder.layers.*.self_attention.linear_attn.in_proj_a.weight": "model.language_model.layers.*.linear_attn.in_proj_a.weight",
+            "language_model.decoder.layers.*.self_attention.linear_attn.norm.weight": "model.language_model.layers.*.linear_attn.norm.weight",
+            "language_model.decoder.layers.*.self_attention.linear_attn.out_proj.weight": "model.language_model.layers.*.linear_attn.out_proj.weight",
+            # Local bridge vision model is the HF module directly, so it exposes blocks.* and merger.norm.*.
+            "vision_model.blocks.*.norm1.weight": "model.visual.blocks.*.norm1.weight",
+            "vision_model.blocks.*.norm1.bias": "model.visual.blocks.*.norm1.bias",
+            "vision_model.blocks.*.norm2.weight": "model.visual.blocks.*.norm2.weight",
+            "vision_model.blocks.*.norm2.bias": "model.visual.blocks.*.norm2.bias",
+            "vision_model.blocks.*.attn.qkv.weight": "model.visual.blocks.*.attn.qkv.weight",
+            "vision_model.blocks.*.attn.qkv.bias": "model.visual.blocks.*.attn.qkv.bias",
+            "vision_model.blocks.*.attn.proj.weight": "model.visual.blocks.*.attn.proj.weight",
+            "vision_model.blocks.*.attn.proj.bias": "model.visual.blocks.*.attn.proj.bias",
+            "vision_model.blocks.*.mlp.linear_fc1.weight": "model.visual.blocks.*.mlp.linear_fc1.weight",
+            "vision_model.blocks.*.mlp.linear_fc1.bias": "model.visual.blocks.*.mlp.linear_fc1.bias",
+            "vision_model.blocks.*.mlp.linear_fc2.weight": "model.visual.blocks.*.mlp.linear_fc2.weight",
+            "vision_model.blocks.*.mlp.linear_fc2.bias": "model.visual.blocks.*.mlp.linear_fc2.bias",
+            "vision_model.patch_embed.proj.weight": "model.visual.patch_embed.proj.weight",
+            "vision_model.patch_embed.proj.bias": "model.visual.patch_embed.proj.bias",
+            "vision_model.pos_embed.weight": "model.visual.pos_embed.weight",
+            "vision_model.merger.norm.weight": "model.visual.merger.norm.weight",
+            "vision_model.merger.norm.bias": "model.visual.merger.norm.bias",
+            "vision_model.merger.linear_fc1.weight": "model.visual.merger.linear_fc1.weight",
+            "vision_model.merger.linear_fc1.bias": "model.visual.merger.linear_fc1.bias",
+            "vision_model.merger.linear_fc2.weight": "model.visual.merger.linear_fc2.weight",
+            "vision_model.merger.linear_fc2.bias": "model.visual.merger.linear_fc2.bias",
+        }
+
+        mapping_list = [
+            AutoMapping(megatron_param=megatron_param, hf_param=hf_param)
+            for megatron_param, hf_param in auto_param_mappings.items()
         ]
-        for w in linear_attn_weights:
-            param_mappings[f"decoder.layers.*.self_attention.{w}"] = f"{pfx}.layers.*.{w}"
-
-
-        mapping_list = []
-        for megatron_param, hf_param in param_mappings.items():
-            mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
-
-        # QKV mapping (for full attention layers)
-        mapping_list.append(
-            QKVMapping(
-                megatron_param=f"decoder.layers.*.self_attention.linear_qkv.weight",
-                q=f"{pfx}.layers.*.self_attn.q_proj.weight",
-                k=f"{pfx}.layers.*.self_attn.k_proj.weight",
-                v=f"{pfx}.layers.*.self_attn.v_proj.weight",
-            )
+        mapping_list.extend(
+            [
+                ReplicatedMapping(megatron_param=megatron_param, hf_param=hf_param)
+                for megatron_param, hf_param in replicated_param_mappings.items()
+            ]
+        )
+        mapping_list.extend(
+            [
+                QKVMapping(
+                    megatron_param="language_model.decoder.layers.*.self_attention.linear_qkv.weight",
+                    q="model.language_model.layers.*.self_attn.q_proj.weight",
+                    k="model.language_model.layers.*.self_attn.k_proj.weight",
+                    v="model.language_model.layers.*.self_attn.v_proj.weight",
+                ),
+                GatedMLPMapping(
+                    megatron_param="language_model.decoder.layers.*.mlp.linear_fc1.weight",
+                    gate="model.language_model.layers.*.mlp.gate_proj.weight",
+                    up="model.language_model.layers.*.mlp.up_proj.weight",
+                ),
+            ]
         )
 
-        # Gated MLP (gate + up fused)
-        mapping_list.append(
-            GatedMLPMapping(
-                megatron_param=f"decoder.layers.*.mlp.linear_fc1.weight",
-                gate=f"{pfx}.layers.*.mlp.gate_proj.weight",
-                up=f"{pfx}.layers.*.mlp.up_proj.weight",
-            )
+        mtp_param_mappings = {
+            "language_model.mtp.layers.0.eh_proj.weight": "mtp.fc.weight",
+            "language_model.mtp.layers.0.enorm.weight": "mtp.pre_fc_norm_embedding.weight",
+            "language_model.mtp.layers.0.hnorm.weight": "mtp.pre_fc_norm_hidden.weight",
+            "language_model.mtp.layers.0.final_layernorm.weight": "mtp.norm.weight",
+            "language_model.mtp.layers.0.mtp_model_layer.mlp.linear_fc1.layer_norm_weight": "mtp.layers.0.post_attention_layernorm.weight",
+            "language_model.mtp.layers.0.mtp_model_layer.mlp.linear_fc2.weight": "mtp.layers.0.mlp.down_proj.weight",
+            "language_model.mtp.layers.0.mtp_model_layer.self_attention.linear_qkv.layer_norm_weight": "mtp.layers.0.input_layernorm.weight",
+            "language_model.mtp.layers.0.mtp_model_layer.self_attention.q_layernorm.weight": "mtp.layers.0.self_attn.q_norm.weight",
+            "language_model.mtp.layers.0.mtp_model_layer.self_attention.k_layernorm.weight": "mtp.layers.0.self_attn.k_norm.weight",
+            "language_model.mtp.layers.0.mtp_model_layer.self_attention.linear_proj.weight": "mtp.layers.0.self_attn.o_proj.weight",
+        }
+        for megatron_param, hf_param in mtp_param_mappings.items():
+            mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
+
+        mapping_list.extend(
+            [
+                QKVMapping(
+                    megatron_param="language_model.mtp.layers.*.mtp_model_layer.self_attention.linear_qkv.weight",
+                    q="mtp.layers.*.self_attn.q_proj.weight",
+                    k="mtp.layers.*.self_attn.k_proj.weight",
+                    v="mtp.layers.*.self_attn.v_proj.weight",
+                ),
+                GatedMLPMapping(
+                    megatron_param="language_model.mtp.layers.*.mtp_model_layer.mlp.linear_fc1.weight",
+                    gate="mtp.layers.*.mlp.gate_proj.weight",
+                    up="mtp.layers.*.mlp.up_proj.weight",
+                ),
+            ]
         )
 
         return MegatronMappingRegistry(*mapping_list)


### PR DESCRIPTION
# feat: add Qwen3.5-4B GUI RL support

## Summary

This PR adds Qwen3.5-4B support to the GUI-RL training stack.

It includes:

- `gui-rl/gui_qwen35_4b_rl.sh`
- `gui-rl/gui_qwen35_4b_prm_rl.sh`
- `gui-rl/agents/qwen35_agent.py`
- Qwen3.5 SGLang loading
- Qwen3.5 Megatron bridge registration
- Qwen3.5 Megatron-to-HF conversion support

It also includes an offline testing path:

- `gui-rl/gui_qwen35_4b_agentnet_rl.sh`
- `gui-rl/generate_with_agentnet.py`
- `gui-rl/gui_data_source.py`

This path is used to test Qwen3.5 with pre-recorded GUI trajectories in an offline setting.

## What's Changed

- add Qwen3.5 GUI RL launcher
- add Qwen3.5 GUI PRM RL launcher
- add Qwen3.5 GUI agent
- add Qwen3.5 VL model script
- add Qwen3.5 bridge registration
- add Qwen3.5 Megatron-to-HF conversion support
- align Ray runtime env with the external Megatron-Bridge layout
- add an offline AgentNet replay path for migration testing

## Environment

Prepare the external dependency first.

Megatron-Bridge version used for this work:

```bash
git clone --recursive https://github.com/NVIDIA-NeMo/Megatron-Bridge.git Megatron-Bridge-qwen35
cd Megatron-Bridge-qwen35
git checkout ebca893607d48388a6c083bfc143bc05621cc753
git submodule update --init --recursive

# Megatron-LM comes from the Megatron-Bridge submodule
cd 3rdparty/Megatron-LM
git checkout 17a67b9a97fb11a75933fd7f76ad76e1ac98a53d
cd /path/to/Megatron-Bridge-qwen35

python3 -m pip uninstall -y megatron-bridge megatron-core mbridge
python3 -m pip install --no-deps -e ./3rdparty/Megatron-LM
python3 -m pip install --no-deps -e ./
```

Then install dependencies:

```bash
pip install transformers==5.3.0 --force-reinstall
pip install peft numpy==1.26.4
pip install nvidia-cudnn-cu12==9.16.0.29
```

Set:

```bash
export OFFICIAL_MBRIDGE_ROOT=./Megatron-Bridge-qwen35
export OFFICIAL_MBRIDGE_SRC=${OFFICIAL_MBRIDGE_ROOT}/src
export MEGATRON_LM_PATH=${OFFICIAL_MBRIDGE_ROOT}/3rdparty/Megatron-LM

export NVIDIA_BIN_DIR=<nvidia-bin-dir>
export NVIDIA_LIB_DIR=<nvidia-lib-dir>
export PATH=${NVIDIA_BIN_DIR}:${PATH}
export LD_LIBRARY_PATH=${NVIDIA_LIB_DIR}:${LD_LIBRARY_PATH:-}
```

Offline AgentNet data from: <https://huggingface.co/datasets/xlangai/AgentNet>
## Verification

The AgentNet offline multimodal data loading, rollout, and training path with Qwen3.5 passed.
