### PR TITLE
feat(combine): add Megatron-based PRM teacher for OPD distillation

### DIFF
--- a/openclaw-combine/combine_loss.py
+++ b/openclaw-combine/combine_loss.py
@@ -3,8 +3,21 @@
 Both branches use the same PPO-style clipped policy gradient objective,
 matching SLIME's ``policy_loss_function``, but with different advantages:
 
-- OPD samples: advantage = teacher_logp - old_logp  (token-level distillation)
+- OPD samples: advantage = teacher_logp - student_megatron_logp (token-level)
 - RL  samples: advantage = reward broadcast          (GRPO-style)
+
+The OPD *student* side is always Megatron ``batch["log_probs"]`` (recomputed
+on the training engine), not ``rollout_log_probs``, so it matches the
+student log-p engine regardless of ``--use-rollout-logprobs``.
+
+Teacher log-p source (env ``OPENCLAW_COMBINE_OPD_TEACHER_SOURCE``):
+
+- ``megatron`` (default): ``batch["prm_teacher_log_probs"]`` computed by
+  the PRM teacher model loaded via ``--prm-teacher-load`` through the same
+  Megatron code path as the student. Independent of ``--ref-load``.
+- ``inference``: ``batch["teacher_log_probs"]`` from rollout/OPD
+  (e.g. PRM SGLang prefill logprobs). Has numerical mismatch with Megatron
+  student log-probs.
 
 OPD samples carry reward=0 so GRPO advantage=0; RL samples carry
 teacher_logp ≈ rollout_logp so teacher advantage ≈ 0.  The combined
@@ -22,6 +35,18 @@ import torch
 
 from slime.backends.megatron_utils.loss import get_log_probs_and_entropy
 from slime.utils.ppo_utils import compute_approx_kl, compute_policy_loss
