### PR TITLE
feat: implement single-GPU (24GB) INT4 QLoRA + offload-rollout + external PRM for OpenClaw-Combine and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Our long-term goal is to **advance personalized, practically useful agents with 
 ✅ **Release Track 1:** Fully async OpenClaw-RL framework with Binary RL + OPD  
 ✅ Best recipe discovery via demonstration experiments  
 ✅ Support LoRA Training  
+✅ Single-GPU INT4 QLoRA with offload-rollout and external PRM API (24 GB VRAM)  
 ✅ Deploy training on [Tinker](https://thinkingmachines.ai/tinker/)  
 ✅ Deploy training on [Fireworks AI](https://fireworks.ai)
 
@@ -240,6 +241,26 @@ If you're interested in any of these, feel free to open an issue to discuss your
 - **Framework:** [Slime](https://github.com/THUDM/slime) (our base RL framework)
 
 For detailed environment setup, see [Slime](https://github.com/THUDM/slime) or [`./instructions/README.md`](./instructions/README.md).
+
+#### Only have a single GPU (≥ 24 GB)?
+
+We support **single-GPU INT4 QLoRA** training and inference via:
+
+- **INT4 QLoRA** — bitsandbytes NF4 quantization + LoRA (rank=4), base weights ~2 GB VRAM
+- **Colocate + CPU Offload** — training and rollout share one GPU, offloading when idle
+- **External PRM API** — PRM scoring via any OpenAI-compatible API, no local PRM GPU needed
+
+```bash
+cd slime
+export HF_CKPT="/path/to/Qwen3-4B"           # original HF weights (not pre-quantized)
+export OPENAI_API_KEY="your-api-key"           # external LLM API key (for PRM & OPD)
+export OPENAI_BASE_URL="https://your-api-base"
+export EXTERNAL_MODEL="your-model-name"
+
+bash ../openclaw-combine/run_qwen3_4b_openclaw_combine_single_gpu_int4_qlora.sh
+```
+
+See [`./openclaw-combine/README.md`](./openclaw-combine/README.md) for full parameter reference and [`./openclaw-test/README.md`](./openclaw-test/README.md) for single-GPU evaluation scripts.
 
 
 

--- a/openclaw-combine/README.md
+++ b/openclaw-combine/README.md
@@ -66,3 +66,53 @@ openclaw-combine/
 ├── combine_loss.py                           # Weighted advantage: w_rl * GRPO + w_opd * teacher
 └── results/                                  # Runtime records (auto-created)
 ```
+
+---
+
+## Single-GPU INT4 QLoRA
+
+Train and serve on a **single 24 GB GPU** using `run_qwen3_4b_openclaw_combine_single_gpu_int4_qlora.sh`.
+
+### Required Environment Variables
+
+| Variable | Description |
+|---|---|
+| `HF_CKPT` | Path to original Qwen3-4B HF weights (**not** pre-quantized) |
+| `OPENAI_API_KEY` | API key for external LLM (used by PRM and OPD teacher) |
+| `OPENAI_BASE_URL` | Base URL for the external LLM API |
+| `EXTERNAL_MODEL` | Model name served by the external API |
+
+### Optional Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `MICRO_BATCH_SIZE` | `1` | Micro-batch size per GPU |
+| `ROLLOUT_BATCH_SIZE` | `16` | Samples collected before each training step |
+
+### Key Features Enabled
+
+| Feature | Flag / Config | Description |
+|---|---|---|
+| INT4 quantization | `--fsdp-load-in-4bit` | bitsandbytes NF4 quantization. Compresses base model weights to ~4 bits, reducing VRAM from ~8 GB (bf16) to ~2 GB for Qwen3-4B. Only LoRA adapters are trained in full precision. |
+| LoRA fine-tuning | `--use-lora --lora-rank 4` | Low-Rank Adaptation. Freezes base weights and inserts small trainable matrices into attention/MLP layers.
+| Gradient checkpointing | `--gradient-checkpointing` | Trades compute for memory by recomputing activations during backward pass instead of storing them. |
+| Colocate (train + rollout on same GPU) | `--colocate` | Runs both the FSDP training actor and the SGLang rollout engine on the same GPU(s). Essential for single-GPU setups. |
+| Rollout offload | `--offload-rollout` | When training starts, the SGLang rollout engine is offloaded from GPU to free VRAM for the training forward/backward pass. When training finishes, the engine is reloaded for the next rollout. This alternating pattern allows a single GPU to handle both roles. |
+| External PRM API | `--prm-use-external-api` | Sends PRM scoring requests to an external OpenAI-compatible API instead of hosting a local PRM model on GPU. Eliminates the need for a dedicated PRM GPU — critical for single-GPU setups. Configured via `PRM_EXTERNAL_API_BASE`, `PRM_EXTERNAL_MODEL`, and `PRM_EXTERNAL_API_KEY`. |
+| Train sequence truncation | `SLIME_TRAIN_MAX_SEQ_LEN=4096` | Caps the token length of each training sample. Sequences longer than this are truncated from the **left** (dropping early prompt tokens, preserving the response). Prevents OOM on long rollouts and keeps per-sample memory bounded. |
+| Logit chunking | `SLIME_LOGIT_CHUNK_SIZE=512` | Computes log-softmax and entropy in chunks of this size instead of materializing the full `[seq_len, vocab_size]` tensor at once. For Qwen3-4B (vocab ~152 K), this reduces peak allocation from ~7.5 GB to ~0.9 GB per sample. Set to `0` to disable chunking. |
+
+### Quick Start
+
+```bash
+cd slime
+
+export HF_CKPT="/path/to/Qwen3-4B"
+export OPENAI_API_KEY="your-api-key"
+export OPENAI_BASE_URL="https://your-api-base"
+export EXTERNAL_MODEL="your-model-name"
+
+bash ../openclaw-combine/run_qwen3_4b_openclaw_combine_single_gpu_int4_qlora.sh
+```
+
+The model is served at `http://0.0.0.0:30000/v1` by default. For single-GPU evaluation scripts, see [`../openclaw-test/README.md`](../openclaw-test/README.md).

--- a/openclaw-combine/run_qwen3_4b_openclaw_combine_qlora_single_gpu_int4.sh
+++ b/openclaw-combine/run_qwen3_4b_openclaw_combine_qlora_single_gpu_int4.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+export PYTORCH_ALLOC_CONF=expandable_segments:True
+export SLIME_TRAINING_SAMPLES_FILE="../results/samples.jsonl"
+export PYTHONUNBUFFERED=1
+export SLIME_LOGIT_CHUNK_SIZE=512
+export PYTHONFAULTHANDLER=1
+export OPENCLAW_GATEWAY_TOKEN=""
+export OPENAI_API_KEY=""
+export OPENCLAW_GATEWAY_URL=""
+export OPENCLAW_WORKSPACE="$HOME/.openclaw/workspace"
+export OPENAI_BASE_URL=""   # point to your external LLM
+export EXTERNAL_MODEL=""            # model name for the external LLM
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+SLIME_ROOT="$(cd -- "${SCRIPT_DIR}/../slime" &>/dev/null && pwd)"
+export SLIME_TRAIN_MAX_SEQ_LEN=4096 # truncation will happen if context + response exceed this length
+NUM_GPUS=${NUM_GPUS:-1}
+ACTOR_GPUS=${ACTOR_GPUS:-1}
+ROLLOUT_GPUS=${ROLLOUT_GPUS:-1}
+
+# For bitsandbytes QLoRA, use the original HF checkpoint (do NOT use pre-converted compressed-tensors INT4 dir).
+HF_CKPT=${HF_CKPT:-to/models/Qwen3-4B}
+REF_LOAD=${REF_LOAD:-${HF_CKPT}}
+SAVE_CKPT=${SAVE_CKPT:-/root/shared-nvme/OpenClaw-RL/models/qwen3_4b_openclaw_combine_single_gpu_int4_qlora_ckpt}
+PRM_MODEL_PATH=${PRM_MODEL_PATH:-${HF_CKPT}}
+# External PRM API (OpenAI-compatible)
+PRM_EXTERNAL_API_BASE=${PRM_EXTERNAL_API_BASE:-${OPENAI_BASE_URL:-}}
+PRM_EXTERNAL_MODEL=${PRM_EXTERNAL_MODEL:-${EXTERNAL_MODEL:-}}
+PRM_EXTERNAL_API_KEY=${PRM_EXTERNAL_API_KEY:-${OPENAI_API_KEY:-}}
+
+if [[ -z "${PRM_EXTERNAL_API_BASE}" || -z "${PRM_EXTERNAL_MODEL}" ]]; then
+  echo "PRM_EXTERNAL_API_BASE and PRM_EXTERNAL_MODEL are required (or set OPENAI_BASE_URL / EXTERNAL_MODEL)."
+  exit 1
+fi
+
+export SERVED_MODEL_NAME="${SERVED_MODEL_NAME:-qwen3-4b-int4}"
+export HOST="0.0.0.0"
+export PORT="${PORT:-30000}"
+
+export OPENCLAW_RECORD_ENABLED="${OPENCLAW_RECORD_ENABLED:-1}"
+export OPENCLAW_RECORD_FILE="${SCRIPT_DIR}/results/qwen3_4b_single_gpu_int4_qlora_record.jsonl"
+export OPENCLAW_EVAL_MODE="${OPENCLAW_EVAL_MODE:-1}"
+
+export OPENCLAW_COMBINE_W_RL="${OPENCLAW_COMBINE_W_RL:-1.0}"
+export OPENCLAW_COMBINE_W_OPD="${OPENCLAW_COMBINE_W_OPD:-1.0}"
+export TRAIN_EPOCHS="${TRAIN_EPOCHS:-1}"
+export PRM_M="${PRM_M:-1}"
+export OPENCLAW_OPD_TEACHER_LP_MAX_CONCURRENCY="${OPENCLAW_OPD_TEACHER_LP_MAX_CONCURRENCY:-1}"
+
+export SGLANG_ENABLE_LOGITS_PROCESSER_CHUNK=True
+export SGLANG_LOGITS_PROCESSER_CHUNK_SIZE=128 # to avoid OOM with long context + response in INT4
+ray stop --force || true
+pkill -9 sglang || true
+pkill -9 ray || true
+
+export MASTER_ADDR=${MASTER_ADDR:-127.0.0.1}
+export no_proxy="127.0.0.1,${MASTER_ADDR}"
+ray start --head --node-ip-address "${MASTER_ADDR}" --num-gpus "${NUM_GPUS}" --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+CKPT_ARGS=(
+  --hf-checkpoint "${HF_CKPT}"
+  --ref-load "${REF_LOAD}"
+  --save "${SAVE_CKPT}"
+  --save-interval 20
+)
+
+ROLLOUT_ARGS=(
+  --disable-rollout-global-dataset
+  --rollout-function-path openclaw_combine_rollout.generate_rollout_openclaw_combine
+  --num-rollout ${NUM_ROLLOUT:-20000}
+  --rollout-batch-size ${ROLLOUT_BATCH_SIZE:-16}
+  --n-samples-per-prompt 1
+  --rollout-max-response-len ${ROLLOUT_MAX_RESPONSE_LEN:-4096}
+  --rollout-max-context-len ${ROLLOUT_MAX_CONTEXT_LEN:-22768}
+  --rollout-temperature ${ROLLOUT_TEMPERATURE:-0.6}
+  --reward-key score
+  --num-steps-per-rollout 1
+)
+
+COMBINE_ARGS=(
+  --advantage-estimator grpo
+  --disable-rewards-normalization
+  --loss-type custom_loss
+  --custom-loss-function-path combine_loss.combine_loss_function   
+  --use-kl-loss
+  --kl-loss-coef 0.0
+  --kl-loss-type low_var_kl
+  --entropy-coef 0.00
+  --eps-clip 0.2
+  --eps-clip-high 0.28
+)
+
+OPTIMIZER_ARGS=(
+  --optimizer adam
+  --lr ${LR:-1e-5}
+  --lr-decay-style constant
+  --weight-decay 0.1
+  --adam-beta1 0.9
+  --adam-beta2 0.98
+)
+
+PERF_ARGS=(
+  --micro-batch-size ${MICRO_BATCH_SIZE:-1}
+  --max-tokens-per-gpu ${MAX_TOKENS_PER_GPU:-4096}
+  --gradient-checkpointing
+)
+
+# FSDP QLoRA (INT4 base + LoRA adapters)
+QLORA_ARGS=(
+  --use-lora
+  --lora-rank ${LORA_RANK:-4}
+  --lora-alpha ${LORA_ALPHA:-4}
+  --lora-target-modules "${LORA_TARGET_MODULES:-q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj}"
+  --fsdp-load-in-4bit
+  --fsdp-bnb-4bit-quant-type ${FSDP_BNB_4BIT_QUANT_TYPE:-nf4}
+  --fsdp-bnb-4bit-compute-dtype ${FSDP_BNB_4BIT_COMPUTE_DTYPE:-bfloat16}
+  --fsdp-bnb-4bit-use-double-quant
+  --fsdp-prepare-model-for-kbit-training
+)
+
+SGLANG_ARGS=(
+  --rollout-num-gpus-per-engine 1
+  --sglang-context-length ${SGLANG_CONTEXT_LENGTH:-22768}
+  --sglang-mem-fraction-static ${SGLANG_MEM_FRACTION_STATIC:-0.6}
+  --sglang-reasoning-parser ${SGLANG_REASONING_PARSER:-qwen3}
+  --sglang-tool-call-parser ${SGLANG_TOOL_CALL_PARSER:-qwen25}
+)
+
+# External PRM: no local PRM engine / GPU allocation.
+PRM_ARGS=(
+  --prm-enable
+  --prm-use-external-api
+  --prm-num-gpus 1
+  --prm-m ${PRM_M}
+  --prm-temperature ${PRM_TEMPERATURE:-0.6}
+  --prm-max-new-tokens ${PRM_MAX_NEW_TOKENS:-4096}
+  --prm-external-api-base "${PRM_EXTERNAL_API_BASE}"
+  --prm-external-model "${PRM_EXTERNAL_MODEL}"
+)
+if [[ -n "${PRM_EXTERNAL_API_KEY}" ]]; then
+  PRM_ARGS+=(--prm-external-api-key "${PRM_EXTERNAL_API_KEY}")
+fi
+
+CUSTOM_ARGS=(
+  --custom-generate-function-path openclaw_combine_api_server.generate
+  --custom-rm-path openclaw_combine_api_server.reward_func
+)
+
+WANDB_ARGS=()
+if [[ "${USE_WANDB:-0}" == "1" && -n "${WANDB_API_KEY:-}" ]]; then
+  WANDB_ARGS=(
+    --use-wandb
+    --wandb-project ${WANDB_PROJECT:-openclaw_rl_int4}
+    --wandb-group qwen3-4b-openclaw-combine-int4-qlora
+    --wandb-key ${WANDB_API_KEY}
+  )
+fi
+
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"${SCRIPT_DIR}:${SCRIPT_DIR}/../openclaw-opd:${SLIME_ROOT}\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"OPENCLAW_EVAL_MODE\": \"${OPENCLAW_EVAL_MODE}\",
+    \"OPENCLAW_COMBINE_W_RL\": \"${OPENCLAW_COMBINE_W_RL}\",
+    \"OPENCLAW_COMBINE_W_OPD\": \"${OPENCLAW_COMBINE_W_OPD}\",
+    \"TRAIN_EPOCHS\": \"${TRAIN_EPOCHS}\"
+  }
+}"
+
+ray job submit --address="http://127.0.0.1:8265" \
+  --runtime-env-json="${RUNTIME_ENV_JSON}" \
+  -- python3 train.py \
+  --train-backend fsdp \
+  --offload-rollout \
+  --actor-num-nodes 1 \
+#   --save-debug-rollout-data debug/data_{rollout_id}.pt \
+#   --load-debug-rollout-data debug/data_{rollout_id}.pt \
+  --actor-num-gpus-per-node "${ACTOR_GPUS}" \
+  --rollout-num-gpus "${ROLLOUT_GPUS}" \
+  --num-gpus-per-node "${NUM_GPUS}" \
+  --colocate \
+  "${CKPT_ARGS[@]}" \
+  "${ROLLOUT_ARGS[@]}" \
+  "${OPTIMIZER_ARGS[@]}" \
+  "${COMBINE_ARGS[@]}" \
+  "${PERF_ARGS[@]}" \
+  "${SGLANG_ARGS[@]}" \
+  "${PRM_ARGS[@]}" \
+  "${QLORA_ARGS[@]}" \
+  "${CUSTOM_ARGS[@]}" \
+  "${WANDB_ARGS[@]}"

--- a/openclaw-combine/run_qwen3_4b_openclaw_combine_qlora_single_gpu_int4.sh
+++ b/openclaw-combine/run_qwen3_4b_openclaw_combine_qlora_single_gpu_int4.sh
@@ -12,15 +12,18 @@ export OPENAI_API_KEY=""
 export OPENCLAW_GATEWAY_URL=""
 export OPENCLAW_WORKSPACE="$HOME/.openclaw/workspace"
 export OPENAI_BASE_URL=""   # point to your external LLM
-export EXTERNAL_MODEL=""            # model name for the external LLM
+export EXTERNAL_MODEL=""    # model name for the external LLM
+export SLIME_TRAIN_MAX_SEQ_LEN=4096 # truncation will happen if context + response exceed this length
+export SGLANG_ENABLE_LOGITS_PROCESSER_CHUNK=True
+export SGLANG_LOGITS_PROCESSER_CHUNK_SIZE=128 # to avoid OOM with long context + response in INT4
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 SLIME_ROOT="$(cd -- "${SCRIPT_DIR}/../slime" &>/dev/null && pwd)"
-export SLIME_TRAIN_MAX_SEQ_LEN=4096 # truncation will happen if context + response exceed this length
+
 NUM_GPUS=${NUM_GPUS:-1}
 ACTOR_GPUS=${ACTOR_GPUS:-1}
 ROLLOUT_GPUS=${ROLLOUT_GPUS:-1}
 
-# For bitsandbytes QLoRA, use the original HF checkpoint (do NOT use pre-converted compressed-tensors INT4 dir).
+# For bitsandbytes QLoRA, use the original HF checkpoint (do NOT use INT4 dir).
 HF_CKPT=${HF_CKPT:-to/models/Qwen3-4B}
 REF_LOAD=${REF_LOAD:-${HF_CKPT}}
 SAVE_CKPT=${SAVE_CKPT:-/root/shared-nvme/OpenClaw-RL/models/qwen3_4b_openclaw_combine_single_gpu_int4_qlora_ckpt}
@@ -49,8 +52,6 @@ export TRAIN_EPOCHS="${TRAIN_EPOCHS:-1}"
 export PRM_M="${PRM_M:-1}"
 export OPENCLAW_OPD_TEACHER_LP_MAX_CONCURRENCY="${OPENCLAW_OPD_TEACHER_LP_MAX_CONCURRENCY:-1}"
 
-export SGLANG_ENABLE_LOGITS_PROCESSER_CHUNK=True
-export SGLANG_LOGITS_PROCESSER_CHUNK_SIZE=128 # to avoid OOM with long context + response in INT4
 ray stop --force || true
 pkill -9 sglang || true
 pkill -9 ray || true
@@ -175,8 +176,6 @@ ray job submit --address="http://127.0.0.1:8265" \
   --train-backend fsdp \
   --offload-rollout \
   --actor-num-nodes 1 \
-#   --save-debug-rollout-data debug/data_{rollout_id}.pt \
-#   --load-debug-rollout-data debug/data_{rollout_id}.pt \
   --actor-num-gpus-per-node "${ACTOR_GPUS}" \
   --rollout-num-gpus "${ROLLOUT_GPUS}" \
   --num-gpus-per-node "${NUM_GPUS}" \

--- a/openclaw-opd/openclaw_opd_api_server.py
+++ b/openclaw-opd/openclaw_opd_api_server.py
@@ -282,6 +282,7 @@ class OpenClawOPDAPIServer:
         self._pending_records: dict[str, dict[str, Any]] = {}
 
         self._prm_enabled = getattr(args, "prm_enable", False)
+        self._prm_use_external_api = bool(getattr(args, "prm_use_external_api", False))
         self._prm_m = int(os.getenv("PRM_M", getattr(args, "prm_m", 3)))
         self._prm_temperature = float(getattr(args, "prm_temperature", 0.6))
         self._prm_max_tokens = int(getattr(args, "prm_max_new_tokens", 4096))
@@ -289,14 +290,33 @@ class OpenClawOPDAPIServer:
         self._teacher_lp_semaphore = asyncio.Semaphore(max(1, self._teacher_lp_max_concurrency))
         self.distill_topk = int(getattr(args, "distill_topk", 0))
         self._use_topk_distillation = self.distill_topk > 0
+        self._prm_external_api_base = (
+            getattr(args, "prm_external_api_base", None) or os.getenv("PRM_EXTERNAL_API_BASE", "")
+        ).rstrip("/")
+        self._prm_external_api_key = (
+            getattr(args, "prm_external_api_key", None) or os.getenv("PRM_EXTERNAL_API_KEY", "")
+        )
+        self._prm_external_model = getattr(args, "prm_external_model", None) or os.getenv("PRM_EXTERNAL_MODEL", "")
+        self._prm_external_chat_url = (
+            f"{self._prm_external_api_base}/chat/completions" if self._prm_external_api_base else ""
+        )
         prm_ip = getattr(args, "prm_router_ip", None)
         prm_port = getattr(args, "prm_router_port", None)
         self._prm_url = f"http://{prm_ip}:{prm_port}/generate" if prm_ip and prm_port else ""
+        self._teacher_logprob_url = self._prm_url or f"http://{args.sglang_router_ip}:{args.sglang_router_port}/generate"
         self._prm_tokenizer = None
         if self._prm_enabled:
-            prm_path = getattr(args, "prm_model_path", None) or args.hf_checkpoint
-            self._prm_tokenizer = load_tokenizer(prm_path, trust_remote_code=True)
-            logger.info("[OpenClaw-OPD] PRM enabled: url=%s m=%d", self._prm_url, self._prm_m)
+            if not self._prm_use_external_api:
+                prm_path = getattr(args, "prm_model_path", None) or args.hf_checkpoint
+                self._prm_tokenizer = load_tokenizer(prm_path, trust_remote_code=True)
+                logger.info("[OpenClaw-OPD] PRM enabled (local): url=%s m=%d", self._prm_url, self._prm_m)
+            else:
+                logger.info(
+                    "[OpenClaw-OPD] PRM enabled (external): chat_url=%s model=%s m=%d",
+                    self._prm_external_chat_url,
+                    self._prm_external_model,
+                    self._prm_m,
+                )
 
         self._record_file = os.getenv("OPENCLAW_RECORD_FILE", "") if os.getenv("OPENCLAW_RECORD_ENABLED", "0") == "1" else ""
         if self._record_file:
@@ -412,8 +432,44 @@ class OpenClawOPDAPIServer:
                 f.write(json.dumps(record, ensure_ascii=False) + "\n")
         except OSError as e:
             logger.warning("[OpenClaw-OPD] failed to write PRM record: %s", e)
+    async def _query_external_prm_chat_once(self, messages: list[dict[str, Any]], vote_id: int) -> str:
+        if not self._prm_external_chat_url:
+            return ""
 
-    async def _query_judge_once(self, judge_prompt: str, vote_id: int) -> dict[str, Any]:
+        payload = {
+            "model": self._prm_external_model,
+            "messages": messages,
+            "temperature": self._prm_temperature,
+            "max_tokens": self._prm_max_tokens,
+            "stream": False,
+        }
+        headers = {"Content-Type": "application/json"}
+        if self._prm_external_api_key:
+            headers["Authorization"] = f"Bearer {self._prm_external_api_key}"
+
+        try:
+            async with httpx.AsyncClient(timeout=None) as client:
+                resp = await client.post(self._prm_external_chat_url, json=payload, headers=headers)
+                resp.raise_for_status()
+                data = resp.json()
+
+            choices = data.get("choices") if isinstance(data, dict) else None
+            if isinstance(choices, list) and choices:
+                message = choices[0].get("message", {}) if isinstance(choices[0], dict) else {}
+                return _flatten_message_content(message.get("content", ""))
+            return ""
+        except Exception as e:
+            logger.warning("[OpenClaw-OPD] external PRM chat query failed (vote %d): %s", vote_id, e)
+            return ""
+
+    async def _query_judge_once(self, judge_prompt: str | list[dict[str, Any]], vote_id: int) -> dict[str, Any]:
+        if self._prm_use_external_api:
+            if not isinstance(judge_prompt, list):
+                judge_prompt = [{"role": "user", "content": str(judge_prompt)}]
+            raw = await self._query_external_prm_chat_once(judge_prompt, vote_id)
+            score, hint = _parse_judge_result(raw)
+            return {"vote_id": vote_id, "score": score, "hint": hint, "raw": raw}
+  
         if not self._prm_url:
             return {"vote_id": vote_id, "score": None, "hint": "", "raw": ""}
         payload = {
@@ -445,6 +501,12 @@ class OpenClawOPDAPIServer:
             return {"vote_id": vote_id, "score": None, "hint": "", "raw": ""}
 
     async def _query_prm_eval_once(self, prompt_text: str, vote_id: int) -> int | None:
+        if self._prm_use_external_api:
+            if not isinstance(prompt_text, list):
+                prompt_text = [{"role": "user", "content": str(prompt_text)}]
+            raw = await self._query_external_prm_chat_once(prompt_text, vote_id)
+            return _parse_prm_eval_score(str(raw))
+        
         if not self._prm_url:
             return None
         payload = {
@@ -487,7 +549,7 @@ class OpenClawOPDAPIServer:
         }
         async with self._teacher_lp_semaphore:
             async with httpx.AsyncClient(timeout=None) as client:
-                resp = await client.post(self._prm_url, json=payload)
+                resp = await client.post(self._teacher_logprob_url, json=payload)
                 resp.raise_for_status()
                 result = resp.json()
 
@@ -536,7 +598,7 @@ class OpenClawOPDAPIServer:
         }
         async with self._teacher_lp_semaphore:
             async with httpx.AsyncClient(timeout=None) as client:
-                resp = await client.post(self._prm_url, json=payload)
+                resp = await client.post(self._teacher_logprob_url, json=payload)
                 resp.raise_for_status()
                 result = resp.json()
 
@@ -587,7 +649,9 @@ class OpenClawOPDAPIServer:
         next_state_text = _flatten_message_content(next_state.get("content")) if next_state else ""
         next_state_role = next_state.get("role", "user") if next_state else "user"
         judge_msgs = _build_hint_judge_messages(turn_data["response_text"], next_state_text, next_state_role)
-        if self._prm_tokenizer:
+        if self._prm_use_external_api:
+            judge_prompt = judge_msgs
+        elif self._prm_tokenizer:
             judge_prompt = self._prm_tokenizer.apply_chat_template(judge_msgs, tokenize=False, add_generation_prompt=True)
         else:
             judge_prompt = "\n".join(m["content"] for m in judge_msgs)
@@ -596,7 +660,9 @@ class OpenClawOPDAPIServer:
 
         if self._eval_mode:
             eval_msgs = _build_prm_eval_prompt(turn_data["response_text"], next_state_text, next_state_role)
-            if self._prm_tokenizer:
+            if self._prm_use_external_api:
+                eval_prompt = eval_msgs
+            elif self._prm_tokenizer:
                 eval_prompt = self._prm_tokenizer.apply_chat_template(
                     eval_msgs, tokenize=False, add_generation_prompt=True,
                 )

--- a/openclaw-test/README.md
+++ b/openclaw-test/README.md
@@ -205,6 +205,64 @@ openclaw-test/
 ├── README.md              # This file
 ├── launch_user_llm.sh     # Script to host the external LLM via SGLang
 ├── student_chat.py        # Phase 1: Student asks agent to solve homework
+├── student_chat_single_gpu.py  # Single-GPU variant (SGLang offload-aware)
 ├── teacher_chat.py        # Phase 2: Teacher asks agent to grade homework
+├── teacher_chat_single_gpu.py  # Single-GPU variant (SGLang offload-aware)
 └── GSM8K.json             # Dataset (to be placed here)
 ```
+
+---
+
+## Single-GPU INT4 QLoRA  Evaluation
+
+OpenClaw supports training and inference on a **single 24 GB GPU** using INT4 QLoRA (NF4 quantization + LoRA fine-tuning).
+
+### Requirements
+
+- 1× GPU with ≥ 24 GB VRAM (e.g. RTX 4090, A5000, L20)
+- Base model: Qwen3-4B or Qwen3-0.6B for quick start(original HF weights, **not** a pre-quantized checkpoint)
+
+### Training
+
+```bash
+cd slime
+
+export HF_CKPT="/path/to/Qwen3-4B"
+export OPENAI_API_KEY="your-api-key"
+export OPENAI_BASE_URL="https://your-api-base"
+export EXTERNAL_MODEL="your-model-name"
+
+bash ../openclaw-combine/run_qwen3_4b_openclaw_combine_single_gpu_int4_qlora.sh
+```
+
+### Single-GPU Evaluation
+
+The `*_single_gpu.py` scripts check the local SGLang engine health before each request. If the engine is offloaded for training (weight updating), they automatically poll and retry until the engine is back online:
+
+```
+[SGLang] Engine not ready (weight updating/503). Polling every 60s...
+[SGLang] Waiting for weight update (503) | attempt 1/60
+[SGLang] Waiting for weight update (503) | attempt 2/60
+[SGLang] Waiting for weight update (503) | attempt 3/60
+...
+```
+
+This is expected behavior in single-GPU colocate mode — the rollout engine is temporarily unavailable while the training step runs. The script resumes automatically once training finishes and the engine reloads.
+
+```bash
+cd openclaw-test
+
+# Phase 1: Student Chat (run first)
+python student_chat_single_gpu.py \
+    --dataset GSM8K.json \
+    --num-problems 36 \
+    --max-turns 8
+
+# Phase 2: Teacher Chat (run after student)
+python teacher_chat_single_gpu.py \
+    --dataset GSM8K.json \
+    --num-problems 36 \
+    --max-turns 8
+```
+
+

--- a/openclaw-test/student_chat_single_gpu.py
+++ b/openclaw-test/student_chat_single_gpu.py
@@ -1,0 +1,323 @@
+"""
+Single-GPU GSM8K student runner with SGLang-aware retry.
+
+Pre-checks the local SGLang rollout engine (/health_generate) before each request.
+If the engine is offloaded for training, waits RETRY_INTERVAL seconds and retries.
+Falls back to 503/ENGINE_OFFLOADED detection from OpenClaw as a secondary guard.
+
+Env vars:
+  OPENCLAW_GATEWAY_TOKEN  required: OpenClaw auth token
+  OPENAI_API_KEY          required: external (student) LLM key
+  OPENCLAW_GATEWAY_URL    default: http://localhost:18789
+  OPENCLAW_WORKSPACE      default: ~/.openclaw/workspace
+  OPENAI_BASE_URL         optional: custom LLM base URL
+  EXTERNAL_MODEL          default: gpt-4o
+  SGLANG_ENGINE_URL       default: http://localhost:30000  (empty = disable pre-check)
+  OFFLOAD_RETRY_INTERVAL  default: 180 (seconds between retries)
+  OFFLOAD_MAX_RETRIES     default: 30
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+
+import requests
+from openai import OpenAI
+STUDENT_SYSTEM_PROMPT = """\
+You are role-playing as a lazy student who knows nothing. You talk casually. \
+You have no idea what the homework is even about.
+
+You CANNOT solve, rewrite, rephrase, or produce any answer yourself. \
+You can ONLY tell the AI what to do. Never use academic or technical language.
+
+Your goal: get the AI to do your homework so you can hand it in as your own. \
+It should NOT look like an AI wrote it. The answers must still include the \
+full solution process with all steps shown — NEVER ask the AI to remove steps \
+or give only the final answer. You need the complete work. The only problem \
+is the WRITING STYLE. If the AI's answer has stuff like bold text, numbered \
+lists, "**Final answer**:", or anything too AI-like, tell it to \
+rewrite in a more natural way but keep all the steps. Just tell it to fix \
+the style — don't fix it yourself. If there is no AI-like stuff, no need to rewrite.
+
+Steps:
+1. Look at what the AI gives you. If it looks too "AI-like", tell it to redo it. If not, no need to redo. \
+Do NOT mention writing to the file in the same message. Only ask for a rewrite.
+2. After the AI shows you the satisfactory version and it looks good, THEN in a \
+separate message ask it to append the answers to the end of the homework file \
+(not overwrite it). Do NOT combine a rewrite request and a write request.
+3. After the AI says it saved the file, say exactly: HOMEWORK_DONE
+
+Never say HOMEWORK_DONE until the AI confirms it wrote the file.
+Never write or solve anything yourself. Just give simple instructions."""
+
+FIRST_MESSAGE_TEMPLATE = (
+    "Hey, I have my homework in the file homework/{index}.txt in your workspace. "
+    "Can you read it and help me solve it? "
+    "Show me the answer first — don't write to the file until I tell you to."
+)
+
+DONE_SENTINEL = "HOMEWORK_DONE"
+ENGINE_OFFLOADED_CODE = "ENGINE_OFFLOADED"
+
+RETRY_INTERVAL = int(os.environ.get("OFFLOAD_RETRY_INTERVAL", "60"))
+MAX_RETRIES = int(os.environ.get("OFFLOAD_MAX_RETRIES", "60"))
+SGLANG_ENGINE_URL = os.environ.get("SGLANG_ENGINE_URL", "http://127.0.0.1:30000").rstrip("/")
+
+
+def strip_thinking(text: str) -> str:
+    """Remove <think>...</think> blocks from model output."""
+    return re.sub(r"<think>[\s\S]*?</think>\s*", "", text).strip()
+
+
+def get_env_or_exit(name: str) -> str:
+    val = os.environ.get(name, "").strip()
+    if not val:
+        print(f"Error: environment variable {name} is not set.", file=sys.stderr)
+        sys.exit(1)
+    return val
+
+
+def load_dataset(path: str) -> list[dict]:
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        print(f"Error: dataset file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(data, list):
+        print("Error: dataset must be a JSON array.", file=sys.stderr)
+        sys.exit(1)
+    return data
+
+
+def prepare_homework_files(
+    problems: list[dict],
+    workspace_dir: str,
+    num_problems: int,
+) -> int:
+    homework_dir = os.path.join(workspace_dir, "homework")
+    os.makedirs(homework_dir, exist_ok=True)
+
+    count = min(num_problems, len(problems))
+    for i in range(count):
+        question = problems[i].get("question", "")
+        filepath = os.path.join(homework_dir, f"{i}.txt")
+        with open(filepath, "w", encoding="utf-8") as f:
+            f.write(f"Problem:\n{question}\n\nSolution:\n")
+        print(f"  Written: homework/{i}.txt")
+    return count
+
+
+def _wait_engine_ready(engine_url: str) -> None:
+    """Poll SGLang until engine is ready. No-op if url is empty."""
+    if not engine_url:
+        return
+    api_url = f"{engine_url}/v1/chat/completions"
+    payload = {"model": "qwen3-4b", "messages": [{"role": "user", "content": "test"}]}
+    headers = {"Content-Type": "application/json"}
+
+    for attempt in range(MAX_RETRIES + 1):
+        time.sleep(2 if attempt == 0 else RETRY_INTERVAL)
+        try:
+            response = requests.post(api_url, json=payload, headers=headers, timeout=5)
+            if response.status_code == 200:
+                if attempt > 0:
+                    print(f"  [SGLang] Engine ready (attempt {attempt}).")
+                return
+            status = response.status_code
+        except requests.RequestException:
+            status = None
+
+        if attempt == 0:
+            print(f"  [SGLang] Engine not ready (weight updating/503). Polling every {RETRY_INTERVAL}s...")
+        elif status == 503:
+            print(f"  [SGLang] Waiting for weight update (503) | attempt {attempt}/{MAX_RETRIES}")
+        else:
+            print(f"  [SGLang] Still not ready (attempt {attempt}/{MAX_RETRIES}).")
+
+    raise RuntimeError(f"SGLang engine at {engine_url} not ready after {MAX_RETRIES} retries.")
+
+def send_to_openclaw(gateway_url: str, token: str, message: str, session_user: str) -> str:
+    """Send a message to OpenClaw with SGLang pre-check and 503 fallback retry."""
+    for attempt in range(1, MAX_RETRIES + 1):
+        _wait_engine_ready(SGLANG_ENGINE_URL)  # wait until local SGLang is not offloaded
+        try:
+            resp = requests.post(
+                f"{gateway_url}/v1/chat/completions",
+                headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+                json={"model": "openclaw", "stream": False, "user": session_user,
+                      "messages": [{"role": "user", "content": message}]},
+                timeout=180,
+            )
+            # fallback: if SGLang went offloaded between our check and the request
+            if resp.status_code == 503:
+                try:
+                    detail = resp.json().get("detail", "")
+                    is_offloaded = (
+                        (isinstance(detail, dict) and detail.get("code") == ENGINE_OFFLOADED_CODE)
+                        or (isinstance(detail, str) and ENGINE_OFFLOADED_CODE in detail)
+                    )
+                except ValueError:
+                    is_offloaded = False
+                if is_offloaded:
+                    print(f"  [503 fallback] ENGINE_OFFLOADED, retry {attempt}/{MAX_RETRIES}...")
+                    time.sleep(RETRY_INTERVAL)
+                    continue
+            resp.raise_for_status()
+            return resp.json()["choices"][0]["message"]["content"]
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+            print(f"  [Network error] {e}, retry {attempt}/{MAX_RETRIES} in {RETRY_INTERVAL}s...")
+            time.sleep(RETRY_INTERVAL)
+    raise RuntimeError(f"Failed after {MAX_RETRIES} retries.")
+
+
+def generate_student_message(
+    client: OpenAI,
+    model: str,
+    problem_index: int,
+    conversation_history: list[dict],
+) -> str:
+    filename = f"homework/{problem_index}.txt"
+    system = STUDENT_SYSTEM_PROMPT.replace("homework file", f"file {filename}")
+    messages = [
+        {"role": "system", "content": system},
+        *conversation_history,
+    ]
+    resp = client.chat.completions.create(model=model, messages=messages)
+    return strip_thinking(resp.choices[0].message.content)
+
+
+def run_one_problem(
+    problem_index: int,
+    gateway_url: str,
+    gateway_token: str,
+    external_client: OpenAI,
+    model: str,
+    max_turns: int,
+    output_file: str="student_results.txt",
+) -> bool:
+    session_user = f"student-hw-{problem_index}-{os.getpid()}"
+    conversation_history: list[dict] = []
+
+    print(f"\n{'#'*60}")
+    print(f"# Problem {problem_index} (session: {session_user})")
+    print(f"{'#'*60}")
+
+    for turn in range(max_turns):
+        if turn == 0:
+            student_msg = FIRST_MESSAGE_TEMPLATE.format(index=problem_index)
+        else:
+            student_msg = generate_student_message(
+                external_client, model, problem_index, conversation_history,
+            )
+
+        if DONE_SENTINEL in student_msg:
+            print(f"\n  Turn {turn + 1}: Student confirmed problem {problem_index} is done!")
+            return True
+
+        print(f"\n  {'='*56}")
+        print(f"  Turn {turn + 1}/{max_turns}")
+        print(f"  {'='*56}")
+        print(f"  >> Student -> OpenClaw:\n  {student_msg}\n")
+
+        time.sleep(1)
+
+        conversation_history.append({"role": "assistant", "content": student_msg})
+
+        openclaw_reply = send_to_openclaw(gateway_url, gateway_token, student_msg, session_user)
+        print(f"  << OpenClaw -> Student:\n  {openclaw_reply}\n")
+
+        if output_file and turn == 0:
+            with open(output_file, "a", encoding="utf-8") as f:
+                f.write(f"[session: {session_user}]\n")
+                f.write(f"{openclaw_reply}\n\n")
+
+        conversation_history.append({
+            "role": "user",
+            "content": f"The AI assistant replied:\n\n{openclaw_reply}",
+        })
+
+    print(f"\n  Reached max turns ({max_turns}) for problem {problem_index}.")
+    return False
+
+
+def main():
+    global RETRY_INTERVAL, MAX_RETRIES, SGLANG_ENGINE_URL
+    parser = argparse.ArgumentParser(
+        description="Single-GPU GSM8K homework runner with offload-aware retry"
+    )
+    parser.add_argument("--dataset", type=str, required=True, help="Path to GSM8K.json")
+    parser.add_argument("--num-problems", type=int, default=5, help="Number of problems (default: 5)")
+    parser.add_argument("--max-turns", type=int, default=8, help="Max turns per problem (default: 8)")
+    parser.add_argument(
+        "--retry-interval", type=int, default=None,
+        help=f"Seconds to wait on ENGINE_OFFLOADED (default: {RETRY_INTERVAL})",
+    )
+    parser.add_argument(
+        "--max-retries", type=int, default=None,
+        help=f"Max retry attempts per request (default: {MAX_RETRIES})",
+    )
+    parser.add_argument(
+        "--sglang-url", type=str, default=None,
+        help=f"Local SGLang engine URL for pre-flight health check (default: {SGLANG_ENGINE_URL}). Pass empty string to disable.",
+    )
+    args = parser.parse_args()
+
+    if args.retry_interval is not None:
+        RETRY_INTERVAL = args.retry_interval
+    if args.max_retries is not None:
+        MAX_RETRIES = args.max_retries
+    if args.sglang_url is not None:
+        SGLANG_ENGINE_URL = args.sglang_url
+
+    gateway_token = get_env_or_exit("OPENCLAW_GATEWAY_TOKEN")
+    gateway_url = os.environ.get("OPENCLAW_GATEWAY_URL", "http://localhost:18789").rstrip("/")
+    openai_api_key = get_env_or_exit("OPENAI_API_KEY")
+    openai_base_url = os.environ.get("OPENAI_BASE_URL", "").strip() or None
+    model = os.environ.get("EXTERNAL_MODEL", "gpt-4o").strip()
+    workspace = os.environ.get(
+        "OPENCLAW_WORKSPACE",
+        os.path.expanduser("~/.openclaw/workspace"),
+    )
+
+    external_client = OpenAI(api_key=openai_api_key, base_url=openai_base_url)
+
+    problems = load_dataset(args.dataset)
+    print(f"Loaded {len(problems)} problems from {args.dataset}")
+    print(f"Running {args.num_problems} problems, max {args.max_turns} turns each")
+    print(f"Offload retry: {RETRY_INTERVAL}s interval, {MAX_RETRIES} max retries")
+    print(f"SGLang pre-check URL: {SGLANG_ENGINE_URL or '(disabled)'}")
+    print(f"Workspace: {workspace}\n")
+
+    print("Preparing homework files:")
+    count = prepare_homework_files(problems, workspace, args.num_problems)
+    print()
+
+    results = []
+    for i in range(count):
+        completed = run_one_problem(
+            problem_index=i,
+            gateway_url=gateway_url,
+            gateway_token=gateway_token,
+            external_client=external_client,
+            model=model,
+            max_turns=args.max_turns,
+            output_file="student_results.txt",
+        )
+        results.append(completed)
+
+    done = sum(results)
+    print(f"\n{'#'*60}")
+    print(f"# Summary: {done}/{count} problems completed within turn limit")
+    print(f"{'#'*60}")
+    for i, ok in enumerate(results):
+        status = "done" if ok else "incomplete"
+        gt = problems[i].get("ground_truth_answer", "?")
+        print(f"  Problem {i}: {status} (ground truth: {gt})")
+
+
+if __name__ == "__main__":
+    main()

--- a/openclaw-test/teacher_chat_single_gpu.py
+++ b/openclaw-test/teacher_chat_single_gpu.py
@@ -1,0 +1,239 @@
+"""
+Single-GPU GSM8K teacher/grader runner with SGLang-aware retry.
+
+Pre-checks the local SGLang rollout engine (/health_generate) before each request.
+If the engine is offloaded for training, waits RETRY_INTERVAL seconds and retries.
+Falls back to 503/ENGINE_OFFLOADED detection from OpenClaw as a secondary guard.
+
+Env vars:
+  OPENCLAW_GATEWAY_TOKEN  required: OpenClaw auth token
+  OPENAI_API_KEY          required: external (teacher) LLM key
+  OPENCLAW_GATEWAY_URL    default: http://localhost:18789
+  OPENCLAW_WORKSPACE      default: ~/.openclaw/workspace
+  OPENAI_BASE_URL         optional: custom LLM base URL
+  EXTERNAL_MODEL          default: gpt-4o
+  SGLANG_ENGINE_URL       default: http://localhost:30000  (empty = disable pre-check)
+  OFFLOAD_RETRY_INTERVAL  default: 180 (seconds between retries)
+  OFFLOAD_MAX_RETRIES     default: 30
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+
+import requests
+from openai import OpenAI
+from student_chat_single_gpu import send_to_openclaw
+TEACHER_SYSTEM_PROMPT = """\
+You are role-playing as a teacher who is grading student homework. You talk casually. \
+You want the AI to write comments that is detailed, patient, and encouraging.
+
+You CANNOT grade, rewrite, rephrase, or produce any comments yourself. \
+You can ONLY tell the AI what to do. Never do the grading yourself.
+
+Your goal: get the AI to grade the student's homework and write comments. \
+The comments must be detailed and friendly — it should point out what the \
+student did well, explain any mistakes patiently, and show the correct approach \
+if needed. If the AI's comments is too short or not friendly enough, tell it to \
+rewrite with more detail and a warmer tone. Just tell it to fix it — don't fix \
+it yourself. If the comments is already detailed and friendly, no need to rewrite.
+
+Steps:
+1. Look at what the AI gives you. If the comments is not detailed or friendly enough, \
+tell it to redo it. If it's good, no need to redo. \
+Do NOT mention writing to the file in the same message. Only ask for a rewrite.
+2. After the AI shows you the satisfactory version, THEN in a \
+separate message ask it to append the comments to the end of the homework file \
+(not overwrite it). Do NOT combine a rewrite request and a write request.
+3. After the AI says it saved the file, say exactly: GRADING_DONE
+
+Never say GRADING_DONE until the AI confirms it wrote the file.
+Never write or grade anything yourself. Just give simple instructions."""
+
+FIRST_MESSAGE_TEMPLATE = """\
+I'm grading a student's homework. The submission is in the file homework/{index}.txt \
+in your workspace. Please read the file first.
+
+Here is the original question and the correct answer for reference:
+
+Question: {question}
+
+Correct answer: {ground_truth}
+
+Please read the student's submission from the file, compare it with the correct \
+answer, and write the grading comments directly. No intro, no summary, no \
+"here are the comments" — just the comments themselves, as if you are writing \
+them on the student's paper. \
+Show me the comments first — don't write to the file until I tell you to."""
+
+DONE_SENTINEL = "GRADING_DONE"
+ENGINE_OFFLOADED_CODE = "ENGINE_OFFLOADED"
+
+RETRY_INTERVAL = int(os.environ.get("OFFLOAD_RETRY_INTERVAL", "60"))
+MAX_RETRIES = int(os.environ.get("OFFLOAD_MAX_RETRIES", "60"))
+SGLANG_ENGINE_URL = os.environ.get("SGLANG_ENGINE_URL", "http://localhost:30000").rstrip("/")
+
+
+def strip_thinking(text: str) -> str:
+    return re.sub(r"<think>[\s\S]*?</think>\s*", "", text).strip()
+
+
+def get_env_or_exit(name: str) -> str:
+    val = os.environ.get(name, "").strip()
+    if not val:
+        print(f"Error: environment variable {name} is not set.", file=sys.stderr)
+        sys.exit(1)
+    return val
+
+
+def load_dataset(path: str) -> list[dict]:
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        print(f"Error: dataset file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(data, list):
+        print("Error: dataset must be a JSON array.", file=sys.stderr)
+        sys.exit(1)
+    return data
+
+def generate_teacher_message(
+    client: OpenAI,
+    model: str,
+    problem_index: int,
+    conversation_history: list[dict],
+) -> str:
+    filename = f"homework/{problem_index}.txt"
+    system = TEACHER_SYSTEM_PROMPT.replace("homework file", f"file {filename}")
+    messages = [{"role": "system", "content": system}, *conversation_history]
+    resp = client.chat.completions.create(model=model, messages=messages)
+    return strip_thinking(resp.choices[0].message.content)
+
+
+def run_one_grading(
+    problem_index: int,
+    question: str,
+    ground_truth: str,
+    gateway_url: str,
+    gateway_token: str,
+    external_client: OpenAI,
+    model: str,
+    max_turns: int,
+    output_file: str="teacher_results.txt",
+) -> bool:
+    session_user = f"teacher-grade-{problem_index}-{os.getpid()}"
+    conversation_history: list[dict] = []
+
+    print(f"\n{'#'*60}")
+    print(f"# Grading problem {problem_index} (session: {session_user})")
+    print(f"# Ground truth: {ground_truth}")
+    print(f"{'#'*60}")
+
+    for turn in range(max_turns):
+        if turn == 0:
+            teacher_msg = FIRST_MESSAGE_TEMPLATE.format(
+                index=problem_index, question=question, ground_truth=ground_truth,
+            )
+        else:
+            teacher_msg = generate_teacher_message(
+                external_client, model, problem_index, conversation_history,
+            )
+
+        if DONE_SENTINEL in teacher_msg:
+            print(f"\n  Turn {turn + 1}: Grading for problem {problem_index} done!")
+            return True
+
+        print(f"\n  {'='*56}")
+        print(f"  Turn {turn + 1}/{max_turns}")
+        print(f"  {'='*56}")
+        print(f"  >> Teacher -> OpenClaw:\n  {teacher_msg}\n")
+
+        time.sleep(1)
+        conversation_history.append({"role": "assistant", "content": teacher_msg})
+
+        openclaw_reply = send_to_openclaw(gateway_url, gateway_token, teacher_msg, session_user)
+        print(f"  << OpenClaw -> Teacher:\n  {openclaw_reply}\n")
+
+        if output_file and turn == 0:
+            with open(output_file, "a", encoding="utf-8") as f:
+                f.write(f"[session: {session_user}]\n")
+                f.write(f"{openclaw_reply}\n\n")
+
+        conversation_history.append({
+            "role": "user",
+            "content": f"The AI assistant replied:\n\n{openclaw_reply}",
+        })
+
+    print(f"\n  Reached max turns ({max_turns}) for problem {problem_index}.")
+    return False
+
+
+def main():
+    global RETRY_INTERVAL, MAX_RETRIES, SGLANG_ENGINE_URL
+    parser = argparse.ArgumentParser(description="Single-GPU GSM8K grader with SGLang-aware retry")
+    parser.add_argument("--dataset", type=str, required=True, help="Path to GSM8K.json")
+    parser.add_argument("--num-problems", type=int, default=5, help="Number of problems (default: 5)")
+    parser.add_argument("--max-turns", type=int, default=8, help="Max turns per problem (default: 8)")
+    parser.add_argument("--retry-interval", type=int, default=None,
+                        help=f"Seconds between retries (default: {RETRY_INTERVAL})")
+    parser.add_argument("--max-retries", type=int, default=None,
+                        help=f"Max retry attempts (default: {MAX_RETRIES})")
+    parser.add_argument("--sglang-url", type=str, default=None,
+                        help=f"SGLang engine URL for health pre-check (default: {SGLANG_ENGINE_URL}). Empty = disable.")
+    args = parser.parse_args()
+
+    if args.retry_interval is not None:
+        RETRY_INTERVAL = args.retry_interval
+    if args.max_retries is not None:
+        MAX_RETRIES = args.max_retries
+    if args.sglang_url is not None:
+        SGLANG_ENGINE_URL = args.sglang_url
+
+    gateway_token = get_env_or_exit("OPENCLAW_GATEWAY_TOKEN")
+    gateway_url = os.environ.get("OPENCLAW_GATEWAY_URL", "http://localhost:18789").rstrip("/")
+    openai_api_key = get_env_or_exit("OPENAI_API_KEY")
+    openai_base_url = os.environ.get("OPENAI_BASE_URL", "").strip() or None
+    model = os.environ.get("EXTERNAL_MODEL", "gpt-4o").strip()
+
+    external_client = OpenAI(api_key=openai_api_key, base_url=openai_base_url)
+
+    problems = load_dataset(args.dataset)
+    count = min(args.num_problems, len(problems))
+    print(f"Loaded {len(problems)} problems from {args.dataset}")
+    print(f"Grading {count} problems, max {args.max_turns} turns each")
+    print(f"Retry: {RETRY_INTERVAL}s interval, {MAX_RETRIES} max retries")
+    print(f"SGLang pre-check URL: {SGLANG_ENGINE_URL or '(disabled)'}\n")
+
+    results = []
+    for i in range(count):
+        question = problems[i].get("question", "")
+        ground_truth = problems[i].get("ground_truth_answer", "?")
+        completed = run_one_grading(
+            problem_index=i,
+            question=question,
+            ground_truth=ground_truth,
+            gateway_url=gateway_url,
+            gateway_token=gateway_token,
+            external_client=external_client,
+            model=model,
+            max_turns=args.max_turns,
+            output_file="teacher_results.txt",
+        )
+        results.append(completed)
+
+    done = sum(results)
+    print(f"\n{'#'*60}")
+    print(f"# Summary: {done}/{count} problems graded within turn limit")
+    print(f"{'#'*60}")
+    for i, ok in enumerate(results):
+        status = "done" if ok else "incomplete"
+        gt = problems[i].get("ground_truth_answer", "?")
+        print(f"  Problem {i}: {status} (ground truth: {gt})")
+
+
+if __name__ == "__main__":
+    main()

--- a/slime/slime/backends/fsdp_utils/actor.py
+++ b/slime/slime/backends/fsdp_utils/actor.py
@@ -87,8 +87,7 @@ class FSDPTrainRayActor(TrainRayActor):
         with init_context():
             model = self.get_model_cls().from_pretrained(
                 self.args.hf_checkpoint,
-                trust_remote_code=True,
-                attn_implementation=self.args.attn_implementation,
+                **self._build_model_load_kwargs(),
             )
 
         model.train()
@@ -101,19 +100,24 @@ class FSDPTrainRayActor(TrainRayActor):
             model = apply_lora(model, self.args)
             model = propagate_no_split_modules(model)
 
-        full_state = model.state_dict()
+        if getattr(self.args, "fsdp_load_in_4bit", False) and dist.get_world_size() > 1:
+            raise NotImplementedError("fsdp_load_in_4bit currently supports single-rank training only.")
 
-        model = apply_fsdp2(model, mesh=self.dp_mesh, cpu_offload=self.fsdp_cpu_offload, args=self.args)
-
-        model = self._fsdp2_load_full_state_dict(
-            model, full_state, self.dp_mesh, cpu_offload=True if self.fsdp_cpu_offload else None
-        )
+        if getattr(self.args, "fsdp_load_in_4bit", False):
+            model = apply_fsdp2(model, mesh=self.dp_mesh, cpu_offload=self.fsdp_cpu_offload, args=self.args)
+        else:
+            full_state = model.state_dict()
+            model = apply_fsdp2(model, mesh=self.dp_mesh, cpu_offload=self.fsdp_cpu_offload, args=self.args)
+            model = self._fsdp2_load_full_state_dict(
+                model, full_state, self.dp_mesh, cpu_offload=True if self.fsdp_cpu_offload else None
+            )
 
         self.model = model
 
         if args.gradient_checkpointing:
             # LoRA freezes base params, so reentrant checkpointing fails
             # (inputs don't have requires_grad=True). Use non-reentrant mode.
+            self.model.config.use_cache = False
             gc_kwargs = {"use_reentrant": False} if self._is_lora else {}
             self.model.gradient_checkpointing_enable(gradient_checkpointing_kwargs=gc_kwargs)
 
@@ -161,6 +165,9 @@ class FSDPTrainRayActor(TrainRayActor):
             def _lora_name_transform(name: str) -> str | None:
                 # Skip LoRA adapter parameters — SGLang only needs merged base weights
                 if "lora_A" in name or "lora_B" in name or "lora_embedding" in name:
+                    return None
+                # Skip bitsandbytes quantisation metadata (quant_state / absmax / …)
+                if "quant_state" in name or "bitsandbytes" in name:
                     return None
                 # Strip PEFT outer prefix: base_model.model.xxx → xxx
                 if name.startswith("base_model.model."):
@@ -243,11 +250,14 @@ class FSDPTrainRayActor(TrainRayActor):
         """
         from accelerate import init_empty_weights
 
-        # Check if model uses tied word embeddings (which doesn't work with meta tensors)
-        use_meta_tensor = not self.hf_config.tie_word_embeddings
-
         def cpu_init_weights():
             return torch.device("cpu")
+        
+        if getattr(self.args, "fsdp_load_in_4bit", False):
+            return cpu_init_weights
+
+        # Check if model uses tied word embeddings (which doesn't work with meta tensors)
+        use_meta_tensor = not self.hf_config.tie_word_embeddings
 
         if use_meta_tensor:
             # Rank 0: CPU, others: meta device (memory efficient for large models)
@@ -255,6 +265,55 @@ class FSDPTrainRayActor(TrainRayActor):
         else:
             logger.info(f"[Rank {dist.get_rank()}] tie_word_embeddings=True, loading full model to CPU on all ranks")
             return cpu_init_weights
+    
+    def _build_model_load_kwargs(self) -> dict:
+        kwargs = {
+            "trust_remote_code": True,
+            "attn_implementation": self.args.attn_implementation,
+        }
+
+        if getattr(self.args, "fsdp_load_in_4bit", False):
+            quant_cfg = getattr(self.hf_config, "quantization_config", None)
+            quant_method = None
+            if isinstance(quant_cfg, dict):
+                quant_method = quant_cfg.get("quant_method")
+            elif quant_cfg is not None:
+                quant_method = getattr(quant_cfg, "quant_method", None)
+
+            if str(quant_method).lower() == "compressed-tensors":
+                raise ValueError(
+                    "Detected quant_method=compressed-tensors in checkpoint config. "
+                    "For bitsandbytes QLoRA (--fsdp-load-in-4bit), please use the ORIGINAL HF checkpoint "
+                    "(e.g. Qwen3-4B-Thinking-2507), not a pre-converted INT4 directory."
+                )
+
+            from transformers import BitsAndBytesConfig
+
+            dtype_name = str(getattr(self.args, "fsdp_bnb_4bit_compute_dtype", "bfloat16")).lower()
+            compute_dtype_map = {
+                "bfloat16": torch.bfloat16,
+                "bf16": torch.bfloat16,
+                "float16": torch.float16,
+                "fp16": torch.float16,
+                "float32": torch.float32,
+                "fp32": torch.float32,
+            }
+            compute_dtype = compute_dtype_map.get(dtype_name)
+            if compute_dtype is None:
+                raise ValueError(
+                    f"Unsupported fsdp_bnb_4bit_compute_dtype={self.args.fsdp_bnb_4bit_compute_dtype}. "
+                    "Use bfloat16/float16/float32."
+                )
+
+            kwargs["quantization_config"] = BitsAndBytesConfig(
+                load_in_4bit=True,
+                bnb_4bit_quant_type=getattr(self.args, "fsdp_bnb_4bit_quant_type", "nf4"),
+                bnb_4bit_compute_dtype=compute_dtype,
+                bnb_4bit_use_double_quant=bool(getattr(self.args, "fsdp_bnb_4bit_use_double_quant", True)),
+            )
+            kwargs["device_map"] = {"": torch.cuda.current_device()}
+
+        return kwargs
 
     def _fsdp2_load_full_state_dict(self, model, full_state, device_mesh, cpu_offload):
         """Load full state dict into FSDP2 model with efficient broadcast from rank 0.
@@ -408,6 +467,62 @@ class FSDPTrainRayActor(TrainRayActor):
             of packed batch dictionaries and `grad_accum` lists the micro-batch
             indices at which to perform optimizer steps.
         """
+        # ---- Optional: truncate each sample to keep the LAST max_seq_len tokens ----
+        # This drops the earliest prompt tokens, preserving the full response.
+        # Controlled by env var SLIME_TRAIN_MAX_SEQ_LEN (0 or unset = no truncation).
+        _max_seq_len = int(os.environ.get("SLIME_TRAIN_MAX_SEQ_LEN", "0"))
+        if _max_seq_len > 0:
+            for idx in range(len(rollout_data["tokens"])):
+                t = rollout_data["tokens"][idx]
+                if len(t) > _max_seq_len:
+                    trim = len(t) - _max_seq_len
+                    if dist.get_rank() == 0 and idx == 0:
+                        logger.info(
+                            f"SLIME_TRAIN_MAX_SEQ_LEN={_max_seq_len}: "
+                            f"sample {idx} truncated from {len(t)} to {_max_seq_len} tokens (dropped first {trim})"
+                        )
+                    rollout_data["tokens"][idx] = t[-_max_seq_len:]
+                    rollout_data["loss_masks"][idx] = rollout_data["loss_masks"][idx][-_max_seq_len:]
+
+                    # If truncation cut into the response (thinking models can have
+                    # very long responses), clamp response_lengths and trim all
+                    # response-only tensors to match.
+                    new_resp_len = int(sum(rollout_data["loss_masks"][idx]))
+                    # The first token of a sequence has no autoregressive
+                    # predecessor, so no valid log-prob exists for it.
+                    # Cap response_lengths at seq_len - 1 and zero out the
+                    # corresponding loss_mask bit.
+                    seq_len_after_trunc = len(rollout_data["tokens"][idx])
+                    if new_resp_len >= seq_len_after_trunc:
+                        new_resp_len = seq_len_after_trunc - 1
+                        # Zero the first set bit in loss_masks (the token we can't compute loss for)
+                        lm = rollout_data["loss_masks"][idx]
+                        if isinstance(lm, torch.Tensor):
+                            first_set = (lm != 0).nonzero(as_tuple=True)[0]
+                            if len(first_set) > 0:
+                                lm[first_set[0]] = 0
+                        else:
+                            for k in range(len(lm)):
+                                if lm[k] != 0:
+                                    lm[k] = 0
+                                    break
+                    old_resp_len = rollout_data["response_lengths"][idx]
+                    if new_resp_len < old_resp_len:
+                        rollout_data["response_lengths"][idx] = new_resp_len
+                        for resp_key in ["advantages", "returns"]:
+                            if resp_key in rollout_data and isinstance(rollout_data[resp_key][idx], torch.Tensor):
+                                rollout_data[resp_key][idx] = (
+                                    rollout_data[resp_key][idx][-new_resp_len:] if new_resp_len > 0
+                                    else rollout_data[resp_key][idx][:0]
+                                )
+
+                    if "rollout_log_probs" in rollout_data and rollout_data["rollout_log_probs"][idx] is not None:
+                        rlp = rollout_data["rollout_log_probs"][idx]
+                        if len(rlp) > new_resp_len:
+                            rollout_data["rollout_log_probs"][idx] = (
+                                rlp[-new_resp_len:] if new_resp_len > 0 else rlp[:0]
+                            )
+
         # Pack sequences efficiently
         tokens = rollout_data["tokens"]
 
@@ -562,6 +677,7 @@ class FSDPTrainRayActor(TrainRayActor):
                 )
 
         self.prof.step(rollout_id=rollout_id)
+        print(torch.cuda.memory_summary(device=None, abbreviated=False))
 
         train_dump_utils.save_debug_train_data(self.args, rollout_id=rollout_id, rollout_data=rollout_data)
 
@@ -597,6 +713,8 @@ class FSDPTrainRayActor(TrainRayActor):
             temperature=self.args.rollout_temperature,
             compute_entropy=need_entropy,
         )
+        del logits
+        print_memory(f"计算log_probs和entropy之后")
         packed_batch["cur_log_probs"] = log_probs
         packed_batch["entropy"] = entropy_result
 
@@ -712,7 +830,10 @@ class FSDPTrainRayActor(TrainRayActor):
 
         # Scale loss for gradient accumulation
         loss = loss * self.dp_size / self.args.global_batch_size
+        print_memory(f"计算loss之后")
+        torch.cuda.empty_cache()
         loss.backward()
+        print_memory(f"反向传播之后")
 
         # Accumulate reported metrics (store tensors for later mean)
         for k, v in reported.items():
@@ -757,6 +878,42 @@ class FSDPTrainRayActor(TrainRayActor):
                 log_dict["train/step"] = self.global_step
                 logging_utils.log(self.args, log_dict, step_key="train/step")
             self.global_step += 1
+    
+    def _build_dequantized_state_dict(self) -> dict[str, torch.Tensor]:
+        """Return a state dict with bnb 4-bit weights dequantized to full shape.
+        """
+        try:
+            import bitsandbytes as bnb
+            import bitsandbytes.functional as bnb_F
+
+            bnb_cls = bnb.nn.Linear4bit
+        except ImportError:
+            return self.model.state_dict()
+
+        # Build a lookup: state-dict key -> Linear4bit module
+        bnb_weight_keys: dict[str, torch.nn.Module] = {}
+        for name, module in self.model.named_modules():
+            if isinstance(module, bnb_cls):
+                bnb_weight_keys[f"{name}.weight"] = module
+
+        if bnb_weight_keys:
+            logger.info("_build_dequantized_state_dict: found %d Linear4bit modules to dequantize", len(bnb_weight_keys))
+
+        state_dict: dict[str, torch.Tensor] = {}
+        for key, value in self.model.state_dict().items():
+            is_bnb_meta = any(key.startswith(wk + ".") for wk in bnb_weight_keys)
+            if is_bnb_meta:
+                continue
+            if key in bnb_weight_keys:
+                mod = bnb_weight_keys[key]
+                # Dequantize compressed uint8 → compute dtype (e.g. bf16)
+                w = bnb_F.dequantize_4bit(mod.weight.data, mod.weight.quant_state)
+                
+                state_dict[key] = w
+            else:
+                state_dict[key] = value
+
+        return state_dict
 
     @timer
     def update_weights(self) -> None:  # type: ignore[override]
@@ -782,7 +939,11 @@ class FSDPTrainRayActor(TrainRayActor):
         if self._is_lora:
             self.model.merge_adapter()
         try:
-            self.weight_updater.update_weights()
+            if getattr(self.args, "fsdp_load_in_4bit", False):
+                dequant_sd = self._build_dequantized_state_dict()
+                self.weight_updater.update_weights(state_dict=dequant_sd)
+            else:
+                self.weight_updater.update_weights()
         finally:
             if self._is_lora:
                 self.model.unmerge_adapter()
@@ -823,15 +984,17 @@ class FSDPTrainRayActor(TrainRayActor):
             with init_context():
                 ref_model = self.get_model_cls().from_pretrained(
                     ref_load_path,
-                    trust_remote_code=True,
-                    attn_implementation=self.args.attn_implementation,
+                    **self._build_model_load_kwargs(),
                 )
+            
+            if getattr(self.args, "fsdp_load_in_4bit", False):
+                ref_model = apply_fsdp2(ref_model, mesh=self.dp_mesh, cpu_offload=self.fsdp_cpu_offload, args=self.args)
+            else:
+                full_state = ref_model.state_dict()
 
-            full_state = ref_model.state_dict()
-
-            # Always use CPUOffloadPolicy for reference, let FSDP2 handle the offload. It is faster than model.cpu().
-            ref_model = apply_fsdp2(ref_model, mesh=self.dp_mesh, cpu_offload=True, args=self.args)
-            ref_model = self._fsdp2_load_full_state_dict(ref_model, full_state, self.dp_mesh, cpu_offload=True)
+                # Always use CPUOffloadPolicy for reference, let FSDP2 handle the offload. It is faster than model.cpu().
+                ref_model = apply_fsdp2(ref_model, mesh=self.dp_mesh, cpu_offload=True, args=self.args)
+                ref_model = self._fsdp2_load_full_state_dict(ref_model, full_state, self.dp_mesh, cpu_offload=True)
 
             logger.info(f"[Rank {dist.get_rank()}] Reference model created with FSDP2 CPUOffloadPolicy")
             return ref_model
@@ -839,8 +1002,9 @@ class FSDPTrainRayActor(TrainRayActor):
             raise NotImplementedError(f"Loading from checkpoint file {ref_load_path} not yet implemented")
 
     def _get_model_inputs_args(self, packed_sequence: dict) -> dict:
-        input_ids = packed_sequence["tokens"].unsqueeze(0)
-        position_ids = packed_sequence["position_ids"].unsqueeze(0)
+        device = torch.cuda.current_device()
+        input_ids = packed_sequence["tokens"].unsqueeze(0).to(device)
+        position_ids = packed_sequence["position_ids"].unsqueeze(0).to(device)
 
         model_args = {
             "input_ids": input_ids,
@@ -928,6 +1092,44 @@ def get_logprob_and_entropy(
         entropy: Entropy with shape [seq_len - 1]
     """
     shifted_logits = logits[:-1, :]
+    _chunk_size = int(os.environ.get("SLIME_LOGIT_CHUNK_SIZE", "1024"))
+    if _chunk_size > 0:
+        # Chunked path: avoids materialising a full [T-1, V] log-softmax tensor.
+        # Peak extra VRAM is O(chunk * V) instead of O(T * V).
+        # For Qwen3-4B (V≈152K, T≈4096) this cuts peak allocation from ~7.5 GB to ~0.9 GB.
+        T = shifted_logits.shape[0]
+        targets = target_tokens[1:].to(device=shifted_logits.device)
+        if temperature is not None:
+            temp_tensor = torch.tensor(temperature, dtype=shifted_logits.dtype, device=shifted_logits.device)
+
+        log_probs_chunks: list[torch.Tensor] = []
+        entropy_chunks: list[torch.Tensor] = []
+
+        for start in range(0, T, _chunk_size):
+            chunk = shifted_logits[start : start + _chunk_size].float()
+            if temperature is not None:
+                chunk = chunk / temp_tensor
+            log_p = torch.log_softmax(chunk, dim=-1)         # [chunk, V]
+            del chunk
+
+            chunk_targets = targets[start : start + _chunk_size]
+            lp = torch.gather(log_p, dim=-1, index=chunk_targets.unsqueeze(-1)).squeeze(-1)
+            log_probs_chunks.append(lp)
+
+            if compute_entropy:
+                p = log_p.exp()                               # [chunk, V]
+                ent = -(p * log_p).sum(dim=-1)               # [chunk]
+                entropy_chunks.append(ent)
+                del p
+            del log_p
+
+        log_probs = torch.cat(log_probs_chunks)
+        if compute_entropy:
+            entropy = torch.cat(entropy_chunks)
+        else:
+            entropy = torch.zeros_like(log_probs)
+        return log_probs, entropy
+    
     log_probs = gather_log_probs_packed(
         shifted_logits, target_tokens, allow_compile=allow_compile, temperature=temperature
     )
@@ -989,6 +1191,12 @@ def apply_fsdp2(model, mesh=None, cpu_offload=False, args=None):
     Ref: https://github.com/volcengine/verl/blob/main/verl/utils/fsdp_utils.py
     """
     from torch.distributed.fsdp import CPUOffloadPolicy, MixedPrecisionPolicy, fully_shard
+
+    if args is not None and getattr(args, "fsdp_load_in_4bit", False):
+        logger.warning(
+            "Skip FSDP fully_shard for fsdp_load_in_4bit to avoid bnb-4bit non-floating parameter conflict."
+        )
+        return model
 
     offload_policy = CPUOffloadPolicy() if cpu_offload else None
 

--- a/slime/slime/backends/fsdp_utils/arguments.py
+++ b/slime/slime/backends/fsdp_utils/arguments.py
@@ -55,6 +55,13 @@ class FSDPArgs:
     lora_target_modules: str | None = None  # comma-separated, e.g. "q_proj,v_proj"
     lora_modules_to_save: str | None = None  # modules kept fully trainable
 
+    # QLoRA / INT4
+    fsdp_load_in_4bit: bool = False
+    fsdp_bnb_4bit_quant_type: str = "nf4"  # nf4 / fp4
+    fsdp_bnb_4bit_compute_dtype: str = "bfloat16"  # bfloat16 / float16 / float32
+    fsdp_bnb_4bit_use_double_quant: bool = True
+    fsdp_prepare_model_for_kbit_training: bool = True
+    
     # Profile
     record_memory_history: bool = False
     memory_snapshot_path: str = "snapshot.pickle"

--- a/slime/slime/backends/fsdp_utils/checkpoint.py
+++ b/slime/slime/backends/fsdp_utils/checkpoint.py
@@ -135,13 +135,23 @@ def load(actor: Any) -> dict[str, Any] | None:
     # Load optimizer state (optional)
     load_optimizer = not getattr(actor.args, "no_load_optim", False) and hasattr(actor, "optimizer")
     if load_optimizer and optimizer_dir.exists():
-        optimizer_state = OptimizerState(actor.model, actor.optimizer)
-        optim_state_dict = {"optim_state": optimizer_state}
-        try:
-            dcp.load(state_dict=optim_state_dict, checkpoint_id=str(optimizer_dir))
-            logger.info(f"[FSDP] Loaded optimizer from {optimizer_dir}")
-        except Exception as e:
-            logger.warning(f"[FSDP] Failed to load optimizer from {optimizer_dir}: {e}")
+        raw_optim_file = optimizer_dir / "optimizer.pt"
+        if raw_optim_file.exists():
+            # Saved via torch.save (4-bit path)
+            try:
+                state = torch.load(raw_optim_file, map_location="cpu", weights_only=True)
+                actor.optimizer.load_state_dict(state)
+                logger.info(f"[FSDP] Loaded optimizer from {raw_optim_file}")
+            except Exception as e:
+                logger.warning(f"[FSDP] Failed to load optimizer from {raw_optim_file}: {e}")
+        else:
+            optimizer_state = OptimizerState(actor.model, actor.optimizer)
+            optim_state_dict = {"optim_state": optimizer_state}
+            try:
+                dcp.load(state_dict=optim_state_dict, checkpoint_id=str(optimizer_dir))
+                logger.info(f"[FSDP] Loaded optimizer from {optimizer_dir}")
+            except Exception as e:
+                logger.warning(f"[FSDP] Failed to load optimizer from {optimizer_dir}: {e}")
     elif load_optimizer:
         logger.info(f"[FSDP] Optimizer checkpoint not found at {optimizer_dir}, skipping optimizer load.")
 
@@ -236,9 +246,19 @@ def save(actor: Any, iteration: int) -> None:
     # Save optimizer state (skip if --no-save-optim is set)
     save_optimizer_state = not getattr(actor.args, "no_save_optim", False)
     if save_optimizer_state and hasattr(actor, "optimizer") and actor.optimizer is not None:
-        optimizer_state = OptimizerState(actor.model, actor.optimizer)
-        optim_state_dict = {"optim_state": optimizer_state}
-        dcp.save(optim_state_dict, checkpoint_id=str(optimizer_dir))
+        from .lora_utils import _has_4bit_params
+        if _has_4bit_params(actor.model):
+            # DCP's get_state_dict traverses the model for FQNs and chokes on
+            # Params4bit.  For 4-bit LoRA the optimizer only holds LoRA param
+            # states (base model is frozen), so plain torch.save is sufficient.
+            if dist.get_rank() == 0:
+                optimizer_dir.mkdir(parents=True, exist_ok=True)
+                torch.save(actor.optimizer.state_dict(), optimizer_dir / "optimizer.pt")
+            dist.barrier()
+        else:
+            optimizer_state = OptimizerState(actor.model, actor.optimizer)
+            optim_state_dict = {"optim_state": optimizer_state}
+            dcp.save(optim_state_dict, checkpoint_id=str(optimizer_dir))
 
     # Save LR scheduler state (skip if --no-save-optim is set)
     if save_optimizer_state and hasattr(actor, "lr_scheduler") and actor.lr_scheduler is not None:

--- a/slime/slime/backends/fsdp_utils/data_packing.py
+++ b/slime/slime/backends/fsdp_utils/data_packing.py
@@ -139,14 +139,10 @@ def unpack_sequences(packed_batch: dict) -> list[dict]:
 
     instances = []
 
-    # Calculate pad_length by counting trailing zeros
+    # Use cu_seqlens to compute padding length instead of counting trailing
+    # zero-valued tokens, because token id 0 can be a legitimate vocabulary entry.
     tokens = packed_batch["tokens"]
-    nonzero_indices = (tokens != 0).nonzero(as_tuple=True)[0]
-    if len(nonzero_indices) > 0:
-        # Last non-zero index, pad_length is everything after it
-        pad_length = len(tokens) - nonzero_indices[-1].item() - 1
-    else:
-        pad_length = 0  # No padding if no non-zero tokens (or all zeros)
+    pad_length = len(tokens) - cu_seqlens[-1].item()
     for i in range(num_sequences):
         start_idx = cu_seqlens[i].item()
         end_idx = cu_seqlens[i + 1].item()

--- a/slime/slime/backends/fsdp_utils/lora_utils.py
+++ b/slime/slime/backends/fsdp_utils/lora_utils.py
@@ -22,7 +22,13 @@ def apply_lora(model: torch.nn.Module, args: Namespace) -> torch.nn.Module:
     Returns the PeftModel wrapper.  All base-model parameters are frozen;
     only the LoRA parameters are trainable.
     """
-    from peft import LoraConfig, get_peft_model
+    from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
+
+    if getattr(args, "fsdp_load_in_4bit", False) and getattr(args, "fsdp_prepare_model_for_kbit_training", True):
+        model = prepare_model_for_kbit_training(
+            model,
+            use_gradient_checkpointing=getattr(args, "gradient_checkpointing", False),
+        )
 
     target_modules = None
     if args.lora_target_modules:
@@ -43,6 +49,9 @@ def apply_lora(model: torch.nn.Module, args: Namespace) -> torch.nn.Module:
     )
 
     model = get_peft_model(model, lora_config)
+    
+    for name, param in model.named_parameters():
+        param.requires_grad = ("lora_" in name)
 
     if dist.get_rank() == 0:
         model.print_trainable_parameters()
@@ -73,23 +82,42 @@ def propagate_no_split_modules(model: torch.nn.Module) -> torch.nn.Module:
     return model
 
 
+def _has_4bit_params(model: torch.nn.Module) -> bool:
+    """Return True if *model* contains any bitsandbytes Params4bit parameters."""
+    try:
+        from bitsandbytes.nn import Params4bit
+        return any(isinstance(p, Params4bit) for _, p in model.named_parameters())
+    except ImportError:
+        return False
+
+
 def save_lora_checkpoint(model: torch.nn.Module, path: Path) -> None:
     """Save only the LoRA adapter weights + config to *path*.
 
     Only rank 0 writes to disk.  All ranks participate in the state-dict
     gathering (handled by FSDP through ``state_dict()``).
     """
-    from torch.distributed.checkpoint.state_dict import StateDictOptions, get_model_state_dict
+    if _has_4bit_params(model):
+        print("save_lora_checkpoint: Detected 4-bit quantized parameters; saving LoRA weights directly without FSDP state dict.")
+        # get_model_state_dict (DCP) chokes on Params4bit objects.  LoRA params
+        # are regular float tensors so we can collect them directly.
+        lora_state = {
+            k: v.detach().cpu()
+            for k, v in model.named_parameters()
+            if "lora_" in k
+        }
+    else:
+        from torch.distributed.checkpoint.state_dict import StateDictOptions, get_model_state_dict
 
-    # Gather full state dict (FSDP2 sharded -> full)
-    full_state = get_model_state_dict(
-        model,
-        options=StateDictOptions(full_state_dict=True, cpu_offload=True),
-    )
-
-    if dist.get_rank() == 0:
+        # Gather full state dict (FSDP2 sharded -> full)
+        full_state = get_model_state_dict(
+            model,
+            options=StateDictOptions(full_state_dict=True, cpu_offload=True),
+        )
         # Filter to only LoRA keys
         lora_state = {k: v for k, v in full_state.items() if "lora_" in k}
+
+    if dist.get_rank() == 0:
         path.mkdir(parents=True, exist_ok=True)
         torch.save(lora_state, path / "adapter_weights.pt")
 

--- a/slime/slime/backends/fsdp_utils/update_weight_utils.py
+++ b/slime/slime/backends/fsdp_utils/update_weight_utils.py
@@ -44,11 +44,11 @@ class UpdateWeight(abc.ABC):
     ) -> None:
         pass
 
-    def update_weights(self) -> None:
+    def update_weights(self, state_dict=None) -> None:
         self.weight_version += 1
         bucket = []
         bucket_size = 0
-        for name, param in self.model.state_dict().items():
+        for name, param in (state_dict or self.model.state_dict()).items():
             if self._name_transform is not None:
                 name = self._name_transform(name)
                 if name is None:
@@ -175,9 +175,9 @@ class UpdateWeightFromTensor(UpdateWeight):
                 ray.get(ref)
 
         if dist.get_rank() == self._ipc_gather_src:
-            ref = self._ipc_engine.flush_cache.remote()
-            ray.get(ref)
-
+            if not getattr(self.args, "offload_rollout", False):
+                ref = self._ipc_engine.flush_cache.remote()
+                ray.get(ref)
 
 class UpdateWeightFromDistributed(UpdateWeight):
     """Broadcast weights via a temporary NCCL group to rollout engines."""

--- a/slime/slime/ray/rollout.py
+++ b/slime/slime/ray/rollout.py
@@ -178,6 +178,7 @@ class RolloutManager:
 
     def offload(self):
         self.health_monitoring_pause()
+        ray.get([engine.pause_generation.remote() for engine in self.rollout_engines if engine is not None])
         return ray.get(
             [engine.release_memory_occupation.remote() for engine in self.rollout_engines if engine is not None]
         )
@@ -196,6 +197,7 @@ class RolloutManager:
 
     def onload_kv(self):
         self.onload(tags=[GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_CUDA_GRAPH])
+        ray.get([engine.continue_generation.remote() for engine in self.rollout_engines if engine is not None])
 
     def recover_rollout_engines(self):
         """Restart any dead rollout engines and update num_new_engines for update_weights detection."""

--- a/slime/slime/utils/arguments.py
+++ b/slime/slime/utils/arguments.py
@@ -1345,6 +1345,42 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 help="PRM model path for PRM engines; defaults to --hf-checkpoint when unset.",
             )
             parser.add_argument(
+                "--prm-use-external-api",
+                action="store_true",
+                default=False,
+                help=(
+                    "Use external OpenAI-compatible PRM API instead of framework-hosted PRM engines. "
+                    "When set, --prm-num-gpus can be 0."
+                ),
+            )
+            parser.add_argument(
+                "--prm-external-api-base",
+                type=str,
+                default=None,
+                help=(
+                    "Base URL for external OpenAI-compatible PRM API, e.g. https://api.example.com/v1. "
+                    "Can also be provided by PRM_EXTERNAL_API_BASE env var."
+                ),
+            )
+            parser.add_argument(
+                "--prm-external-api-key",
+                type=str,
+                default=None,
+                help=(
+                    "API key for external PRM API. "
+                    "Can also be provided by PRM_EXTERNAL_API_KEY env var."
+                ),
+            )
+            parser.add_argument(
+                "--prm-external-model",
+                type=str,
+                default=None,
+                help=(
+                    "Model name used on external PRM API. "
+                    "Can also be provided by PRM_EXTERNAL_MODEL env var."
+                ),
+            )
+            parser.add_argument(
                 "--prm-step-coef",
                 type=float,
                 default=1.0,
@@ -1746,14 +1782,31 @@ def slime_validate_args(args):
     if not args.prm_enable:
         args.prm_num_gpus = 0
     else:
-        assert args.prm_num_gpus > 0, "When --prm-enable is set, --prm-num-gpus must be > 0."
-        assert args.prm_num_gpus_per_engine > 0, "--prm-num-gpus-per-engine must be > 0."
-        assert args.prm_num_gpus % min(args.prm_num_gpus_per_engine, args.num_gpus_per_node) == 0, (
-            "prm_num_gpus must be divisible by min(prm_num_gpus_per_engine, num_gpus_per_node)."
-        )
-        if args.prm_model_path is None:
-            args.prm_model_path = args.hf_checkpoint
+        if args.prm_use_external_api:
+            if args.prm_external_api_base is None:
+                args.prm_external_api_base = os.getenv("PRM_EXTERNAL_API_BASE", None)
+            if args.prm_external_api_key is None:
+                args.prm_external_api_key = os.getenv("PRM_EXTERNAL_API_KEY", None)
+            if args.prm_external_model is None:
+                args.prm_external_model = os.getenv("PRM_EXTERNAL_MODEL", None)
 
+            assert args.prm_external_api_base, (
+                "When --prm-use-external-api is set, --prm-external-api-base or PRM_EXTERNAL_API_BASE is required."
+            )
+            assert args.prm_external_model, (
+                "When --prm-use-external-api is set, --prm-external-model or PRM_EXTERNAL_MODEL is required."
+            )
+            # External PRM API mode does not need local PRM engines.
+            args.prm_num_gpus = 0
+        else:
+            assert args.prm_num_gpus > 0, "When --prm-enable is set, --prm-num-gpus must be > 0."
+            assert args.prm_num_gpus_per_engine > 0, "--prm-num-gpus-per-engine must be > 0."
+            assert args.prm_num_gpus % min(args.prm_num_gpus_per_engine, args.num_gpus_per_node) == 0, (
+                "prm_num_gpus must be divisible by min(prm_num_gpus_per_engine, num_gpus_per_node)."
+            )
+            if args.prm_model_path is None:
+                args.prm_model_path = args.hf_checkpoint
+                
     if args.dump_details is not None:
         args.save_debug_rollout_data = f"{args.dump_details}/rollout_data/{{rollout_id}}.pt"
         args.save_debug_train_data = f"{args.dump_details}/train_data/{{rollout_id}}_{{rank}}.pt"

--- a/slime/train.py
+++ b/slime/train.py
@@ -17,7 +17,7 @@ def train(args):
     rollout_manager, num_rollout_per_epoch = create_rollout_manager(args, pgs["rollout"])
 
     # create the actor and critic models
-    actor_model, critic_model = create_training_models(args, pgs, rollout_manager)
+    actor_model, critic_model, prm_teacher_model= create_training_models(args, pgs, rollout_manager)
 
     if args.offload_rollout:
         ray.get(rollout_manager.onload_weights.remote())


### PR DESCRIPTION
This PR adds support for running OpenClaw-Combine on a single 24 GB GPU using INT4 QLoRA. I’ve included new scripts, updated documentation, and made significant changes to the PRM API server to support external PRM scoring via any OpenAI-compatible API.

**Single-GPU INT4 QLoRA Support**

* Added a new script, `run_qwen3_4b_openclaw_combine_qlora_single_gpu_int4.sh`, that enables full training and inference with QLoRA (**NF4** quantization) on a single **24 GB** GPU. This includes rollout offloading and integration with the external PRM API.
* Added single-GPU memory management features: colocated training + rollout on one GPU, rollout offloading during training (`--offload-rollout`), sequence truncation control (`SLIME_TRAIN_MAX_SEQ_LEN`), and chunked log-prob/entropy computation (`SLIME_LOGIT_CHUNK_SIZE`).
* Updated documentation in `README.md`, `openclaw-combine/README.md`, and `openclaw-test/README.md` to provide detailed setup, environment variables, and step-by-step instructions for single-GPU INT4 QLoRA workflows. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R120) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R245-R264) [[3]](diffhunk://#diff-139ac7e3638500ebcceb466a362310d57324d4d3b16f1f958cbb99cc848d4b92R69-R118) [[4]](diffhunk://#diff-30c020a2266fd0fa01425f4f6a63918f29b69d365b4cfd5add4cf2b64a2aad87R208-R268)

**External PRM API Integration**

* Enhanced openclaw_opd_api_server.py to support PRM scoring via external OpenAI-compatible APIs. This includes new environment and config options, request logic, and result parsing. Local PRM is now optional—all PRM-related evaluations can be routed to an external service. 

**Single-GPU Evaluation Scripts**

* Added `student_chat_single_gpu.py` and `teacher_chat_single_gpu.py`. These scripts include logic to automatically poll and resume when the rollout engine is offloaded for training, ensuring reliable evaluation in single-GPU colocate mode.

**What has been tested:**
* 10 problems with a maximum of 8 turns per conversation, for both student chat and teacher chat running on a single RTX 4090 (24 GB).

* Saving the INT4 model and optimizers.

With these changes, OpenClaw-RL is now much more accessible for users with a single high-memory GPU. It also enables seamless integration with external LLM APIs for reward modeling and evaluation.
