### PR TITLE
fix: repad rollout samples after sample filtering

### DIFF
--- a/slime/slime/ray/rollout.py
+++ b/slime/slime/ray/rollout.py
@@ -649,12 +649,13 @@ class RolloutManager:
         samples = _drop_removed_samples(samples)
         samples = self._drop_constant_reward_groups(samples)
         dp_size = self.train_parallel_config["dp_size"]
-        if len(samples) < dp_size:
+        remainder = len(samples) % dp_size
+        if len(samples) < dp_size or remainder != 0:
             logger.warning(
                 "Injecting %d dummy samples.",
-                dp_size - len(samples),
+                dp_size - remainder,
             )
-            samples.extend(_make_dummy_samples(dp_size - len(samples)))
+            samples.extend(_make_dummy_samples(dp_size - remainder))
 
         raw_rewards, rewards = self._post_process_rewards(samples)
 


### PR DESCRIPTION
## Summary

This change pads the filtered samples to the next multiple of `dp_size` before reward post-processing.