+
+
+def _opd_teacher_source() -> str:
+    v = os.getenv("OPENCLAW_COMBINE_OPD_TEACHER_SOURCE", "megatron").strip().lower()
+    if v in ("infer", "inference", "sglang", "rollout"):
+        return "inference"
+    if v in ("megatron", "mcore"):
+        return "megatron"
+    raise ValueError(
+        "OPENCLAW_COMBINE_OPD_TEACHER_SOURCE must be 'inference' or 'megatron', "
+        f"got {v!r}"
+    )
 
 
 def combine_loss_function(
@@ -55,21 +80,51 @@ def combine_loss_function(
     new_log_probs = torch.cat(log_probs_and_entropy["log_probs"], dim=0)
     old_log_probs = torch.cat(old_log_probs_list, dim=0)
 
-    # ---- OPD teacher advantages ----
-    teacher_log_probs_list = batch.get("teacher_log_probs")
-    if teacher_log_probs_list is not None:
-        device = new_log_probs.device
+    # ---- OPD: teacher vs student (student always Megatron log_probs) ----
+    device = new_log_probs.device
+    student_log_probs_list = batch["log_probs"]
+    teacher_source = _opd_teacher_source()
+    if teacher_source == "inference":
+        teacher_log_probs_list = batch.get("teacher_log_probs")
+    else:
+        teacher_log_probs_list = batch.get("prm_teacher_log_probs")
+        if teacher_log_probs_list is None or len(teacher_log_probs_list) == 0:
+            raise RuntimeError(
+                "OPENCLAW_COMBINE_OPD_TEACHER_SOURCE=megatron requires "
+                "batch['prm_teacher_log_probs']. Set --prm-teacher-load to "
+                "the Megatron checkpoint of the PRM teacher model."
+            )
+
+    if teacher_log_probs_list is not None and len(teacher_log_probs_list) > 0:
         teacher_advantages = torch.cat(
             [
-                t.to(device=device) - o.to(device=device)
-                for t, o in zip(teacher_log_probs_list, old_log_probs_list)
+                t.to(device=device) - s.to(device=device)
+                for t, s in zip(teacher_log_probs_list, student_log_probs_list, strict=True)
             ],
             dim=0,
         )
     else:
         teacher_advantages = torch.zeros_like(grpo_advantages)
 
-    # ---- combine: w_opd * (teacher - old) + w_rl * grpo_advantage ----
+    teacher_cat = (
+        torch.cat(
+            [t.to(device=device) for t in teacher_log_probs_list],
+            dim=0,
+        )
+        if teacher_log_probs_list is not None and len(teacher_log_probs_list) > 0
+        else None
+    )
+    student_megatron_cat = torch.cat(
+        [s.to(device=device) for s in student_log_probs_list],
+        dim=0,
+    )
+    opd_teacher_student_logprob_abs_mean = None
+    if teacher_cat is not None and teacher_cat.numel() > 0:
+        opd_teacher_student_logprob_abs_mean = sum_of_sample_mean(
+            (teacher_cat - student_megatron_cat).abs()
+        )
+
+    # ---- combine: w_opd * (teacher - student_megatron) + w_rl * grpo_advantage ----
     w_opd = float(os.getenv("OPENCLAW_COMBINE_W_OPD", "1.0"))
     w_rl = float(os.getenv("OPENCLAW_COMBINE_W_RL", "1.0"))
     combined_advantages = w_opd * teacher_advantages + w_rl * grpo_advantages
@@ -136,5 +191,10 @@ def combine_loss_function(
         )
     if args.use_kl_loss:
         reported_loss["kl_loss"] = kl_loss.clone().detach()
+
+    if opd_teacher_student_logprob_abs_mean is not None:
+        reported_loss["opd_teacher_student_logprob_abs_mean"] = (
+            opd_teacher_student_logprob_abs_mean.clone().detach()
+        )
 
     return loss, reported_loss

--- a/openclaw-combine/openclaw_combine_api_server.py
+++ b/openclaw-combine/openclaw_combine_api_server.py
@@ -64,6 +64,12 @@ class OpenClawCombineAPIServer(OpenClawOPDAPIServer):
         sample.rollout_log_probs = turn_data["response_logprobs"]
         sample.teacher_log_probs = torch.tensor(teacher_log_probs, dtype=torch.float32)
 
+        teacher_tokens = opd_result.get("teacher_tokens")
+        if teacher_tokens is not None:
+            sample.teacher_tokens = teacher_tokens
+        else:
+            sample.teacher_tokens = prompt_ids + response_ids
+
         if self._use_topk_distillation:
             K = self.distill_topk
             topk_lp = opd_result.get("teacher_topk_log_probs") or []
@@ -122,6 +128,7 @@ class OpenClawCombineAPIServer(OpenClawOPDAPIServer):
         sample.loss_mask = [1] * len(response_ids)
         sample.rollout_log_probs = response_logprobs
         sample.teacher_log_probs = torch.tensor(response_logprobs, dtype=torch.float32)
+        sample.teacher_tokens = prompt_ids + response_ids
         sample.status = Sample.Status.COMPLETED
         sample.index = next(self._index_counter)
         sample.group_index = next(self._group_counter)

--- a/openclaw-combine/prm_teacher_postprocess.py
+++ b/openclaw-combine/prm_teacher_postprocess.py
@@ -1,0 +1,184 @@
+"""Fill ``rollout_data[\"teacher_log_probs_megatron\"]`` for OPD (Megatron-teacher mode).
+
+Runs as ``--rollout-data-postprocess-path`` after slime packs rollout tensors and
+before ``log_rollout_data``. **Does nothing** unless
+``OPENCLAW_COMBINE_OPD_TEACHER_SOURCE=megatron`` (or alias ``ref`` / ``mcore``).
+
+Uses **HuggingFace** causal LM on **OPENCLAW_PRM_TEACHER_HF_DEVICE** so the actor
+Megatron process does not load a second mcore model. Log-probs are for the same
+packed ``tokens`` / response span as training.
+
+Env: ``OPENCLAW_PRM_TEACHER_HF_DEVICE`` (e.g. ``6`` or ``cuda:6``) — must be a
+GPU not used by this process’s other work.
+
+If actor **data parallel > 1**, the hook skips (single HF device would race).
+
+Signature: ``postprocess_openclaw_prm_teacher(args, rollout_data)`` (2 args; slime
+falls back to ``(args)`` for older single-arg hooks).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from argparse import Namespace
+from typing import TYPE_CHECKING
+
+import torch
+import torch.distributed as dist
+
+if TYPE_CHECKING:
+    from slime.utils.types import RolloutBatch
+
+logger = logging.getLogger("openclaw.prm_teacher_postprocess")
+
+_prm_hf_model = None
+_prm_hf_tokenizer = None
+
+
+def _want_megatron_teacher() -> bool:
+    v = os.getenv("OPENCLAW_COMBINE_OPD_TEACHER_SOURCE", "inference").strip().lower()
+    return v in ("megatron", "ref", "mcore")
+
+
+def _hf_device() -> torch.device | None:
+    raw = os.getenv("OPENCLAW_PRM_TEACHER_HF_DEVICE", "").strip()
+    if not raw:
+        return None
+    if raw.startswith("cuda"):
+        return torch.device(raw)
+    return torch.device(f"cuda:{int(raw)}")
+
+
+def _get_teacher_model_path(args: Namespace) -> str | None:
+    # Prefer an explicit teacher/ref path. Falling back to prm_model_path can
+    # silently load a different judge model and blow up teacher-student log-p deltas.
+    for value in (
+        os.getenv("OPENCLAW_PRM_TEACHER_HF_MODEL_PATH"),
+        getattr(args, "ref_load", None),
+        os.getenv("REF_LOAD"),
+        getattr(args, "prm_model_path", None),
+        os.getenv("PRM_MODEL_PATH"),
+    ):
+        if value:
+            return str(value)
+    return None
+
+
+def _load_hf_prm(path: str, device: torch.device):
+    global _prm_hf_model, _prm_hf_tokenizer
+    if _prm_hf_model is not None:
+        return _prm_hf_model, _prm_hf_tokenizer
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(path, trust_remote_code=True)
+    dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+    model = AutoModelForCausalLM.from_pretrained(
+        path,
+        trust_remote_code=True,
+        torch_dtype=dtype,
+        device_map=None,
+    )
+    model.to(device)
+    model.eval()
+    _prm_hf_model = model
+    _prm_hf_tokenizer = tok
+    logger.info("Loaded PRM HF teacher on %s from %s", device, path)
+    return model, tok
+
+
+@torch.inference_mode()
+def _response_logprobs_hf(
+    model,
+    input_ids_1d: torch.Tensor,
+    response_len: int,
+    device: torch.device,
+    temperature: float = 1.0,
+) -> torch.Tensor:
+    if response_len <= 0:
+        return torch.zeros(0, dtype=torch.float32)
+    ids = input_ids_1d.to(device).unsqueeze(0)
+    out = model(ids)
+    logits = out.logits[0]
+    if temperature != 1.0:
+        logits = logits / temperature
+    logp = torch.log_softmax(logits.float(), dim=-1)
+    tlen = ids.size(1)
+    pl = tlen - response_len
+    lps: list[float] = []
+    for k in range(response_len):
+        pos = pl - 1 + k
+        tok = int(ids[0, pl + k].item())
+        lps.append(float(logp[pos, tok].item()))
+    return torch.tensor(lps, dtype=torch.float32)
+
+
+def postprocess_openclaw_prm_teacher(args: Namespace, rollout_data: RolloutBatch) -> None:
+    if not _want_megatron_teacher():
+        return
+
+    from megatron.core import mpu
+
+    if not mpu.is_pipeline_last_stage(ignore_virtual=True):
+        return
+
+    if mpu.get_data_parallel_world_size(with_context_parallel=False) > 1:
+        logger.warning(
+            "teacher_log_probs_megatron: data_parallel_world_size>1 unsupported; skip"
+        )
+        return
+
+    if "tokens" not in rollout_data or not rollout_data["tokens"]:
+        return
+
+    dev = _hf_device()
+    if dev is None:
+        logger.warning(
+            "OPENCLAW_COMBINE_OPD_TEACHER_SOURCE=megatron but OPENCLAW_PRM_TEACHER_HF_DEVICE "
+            "unset; set e.g. OPENCLAW_PRM_TEACHER_HF_DEVICE=6 (free GPU). Skip."
+        )
+        return
+
+    path = _get_teacher_model_path(args)
+    if not path:
+        logger.warning(
+            "teacher HF model path missing; set OPENCLAW_PRM_TEACHER_HF_MODEL_PATH "
+            "or provide ref_load / REF_LOAD. Skip teacher log-p."
+        )
+        return
+
+    lengths = [int(x) for x in rollout_data["response_lengths"]]
+    tp_world = mpu.get_tensor_model_parallel_world_size()
+    tp_rank = mpu.get_tensor_model_parallel_rank()
+    tp_group = mpu.get_tensor_model_parallel_group()
+    tp_src = mpu.get_tensor_model_parallel_src_rank()
+    train_dev = torch.device(f"cuda:{torch.cuda.current_device()}")
+    temperature = float(getattr(args, "rollout_temperature", 1.0))
+
+    broadcast_list: list[torch.Tensor] = []
+    if tp_rank == 0:
+        model, _ = _load_hf_prm(path, dev)
+        for i, toks in enumerate(rollout_data["tokens"]):
+            if isinstance(toks, torch.Tensor):
+                row = toks.detach().long().flatten()
+            else:
+                row = torch.tensor(toks, dtype=torch.long)
+            rl = lengths[i]
+            cpu_vec = _response_logprobs_hf(
+                model,
+                row,
+                rl,
+                dev,
+                temperature=temperature,
+            )
+            broadcast_list.append(cpu_vec.to(train_dev))
+    else:
+        broadcast_list = [
+            torch.zeros(rl, dtype=torch.float32, device=train_dev) for rl in lengths
+        ]
+
+    if tp_world > 1:
+        for t in broadcast_list:
+            dist.broadcast(t, src=tp_src, group=tp_group)
+
+    rollout_data["teacher_log_probs_megatron"] = [x.detach().cpu().clone() for x in broadcast_list]

--- a/openclaw-combine/run_qwen35_4b_openclaw_combine.sh
+++ b/openclaw-combine/run_qwen35_4b_openclaw_combine.sh
@@ -23,11 +23,24 @@ export FLASHINFER_WORKSPACE_BASE="${FLASHINFER_WORKSPACE_BASE:-/tmp}"
 NUM_GPUS=${NUM_GPUS:-8}
 ACTOR_GPUS=${ACTOR_GPUS:-4}
 ROLLOUT_GPUS=${ROLLOUT_GPUS:-2}
-PRM_GPUS=${PRM_GPUS:-2}
 
-if (( ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS > NUM_GPUS )); then
-    echo "ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS must be <= NUM_GPUS"
-    echo "ACTOR_GPUS=${ACTOR_GPUS}, ROLLOUT_GPUS=${ROLLOUT_GPUS}, PRM_GPUS=${PRM_GPUS}, NUM_GPUS=${NUM_GPUS}"
+# OPD teacher source decides GPU layout for PRM:
+#   megatron  (default): 1 GPU PRM SGLang + 1 GPU Megatron teacher = "1+1"
+#   inference:           2 GPU PRM SGLang + 0 GPU Megatron teacher
+OPD_SRC="${OPENCLAW_COMBINE_OPD_TEACHER_SOURCE:-megatron}"
+if [ "${OPD_SRC}" = "inference" ]; then
+    PRM_GPUS=${PRM_GPUS:-2}
+    PRM_NUM_GPUS_PER_ENGINE=${PRM_NUM_GPUS_PER_ENGINE:-2}
+    PRM_TEACHER_GPUS=${PRM_TEACHER_GPUS:-0}
+else
+    PRM_GPUS=${PRM_GPUS:-1}
+    PRM_NUM_GPUS_PER_ENGINE=${PRM_NUM_GPUS_PER_ENGINE:-1}
+    PRM_TEACHER_GPUS=${PRM_TEACHER_GPUS:-1}
+fi
+
+if (( ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS + PRM_TEACHER_GPUS > NUM_GPUS )); then
+    echo "ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS + PRM_TEACHER_GPUS must be <= NUM_GPUS"
+    echo "ACTOR_GPUS=${ACTOR_GPUS}, ROLLOUT_GPUS=${ROLLOUT_GPUS}, PRM_GPUS=${PRM_GPUS}, PRM_TEACHER_GPUS=${PRM_TEACHER_GPUS}, NUM_GPUS=${NUM_GPUS}"
     exit 1
 fi
 
@@ -45,6 +58,7 @@ HF_CKPT=${HF_CKPT:-/data_storage/wyj/systems/huggingface/hub/Qwen35-4B}
 REF_LOAD=${REF_LOAD:-${HF_CKPT}}
 SAVE_CKPT=${SAVE_CKPT:-${REPO_ROOT}/ckpt/qwen35-4b-openclaw-combine}
 PRM_MODEL_PATH=${PRM_MODEL_PATH:-/data_storage/wyj/systems/huggingface/hub/Qwen35-4B}
+PRM_TEACHER_LOAD=${PRM_TEACHER_LOAD:-${PRM_MODEL_PATH}}
 
 export SGLANG_API_KEY="${SGLANG_API_KEY}"
 export SERVED_MODEL_NAME="qwen3.5-4b"
@@ -65,6 +79,12 @@ export OPENCLAW_COMBINE_W_RL="${OPENCLAW_COMBINE_W_RL:-1.0}"
 export OPENCLAW_COMBINE_W_OPD="${OPENCLAW_COMBINE_W_OPD:-1.0}"
 export TRAIN_EPOCHS="${TRAIN_EPOCHS:-2}"
 
+# OPD teacher source (driven by OPD_SRC set above from GPU layout logic):
+#   megatron (default) = PRM teacher log-probs computed by Megatron via --prm-teacher-load.
+#                        Same code path as student, no numerical mismatch.
+#   inference          = teacher_log_probs from PRM SGLang inference engine.
+export OPENCLAW_COMBINE_OPD_TEACHER_SOURCE="${OPD_SRC}"
+
 CKPT_ARGS=(
    --megatron-to-hf-mode bridge
    --hf-checkpoint "${HF_CKPT}"
@@ -73,6 +93,12 @@ CKPT_ARGS=(
    --save-interval 100
    --rotary-base 10000000
 )
+if [ "${PRM_TEACHER_GPUS}" -gt 0 ]; then
+    CKPT_ARGS+=(
+        --prm-teacher-load "${PRM_TEACHER_LOAD}"
+        --prm-teacher-num-gpus "${PRM_TEACHER_GPUS}"
+    )
+fi
 
 ROLLOUT_ARGS=(
    --disable-rollout-global-dataset
@@ -148,7 +174,7 @@ fi
 PRM_ARGS=(
    --prm-enable
    --prm-num-gpus "${PRM_GPUS}"
-   --prm-num-gpus-per-engine 2
+   --prm-num-gpus-per-engine "${PRM_NUM_GPUS_PER_ENGINE}"
    --prm-model-path "${PRM_MODEL_PATH}"
    --prm-m "${PRM_M}"
    --prm-temperature "${PRM_TEMPERATURE:-0.6}"
@@ -197,6 +223,7 @@ RUNTIME_ENV_JSON="{
     \"OPENCLAW_COMBINE_W_RL\": \"${OPENCLAW_COMBINE_W_RL}\",
     \"OPENCLAW_COMBINE_W_OPD\": \"${OPENCLAW_COMBINE_W_OPD}\",
     \"SLIME_QWEN35_TEXT_ONLY_BRIDGE\": \"${SLIME_QWEN35_TEXT_ONLY_BRIDGE}\",
+    \"OPENCLAW_COMBINE_OPD_TEACHER_SOURCE\": \"${OPENCLAW_COMBINE_OPD_TEACHER_SOURCE}\",
     \"TRAIN_EPOCHS\": \"${TRAIN_EPOCHS}\"
   }
 }"

--- a/openclaw-combine/run_qwen3_4b_openclaw_combine.sh
+++ b/openclaw-combine/run_qwen3_4b_openclaw_combine.sh
@@ -17,11 +17,24 @@ export PYTHONFAULTHANDLER=1
 NUM_GPUS=${NUM_GPUS:-8}
 ACTOR_GPUS=${ACTOR_GPUS:-4}
 ROLLOUT_GPUS=${ROLLOUT_GPUS:-2}
-PRM_GPUS=${PRM_GPUS:-2}
 
-if (( ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS > NUM_GPUS )); then
-    echo "ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS must be <= NUM_GPUS"
-    echo "ACTOR_GPUS=${ACTOR_GPUS}, ROLLOUT_GPUS=${ROLLOUT_GPUS}, PRM_GPUS=${PRM_GPUS}, NUM_GPUS=${NUM_GPUS}"
+# OPD teacher source decides GPU layout for PRM:
+#   megatron  (default): 1 GPU PRM SGLang + 1 GPU Megatron teacher = "1+1"
+#   inference:           2 GPU PRM SGLang + 0 GPU Megatron teacher
+OPD_SRC="${OPENCLAW_COMBINE_OPD_TEACHER_SOURCE:-megatron}"
+if [ "${OPD_SRC}" = "inference" ]; then
+    PRM_GPUS=${PRM_GPUS:-2}
+    PRM_NUM_GPUS_PER_ENGINE=${PRM_NUM_GPUS_PER_ENGINE:-2}
+    PRM_TEACHER_GPUS=${PRM_TEACHER_GPUS:-0}
+else
+    PRM_GPUS=${PRM_GPUS:-1}
+    PRM_NUM_GPUS_PER_ENGINE=${PRM_NUM_GPUS_PER_ENGINE:-1}
+    PRM_TEACHER_GPUS=${PRM_TEACHER_GPUS:-1}
+fi
+
+if (( ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS + PRM_TEACHER_GPUS > NUM_GPUS )); then
+    echo "ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS + PRM_TEACHER_GPUS must be <= NUM_GPUS"
+    echo "ACTOR_GPUS=${ACTOR_GPUS}, ROLLOUT_GPUS=${ROLLOUT_GPUS}, PRM_GPUS=${PRM_GPUS}, PRM_TEACHER_GPUS=${PRM_TEACHER_GPUS}, NUM_GPUS=${NUM_GPUS}"
     exit 1
 fi
 
@@ -31,13 +44,15 @@ export RAY_health_check_timeout_ms=30000
 export RAY_num_heartbeats_timeout=60
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
-SLIME_ROOT="$(cd -- "${SCRIPT_DIR}/../slime" &>/dev/null && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+SLIME_ROOT="${REPO_ROOT}/slime"
 source "${SLIME_ROOT}/scripts/models/qwen3-4B.sh"
 
 HF_CKPT=${HF_CKPT:-/data_storage/wyj/systems/huggingface/hub/Qwen3-4B-Thinking-2507}
 REF_LOAD=${REF_LOAD:-${HF_CKPT}}
 SAVE_CKPT=${SAVE_CKPT:-/data_storage/wyj/OpenClaw-RL/ckpt/qwen3-4b-openclaw-combine}
 PRM_MODEL_PATH=${PRM_MODEL_PATH:-/data_storage/wyj/systems/huggingface/hub/Qwen3-4B-Thinking-2507}
+PRM_TEACHER_LOAD=${PRM_TEACHER_LOAD:-${PRM_MODEL_PATH}}
 
 export SGLANG_API_KEY="${SGLANG_API_KEY}"
 export SERVED_MODEL_NAME="qwen3-4b"
@@ -56,6 +71,12 @@ export OPENCLAW_COMBINE_W_RL="${OPENCLAW_COMBINE_W_RL:-1.0}"
 export OPENCLAW_COMBINE_W_OPD="${OPENCLAW_COMBINE_W_OPD:-1.0}"
 export TRAIN_EPOCHS="${TRAIN_EPOCHS:-1}"
 
+# OPD teacher source (driven by OPD_SRC set above from GPU layout logic):
+#   megatron (default) = PRM teacher log-probs computed by Megatron via --prm-teacher-load.
+#                        Same code path as student, no numerical mismatch.
+#   inference          = teacher_log_probs from PRM SGLang inference engine.
+export OPENCLAW_COMBINE_OPD_TEACHER_SOURCE="${OPD_SRC}"
+
 CKPT_ARGS=(
    --megatron-to-hf-mode bridge
    --hf-checkpoint "${HF_CKPT}"
@@ -64,6 +85,12 @@ CKPT_ARGS=(
    --save-interval 100
    --rotary-base 5000000
 )
+if [ "${PRM_TEACHER_GPUS}" -gt 0 ]; then
+    CKPT_ARGS+=(
+        --prm-teacher-load "${PRM_TEACHER_LOAD}"
+        --prm-teacher-num-gpus "${PRM_TEACHER_GPUS}"
+    )
+fi
 
 ROLLOUT_ARGS=(
    --disable-rollout-global-dataset
@@ -135,7 +162,7 @@ SGLANG_ARGS=(
 PRM_ARGS=(
    --prm-enable
    --prm-num-gpus "${PRM_GPUS}"
-   --prm-num-gpus-per-engine 2
+   --prm-num-gpus-per-engine "${PRM_NUM_GPUS_PER_ENGINE}"
    --prm-model-path "${PRM_MODEL_PATH}"
    --prm-m "${PRM_M}"
    --prm-temperature "${PRM_TEMPERATURE:-0.6}"
@@ -177,11 +204,12 @@ ray start --head --node-ip-address "${MASTER_ADDR}" --num-gpus "${NUM_GPUS}" --d
 
 RUNTIME_ENV_JSON="{
   \"env_vars\": {
-    \"PYTHONPATH\": \"/data_storage/wyj/OpenClaw-RL/Megatron-LM/:${SCRIPT_DIR}:${SCRIPT_DIR}/../openclaw-opd:${SLIME_ROOT}\",
+    \"PYTHONPATH\": \"${REPO_ROOT}/Megatron-LM:${SCRIPT_DIR}:${REPO_ROOT}/openclaw-opd:${SLIME_ROOT}\",
     \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
     \"OPENCLAW_EVAL_MODE\": \"${OPENCLAW_EVAL_MODE}\",
     \"OPENCLAW_COMBINE_W_RL\": \"${OPENCLAW_COMBINE_W_RL}\",
     \"OPENCLAW_COMBINE_W_OPD\": \"${OPENCLAW_COMBINE_W_OPD}\",
+    \"OPENCLAW_COMBINE_OPD_TEACHER_SOURCE\": \"${OPENCLAW_COMBINE_OPD_TEACHER_SOURCE}\",
     \"TRAIN_EPOCHS\": \"${TRAIN_EPOCHS}\"
   }
 }"

--- a/openclaw-opd/openclaw_opd_api_server.py
+++ b/openclaw-opd/openclaw_opd_api_server.py
@@ -657,6 +657,7 @@ class OpenClawOPDAPIServer:
         result: dict[str, Any] = {
             "accepted": True,
             "teacher_log_probs": teacher_log_probs,
+            "teacher_tokens": enhanced_ids,
             "hint": hint,
             "votes": votes,
             "eval_score": eval_score,

--- a/slime/slime/backends/megatron_utils/actor.py
+++ b/slime/slime/backends/megatron_utils/actor.py
@@ -1,3 +1,5 @@
+import copy
+import inspect
 import logging
 import os
 import random
@@ -72,6 +74,20 @@ class MegatronTrainRayActor(TrainRayActor):
     ) -> int | None:
         monkey_patch_torch_dist()
 
+        if role == "prm_teacher":
+            args = copy.deepcopy(args)
+            args.tensor_model_parallel_size = getattr(args, "prm_teacher_num_gpus", 1)
+            args.pipeline_model_parallel_size = 1
+            args.context_parallel_size = 1
+            args.sequence_parallel = False
+            args.expert_model_parallel_size = 1
+            args.expert_tensor_parallel_size = 1
+            args.hf_checkpoint = args.prm_teacher_load
+            args.pretrained_checkpoint = args.prm_teacher_load
+            args.load = args.prm_teacher_load
+            args.no_load_optim = True
+            args.no_load_rng = True
+
         super().init(args, role, with_ref)
 
         init(args)
@@ -114,6 +130,10 @@ class MegatronTrainRayActor(TrainRayActor):
         if role == "critic":
             if self.args.offload_train:
                 self.sleep()
+            return
+
+        if role == "prm_teacher":
+            clear_memory()
             return
 
         start_rollout_id = loaded_rollout_id + 1
@@ -210,6 +230,10 @@ class MegatronTrainRayActor(TrainRayActor):
         rollout_data["tokens"] = [
             torch.tensor(t, dtype=torch.long) for t in rollout_data["tokens"]
         ]
+        if "teacher_tokens" in rollout_data:
+            rollout_data["teacher_tokens"] = [
+                torch.tensor(t, dtype=torch.long) for t in rollout_data["teacher_tokens"]
+            ]
         rollout_data["loss_masks"] = [
             torch.tensor(t, dtype=torch.int) for t in rollout_data["loss_masks"]
         ]
@@ -399,6 +423,10 @@ class MegatronTrainRayActor(TrainRayActor):
                 store_prefix=store_prefix,
             )
 
+    def set_prm_teacher_log_probs(self, prm_teacher_log_probs):
+        """Receive PRM teacher log-probs from a separate PRM teacher actor group."""
+        self._prm_teacher_log_probs = prm_teacher_log_probs
+
     def train(self, rollout_id: int, rollout_data_ref: Box) -> None:
         if self.args.offload_train:
             self.wake_up()
@@ -411,8 +439,21 @@ class MegatronTrainRayActor(TrainRayActor):
 
         if self.role == "critic":
             return self.train_critic(rollout_id, rollout_data)
+        elif self.role == "prm_teacher":
+            return self.compute_prm_teacher_log_probs(rollout_id, rollout_data)
         else:
             return self.train_actor(rollout_id, rollout_data)
+
+    def compute_prm_teacher_log_probs(self, rollout_id: int, rollout_data: RolloutBatch):
+        """Compute log-probs on the dedicated PRM teacher GPU using hint-enhanced tokens."""
+        teacher_tokens = rollout_data.get("teacher_tokens")
+        if teacher_tokens is not None:
+            rollout_data["tokens"] = teacher_tokens
+            rollout_data["total_lengths"] = rollout_data["teacher_total_lengths"]
+        data_iterator, num_microbatches = get_data_iterator(self.args, self.model, rollout_data)
+        result = self.compute_log_prob(data_iterator, num_microbatches, store_prefix="prm_teacher_")
+        log_probs = result["prm_teacher_log_probs"]
+        return [lp.cpu() if isinstance(lp, torch.Tensor) else lp for lp in log_probs]
 
     def train_critic(self, rollout_id: int, rollout_data: RolloutBatch) -> None:
         # Create data iterator for log_probs and train.
@@ -466,6 +507,9 @@ class MegatronTrainRayActor(TrainRayActor):
                             store_prefix="ref_",
                         )
                     )
+                if hasattr(self, "_prm_teacher_log_probs") and self._prm_teacher_log_probs is not None:
+                    rollout_data["prm_teacher_log_probs"] = self._prm_teacher_log_probs
+                    self._prm_teacher_log_probs = None
                 self._switch_model("old_actor" if self.args.keep_old_actor else "actor")
                 if not self.args.use_rollout_logprobs or self.args.get_mismatch_metrics:
                     if self.args.use_routing_replay:
@@ -504,7 +548,15 @@ class MegatronTrainRayActor(TrainRayActor):
             clear_memory()
 
             if self.rollout_data_postprocess is not None:
-                self.rollout_data_postprocess(self.args)
+                fn = self.rollout_data_postprocess
+                try:
+                    params = inspect.signature(fn).parameters
+                except (TypeError, ValueError):
+                    params = {}
+                if len(params) >= 2:
+                    fn(self.args, rollout_data)
+                else:
+                    fn(self.args)
 
             log_rollout_data(
                 rollout_id,

--- a/slime/slime/backends/megatron_utils/data.py
+++ b/slime/slime/backends/megatron_utils/data.py
@@ -532,6 +532,8 @@ def log_rollout_data(
                 "step_wise_step_indices",
                 "teacher_topk_log_probs",
                 "teacher_topk_indices",
+                "teacher_tokens",
+                "teacher_total_lengths",
             ]:
                 continue
             # Upload per sample mean for each rollout value
@@ -551,6 +553,7 @@ def log_rollout_data(
                         "advantages",
                         "values",
                         "teacher_log_probs",
+                        "prm_teacher_log_probs",
                     ]:
                         val = torch.cat(val).clone().detach()
                         sum_of_sample_mean = get_sum_of_sample_mean(

--- a/slime/slime/backends/megatron_utils/model.py
+++ b/slime/slime/backends/megatron_utils/model.py
@@ -372,6 +372,7 @@ def train_one_step(
                 "rollout_log_probs",
                 "max_seq_lens",
                 "teacher_log_probs",
+                "prm_teacher_log_probs",
                 "teacher_topk_log_probs",
                 "teacher_topk_indices",
             ],

--- a/slime/slime/ray/actor_group.py
+++ b/slime/slime/ray/actor_group.py
@@ -143,3 +143,8 @@ class RayTrainGroup:
 
     def set_rollout_manager(self, rollout_manager):
         return ray.get([actor.set_rollout_manager.remote(rollout_manager) for actor in self._actor_handlers])
+
+    def set_prm_teacher_log_probs(self, prm_teacher_log_probs):
+        """Broadcast PRM teacher log-probs (computed on a separate GPU) to all actor ranks."""
+        prm_lps_ref = ray.put(prm_teacher_log_probs)
+        return ray.get([actor.set_prm_teacher_log_probs.remote(prm_lps_ref) for actor in self._actor_handlers])

--- a/slime/slime/ray/placement_group.py
+++ b/slime/slime/ray/placement_group.py
@@ -81,6 +81,9 @@ def create_placement_groups(args):
 
     num_gpus = 0
     prm_offset = None
+    prm_teacher_offset = None
+    use_prm_teacher = getattr(args, "prm_teacher_load", None) is not None and getattr(args, "prm_teacher_num_gpus", 0) > 0
+
     if args.debug_train_only:
         num_gpus = args.actor_num_nodes * args.actor_num_gpus_per_node
         rollout_offset = 0
@@ -106,6 +109,9 @@ def create_placement_groups(args):
         if args.prm_enable and args.prm_num_gpus > 0:
             prm_offset = rollout_offset + args.rollout_num_gpus
             num_gpus += args.prm_num_gpus
+        if use_prm_teacher:
+            prm_teacher_offset = num_gpus
+            num_gpus += args.prm_teacher_num_gpus
 
     logger.info(f"Creating placement group with {num_gpus} GPUs...")
     pg, actor_pg_reordered_bundle_indices, actor_pg_reordered_gpu_ids = _create_placement_group(num_gpus)
@@ -117,6 +123,9 @@ def create_placement_groups(args):
         prm_pg_reordered_gpu_ids = actor_pg_reordered_gpu_ids[prm_offset : prm_offset + args.prm_num_gpus]
         rollout_pg_reordered_bundle_indices = actor_pg_reordered_bundle_indices[rollout_offset:prm_offset]
         rollout_pg_reordered_gpu_ids = actor_pg_reordered_gpu_ids[rollout_offset:prm_offset]
+    if prm_teacher_offset is not None:
+        prm_teacher_pg_reordered_bundle_indices = actor_pg_reordered_bundle_indices[prm_teacher_offset : prm_teacher_offset + args.prm_teacher_num_gpus]
+        prm_teacher_pg_reordered_gpu_ids = actor_pg_reordered_gpu_ids[prm_teacher_offset : prm_teacher_offset + args.prm_teacher_num_gpus]
     if args.use_critic:
         critic_pg_reordered_bundle_indices = actor_pg_reordered_bundle_indices[critic_offset:]
         critic_pg_reordered_gpu_ids = actor_pg_reordered_gpu_ids[critic_offset:]
@@ -126,6 +135,7 @@ def create_placement_groups(args):
         "critic": (pg, critic_pg_reordered_bundle_indices, critic_pg_reordered_gpu_ids) if args.use_critic else None,
         "rollout": (pg, rollout_pg_reordered_bundle_indices, rollout_pg_reordered_gpu_ids),
         "prm": (pg, prm_pg_reordered_bundle_indices, prm_pg_reordered_gpu_ids) if prm_offset is not None else None,
+        "prm_teacher": (pg, prm_teacher_pg_reordered_bundle_indices, prm_teacher_pg_reordered_gpu_ids) if prm_teacher_offset is not None else None,
     }
 
 
@@ -157,6 +167,17 @@ def create_training_models(args, pgs, rollout_manager):
     else:
         critic_model = None
 
+    prm_teacher_model = None
+    prm_teacher_init_handle = None
+    if pgs.get("prm_teacher") is not None:
+        prm_teacher_model = allocate_train_group(
+            args=args,
+            num_nodes=1,
+            num_gpus_per_node=getattr(args, "prm_teacher_num_gpus", 1),
+            pg=pgs["prm_teacher"],
+        )
+        prm_teacher_init_handle = prm_teacher_model.async_init(args, role="prm_teacher", with_ref=False)
+
     start_rollout_ids = ray.get(
         actor_model.async_init(args, role="actor", with_ref=args.kl_coef != 0 or args.use_kl_loss)
     )
@@ -169,11 +190,14 @@ def create_training_models(args, pgs, rollout_manager):
         ray.get(critic_init_handle)
         actor_model.connect(critic_model)
 
+    if prm_teacher_init_handle is not None:
+        ray.get(prm_teacher_init_handle)
+
     actor_model.set_rollout_manager(rollout_manager)
     if args.rollout_global_dataset:
         ray.get(rollout_manager.load.remote(args.start_rollout_id - 1))
 
-    return actor_model, critic_model
+    return actor_model, critic_model, prm_teacher_model
 
 
 def create_rollout_manager(args, pg, prm_pg=None):

--- a/slime/slime/ray/rollout.py
+++ b/slime/slime/ray/rollout.py
@@ -725,6 +725,10 @@ class RolloutManager:
         if "teacher_log_probs" in samples[0].__dict__:
             train_data["teacher_log_probs"] = [sample.teacher_log_probs for sample in samples]
 
+        if "teacher_tokens" in samples[0].__dict__:
+            train_data["teacher_tokens"] = [sample.teacher_tokens for sample in samples]
+            train_data["teacher_total_lengths"] = [len(sample.teacher_tokens) for sample in samples]
+
         if "teacher_topk_log_probs" in samples[0].__dict__:
             train_data["teacher_topk_log_probs"] = [sample.teacher_topk_log_probs for sample in samples]
 
@@ -781,6 +785,8 @@ class RolloutManager:
                 "rollout_routed_experts",
                 "prompt",
                 "teacher_log_probs",
+                "teacher_tokens",
+                "teacher_total_lengths",
                 "teacher_topk_log_probs",
                 "teacher_topk_indices",
                 "step_wise_step_rewards",

--- a/slime/slime/utils/arguments.py
+++ b/slime/slime/utils/arguments.py
@@ -764,6 +764,23 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
             parser.add_argument(
                 "--ref-ckpt-step", type=int, default=None, help="The checkpoint step for reference model. "
             )
+            parser.add_argument(
+                "--prm-teacher-load",
+                type=str,
+                default=None,
+                help=(
+                    "HF checkpoint for the PRM teacher model (OPD distillation). "
+                    "Loaded on a dedicated GPU group with TP=1 via bridge mode. "
+                    "Log-probs go through the same Megatron code path as the student. "
+                    "Independent of --ref-load."
+                ),
+            )
+            parser.add_argument(
+                "--prm-teacher-num-gpus",
+                type=int,
+                default=1,
+                help="Number of GPUs for the PRM teacher model (default 1, TP=1).",
+            )
             reset_arg(parser, "--load", type=str, default=None)
             reset_arg(parser, "--save", type=str, default=None)
             reset_arg(parser, "--save-interval", type=int, default=None)

--- a/slime/train_async.py
+++ b/slime/train_async.py
@@ -18,8 +18,8 @@ def train(args):
     # need to initialize rollout manager first to calculate num_rollout
     rollout_manager, num_rollout_per_epoch = create_rollout_manager(args, pgs["rollout"], pgs.get("prm"))
 
-    # create the actor and critic models
-    actor_model, critic_model = create_training_models(args, pgs, rollout_manager)
+    # create the actor, critic, and (optionally) PRM teacher models
+    actor_model, critic_model, prm_teacher_model = create_training_models(args, pgs, rollout_manager)
 
     # always update weight first so that sglang has the loaded weights from training.
     actor_model.update_weights()
@@ -37,6 +37,11 @@ def train(args):
         # Start the next rollout early.
         if rollout_id + 1 < args.num_rollout:
             rollout_data_next_future = rollout_manager.generate.remote(rollout_id + 1)
+
+        if prm_teacher_model is not None:
+            prm_teacher_futures = prm_teacher_model.async_train(rollout_id, rollout_data_curr_ref)
+            prm_teacher_log_probs = ray.get(prm_teacher_futures[0])
+            actor_model.set_prm_teacher_log_probs(prm_teacher_log_probs)
 
         if args.use_critic:
             critic_train_handle = critic_model.async_train(rollout_id, rollout_data_curr_ref)


### PR DESCRIPTION
Introduce a dedicated PRM teacher model that runs inside Megatron on its own GPU group (via --prm-teacher-load / --prm-teacher-num-gpus). Teacher log-probs are computed through the same Megatron code path as the student, eliminating the numerical mismatch between SGLang inference and Megatron training log-probs.

Changes:
- slime core: new prm_teacher role in placement, actor, rollout, data pipeline; flexible rollout_data_postprocess signature; train_async orchestrates teacher forward pass before actor training step
- openclaw-combine: combine_loss supports dual teacher source (megatron vs inference) via OPENCLAW_COMBINE_OPD_TEACHER_SOURCE env; OPD now uses student_megatron_logp instead of old_logp; GPU layout scripts support 1+1 (PRM SGLang + Megatron teacher) mode
- openclaw-combine: add prm_teacher_postprocess.py
- openclaw-opd: return teacher_tokens from OPD api server

Made-with: Cursor