### PR TITLE
slime: Qwen3.5, infra fix, PRM teacher with separate architecture, top-K OPD distillation

### DIFF
--- a/slime/scripts/models/qwen3.5-27B-VL.sh
+++ b/slime/scripts/models/qwen3.5-27B-VL.sh
@@ -1,0 +1,28 @@
+MODEL_ARGS=(
+   --spec "slime_plugins.models.qwen3_5" "get_qwen3_5_spec"
+
+   --disable-bias-linear
+   --qk-layernorm
+   --group-query-attention
+   --num-attention-heads 24
+   --num-query-groups 4
+   --kv-channels 256
+   --num-layers 64
+   --hidden-size 5120
+   --ffn-hidden-size 17408
+   # Dedicated to newer official Megatron-Core where gated delta attention is
+   # configured through the generic experimental attention variant flag.
+   --experimental-attention-variant gated_delta_net
+   --attention-output-gate
+
+   --normalization RMSNorm
+   --apply-layernorm-1p
+   --position-embedding-type rope
+   --norm-epsilon 1e-6
+   --rotary-percent 0.25
+   --swiglu
+   --vocab-size 248320
+
+   --untie-embeddings-and-output-weights
+   --rotary-base "${MODEL_ARGS_ROTARY_BASE:-10000000}"
+)

--- a/slime/scripts/models/qwen3.5-9B-VL.sh
+++ b/slime/scripts/models/qwen3.5-9B-VL.sh
@@ -1,0 +1,28 @@
+MODEL_ARGS=(
+   --spec "slime_plugins.models.qwen3_5" "get_qwen3_5_spec"
+
+   --disable-bias-linear
+   --qk-layernorm
+   --group-query-attention
+   --num-attention-heads 16
+   --num-query-groups 4
+   --kv-channels 256
+   --num-layers 32
+   --hidden-size 4096
+   --ffn-hidden-size 12288
+   # Dedicated to newer official Megatron-Core where gated delta attention is
+   # configured through the generic experimental attention variant flag.
+   --experimental-attention-variant gated_delta_net
+   --attention-output-gate
+
+   --normalization RMSNorm
+   --apply-layernorm-1p
+   --position-embedding-type rope
+   --norm-epsilon 1e-6
+   --rotary-percent 0.25
+   --swiglu
+   --vocab-size 248320
+
+   --untie-embeddings-and-output-weights
+   --rotary-base "${MODEL_ARGS_ROTARY_BASE:-10000000}"
+)

--- a/slime/scripts/run-qwen35-4B.sh
+++ b/slime/scripts/run-qwen35-4B.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+
+pkill -9 sglang || true
+sleep 3
+ray stop --force || true
+pkill -9 ray || true
+pkill -9 python || true
+sleep 3
+pkill -9 ray || true
+pkill -9 python || true
+
+set -ex
+
+export PYTHONUNBUFFERED=1
+export PYTHONFAULTHANDLER=1
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+SLIME_DIR="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+
+OFFICIAL_MBRIDGE_ROOT=${OFFICIAL_MBRIDGE_ROOT:-"/data_storage/wyj/OpenClaw-RL/Megatron-Bridge-qwen35"}
+OFFICIAL_MBRIDGE_SRC="${OFFICIAL_MBRIDGE_ROOT}/src"
+MEGATRON_LM_PATH=${MEGATRON_LM_PATH:-"${OFFICIAL_MBRIDGE_ROOT}/3rdparty/Megatron-LM"}
+
+if [[ ! -d "${OFFICIAL_MBRIDGE_SRC}" ]]; then
+  echo "OFFICIAL_MBRIDGE_SRC does not exist: ${OFFICIAL_MBRIDGE_SRC}"
+  exit 1
+fi
+if [[ ! -d "${MEGATRON_LM_PATH}" ]]; then
+  echo "MEGATRON_LM_PATH does not exist: ${MEGATRON_LM_PATH}"
+  exit 1
+fi
+
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+if [ "${NVLINK_COUNT}" -gt 0 ]; then
+  HAS_NVLINK=1
+else
+  HAS_NVLINK=0
+fi
+echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
+
+# With the official Megatron-Bridge-qwen35 stack, Qwen3.5-4B uses the newer
+# gated-delta-net flag style from the qwen35 VL provider path.
+# The training data here is still text-only; "VL" in the model script name is
+# about bridge/runtime compatibility, not that the rollout data must be multimodal.
+source "${SCRIPT_DIR}/models/qwen3.5-4B-VL.sh"
+
+HF_CKPT=${HF_CKPT:-"/data_storage/wyj/systems/huggingface/hub/Qwen35-4B"}
+REF_LOAD=${REF_LOAD:-"${HF_CKPT}"}
+SAVE_CKPT=${SAVE_CKPT:-"/data_storage/wyj/OpenClaw-RL/ckpt/qwen35-4b-math-rl"}
+ENABLE_RESUME_LOAD=${ENABLE_RESUME_LOAD:-0}
+RESUME_LOAD=${RESUME_LOAD:-"${SAVE_CKPT}"}
+
+PROMPT_DATA=${PROMPT_DATA:-"/data_storage/wyj/OpenClaw-RL1/data/dapo-math-17k/dapo-math-17k.jsonl"}
+EVAL_AIME_DATA=${EVAL_AIME_DATA:-"/data_storage/wyj/OpenClaw-RL1/data/aime-2024/aime-2024.jsonl"}
+
+NUM_GPUS=${NUM_GPUS:-8}
+ACTOR_GPUS=${ACTOR_GPUS:-4}
+ROLLOUT_GPUS=${ROLLOUT_GPUS:-4}
+ROLLOUT_NUM_GPUS_PER_ENGINE=${ROLLOUT_NUM_GPUS_PER_ENGINE:-1}
+SGLANG_LANGUAGE_ONLY=${SGLANG_LANGUAGE_ONLY:-1}
+SGLANG_MEMORY_SAVER_CUDA_GRAPH=${SGLANG_MEMORY_SAVER_CUDA_GRAPH:-false}
+
+if (( ACTOR_GPUS + ROLLOUT_GPUS > NUM_GPUS )); then
+  echo "ACTOR_GPUS + ROLLOUT_GPUS must be <= NUM_GPUS"
+  echo "ACTOR_GPUS=${ACTOR_GPUS}, ROLLOUT_GPUS=${ROLLOUT_GPUS}, NUM_GPUS=${NUM_GPUS}"
+  exit 1
+fi
+
+CKPT_ARGS=(
+  --megatron-to-hf-mode bridge
+  --hf-checkpoint "${HF_CKPT}"
+  --ref-load "${REF_LOAD}"
+  --save "${SAVE_CKPT}"
+  --save-interval 20
+)
+
+if [[ "${ENABLE_RESUME_LOAD}" == "1" ]]; then
+  CKPT_ARGS+=(--load "${RESUME_LOAD}")
+fi
+
+ROLLOUT_ARGS=(
+  --prompt-data "${PROMPT_DATA}"
+  --input-key prompt
+  --label-key label
+  --apply-chat-template
+  --rollout-shuffle
+  --rm-type deepscaler
+  --num-rollout 3000
+  --rollout-batch-size 32
+  --n-samples-per-prompt 8
+  --rollout-max-response-len 8192
+  --rollout-temperature 1
+  --num-steps-per-rollout 2
+  --balance-data
+)
+
+EVAL_ARGS=(
+  --eval-interval 20
+  --eval-prompt-data aime "${EVAL_AIME_DATA}"
+  --n-samples-per-eval-prompt 16
+  --eval-max-response-len 16384
+  --eval-top-p 1
+)
+
+PERF_ARGS=(
+  --tensor-model-parallel-size 4
+  --sequence-parallel
+  --pipeline-model-parallel-size 1
+  --context-parallel-size 1
+  --expert-model-parallel-size 1
+  --expert-tensor-parallel-size 1
+  --recompute-granularity full
+  --recompute-method uniform
+  --recompute-num-layers 1
+  --use-dynamic-batch-size
+  --max-tokens-per-gpu 9216
+)
+
+GRPO_ARGS=(
+  --advantage-estimator grpo
+  --use-kl-loss
+  --kl-loss-coef 0.00
+  --kl-loss-type low_var_kl
+  --entropy-coef 0.00
+  --eps-clip 0.2
+  --eps-clip-high 0.28
+)
+
+OPTIMIZER_ARGS=(
+  --optimizer adam
+  --lr 1e-6
+  --lr-decay-style constant
+  --weight-decay 0.1
+  --adam-beta1 0.9
+  --adam-beta2 0.98
+  --optimizer-cpu-offload
+  --overlap-cpu-optimizer-d2h-h2d
+  --use-precision-aware-optimizer
+)
+
+if [[ -n "${WANDB_KEY:-}" ]]; then
+  WANDB_ARGS=(
+    --use-wandb
+    --wandb-project "${WANDB_PROJECT:-test_slime}"
+    --wandb-group "${WANDB_GROUP:-qwen35-4B-math-rl}"
+    --wandb-key "${WANDB_KEY}"
+  )
+else
+  WANDB_ARGS=()
+fi
+
+SGLANG_ARGS=(
+  --rollout-num-gpus-per-engine "${ROLLOUT_NUM_GPUS_PER_ENGINE}"
+  --sglang-mem-fraction-static 0.7
+)
+if [[ "${SGLANG_LANGUAGE_ONLY}" == "1" ]]; then
+  SGLANG_ARGS+=(--sglang-language-only)
+fi
+
+MISC_ARGS=(
+  --attention-dropout 0.0
+  --hidden-dropout 0.0
+  --accumulate-allreduce-grads-in-fp32
+  --attention-softmax-in-fp32
+  --attention-backend flash
+)
+
+export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-"max_split_size_mb:2048,expandable_segments:True"}
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+ray start --head --node-ip-address "${MASTER_ADDR}" --num-gpus "${NUM_GPUS}" --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"${OFFICIAL_MBRIDGE_SRC}:${MEGATRON_LM_PATH}:${SLIME_DIR}:${SCRIPT_DIR}\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"NCCL_NVLS_ENABLE\": \"${HAS_NVLINK}\",
+    \"SGLANG_MEMORY_SAVER_CUDA_GRAPH\": \"${SGLANG_MEMORY_SAVER_CUDA_GRAPH}\",
+    \"PYTORCH_CUDA_ALLOC_CONF\": \"${PYTORCH_CUDA_ALLOC_CONF}\",
+    \"OFFICIAL_MBRIDGE_ROOT\": \"${OFFICIAL_MBRIDGE_ROOT}\",
+    \"OFFICIAL_MBRIDGE_SRC\": \"${OFFICIAL_MBRIDGE_SRC}\",
+    \"MEGATRON_LM_PATH\": \"${MEGATRON_LM_PATH}\",
+    \"HF_CKPT\": \"${HF_CKPT}\"
+  }
+}"
+
+ray job submit --address="http://127.0.0.1:8265" \
+  --runtime-env-json="${RUNTIME_ENV_JSON}" \
+  -- python3 "${SLIME_DIR}/train_async.py" \
+  --actor-num-nodes 1 \
+  --actor-num-gpus-per-node "${ACTOR_GPUS}" \
+  --rollout-num-gpus "${ROLLOUT_GPUS}" \
+  ${MODEL_ARGS[@]} \
+  ${CKPT_ARGS[@]} \
+  ${ROLLOUT_ARGS[@]} \
+  ${OPTIMIZER_ARGS[@]} \
+  ${GRPO_ARGS[@]} \
+  ${WANDB_ARGS[@]} \
+  ${PERF_ARGS[@]} \
+  ${EVAL_ARGS[@]} \
+  ${SGLANG_ARGS[@]} \
+  ${MISC_ARGS[@]}

--- a/slime/slime/backends/megatron_utils/actor.py
+++ b/slime/slime/backends/megatron_utils/actor.py
@@ -33,7 +33,14 @@ from .checkpoint import load_checkpoint
 from .cp_utils import slice_log_prob_with_cp, slice_with_cp
 from .data import DataIterator, get_data_iterator, log_perf_data, log_rollout_data, sync_actor_critic_data
 from .initialize import init, is_megatron_main_rank
-from .loss import compute_advantages_and_returns, get_log_probs_and_entropy, get_values
+from .loss import (
+    compute_advantages_and_returns,
+    emit_topk_logprobs,
+    gather_log_probs_at_indices,
+    get_log_probs_and_entropy,
+    get_values,
+    set_gather_at_indices,
+)
 from .model import forward_only, initialize_model_and_optimizer, save, train
 from .update_weight.common import named_params_and_buffers
 from .update_weight.update_weight_from_distributed import UpdateWeightFromDistributed
@@ -42,6 +49,88 @@ from .update_weight.update_weight_from_tensor import UpdateWeightFromTensor
 logging.getLogger("megatron").setLevel(logging.WARNING)
 
 logger = logging.getLogger(__name__)
+
+
+# Architectural args copied from the PRM teacher's torch_dist `common.pt` onto the
+# deepcopied `args` namespace when the teacher runs in raw mode. This is what lets
+# the teacher have a different model size than the student's MODEL_ARGS (e.g. an
+# 8B teacher next to a 4B student) without --megatron-to-hf-mode bridge.
+#
+# Scope is intentionally architecture-only: shape (decoder/embedding/RoPE/MoE/MLA/
+# MTP), not training knobs (dropout, optimizer, parallelism, recompute, dtype,
+# kernels). Parallelism overrides for the teacher are still done explicitly below.
+# The transformer layer spec (--spec) is *not* overridden -- it must stay the
+# student's spec, which works as long as student and teacher share an architecture
+# family (e.g. Qwen3-4B / Qwen3-8B). Cross-family mixing isn't supported here.
+_PRM_TEACHER_ARCH_FIELDS = (
+    "num_layers",
+    "hidden_size",
+    "ffn_hidden_size",
+    "num_attention_heads",
+    "num_query_groups",
+    "kv_channels",
+    "max_position_embeddings",
+    "qk_layernorm",
+    "normalization",
+    "norm_epsilon",
+    "swiglu",
+    "untie_embeddings_and_output_weights",
+    "padded_vocab_size",
+    "vocab_size",
+    "add_bias_linear",
+    "group_query_attention",
+    "position_embedding_type",
+    "rotary_percent",
+    "rotary_base",
+    "rotary_interleaved",
+    "rotary_seq_len_interpolation_factor",
+    "use_rope_scaling",
+    "use_rotary_position_embeddings",
+    "num_experts",
+    "moe_ffn_hidden_size",
+    "moe_router_topk",
+    "mtp_num_layers",
+    "multi_latent_attention",
+)
+
+
+def _read_megatron_common_args(load_path: str) -> Namespace | None:
+    """Read the `args` Namespace from a Megatron torch_dist checkpoint's common.pt.
+
+    Returns None if the path is not a Megatron checkpoint or common.pt is missing.
+    Used by the prm_teacher init path to discover the teacher's architecture so a
+    raw-mode teacher can have a different model size than the student.
+    """
+    from pathlib import Path
+
+    import re as _re
+
+    p = Path(load_path)
+    common_pt = None
+    iter_file = p / "latest_checkpointed_iteration.txt"
+    if iter_file.is_file():
+        tag = iter_file.read_text().strip()
+        if tag == "release":
+            common_pt = p / "release" / "common.pt"
+        else:
+            try:
+                step = int(tag)
+                common_pt = p / f"iter_{step:07d}" / "common.pt"
+            except ValueError:
+                common_pt = None
+    elif _re.fullmatch(r"iter_\d{7}", p.name) and (p / "common.pt").is_file():
+        common_pt = p / "common.pt"
+
+    if common_pt is None or not common_pt.is_file():
+        return None
+    try:
+        ckpt = torch.load(str(common_pt), map_location="cpu", weights_only=False)
+    except Exception as exc:
+        logger.warning("Failed to read teacher common.pt at %s: %s", common_pt, exc)
+        return None
+    if not isinstance(ckpt, dict):
+        return None
+    return ckpt.get("args")
 
 
 def _offload_rollout_data_to_cpu(rollout_data: RolloutBatch) -> None:
@@ -75,6 +164,9 @@ class MegatronTrainRayActor(TrainRayActor):
         monkey_patch_torch_dist()
 
         if role == "prm_teacher":
+            import re
+            from pathlib import Path
+
             args = copy.deepcopy(args)
             args.tensor_model_parallel_size = getattr(args, "prm_teacher_num_gpus", 1)
             args.pipeline_model_parallel_size = 1
@@ -82,11 +174,97 @@ class MegatronTrainRayActor(TrainRayActor):
             args.sequence_parallel = False
             args.expert_model_parallel_size = 1
             args.expert_tensor_parallel_size = 1
-            args.hf_checkpoint = args.prm_teacher_load
             args.pretrained_checkpoint = args.prm_teacher_load
             args.load = args.prm_teacher_load
             args.no_load_optim = True
             args.no_load_rng = True
+
+            # Per-teacher bridge/raw mode is independent from the student's mode.
+            # When --prm-teacher-megatron-to-hf-mode is unset, inherit from the
+            # global --megatron-to-hf-mode for backward compatibility.
+            _teacher_mode_override = getattr(args, "prm_teacher_megatron_to_hf_mode", None)
+            if _teacher_mode_override is not None:
+                args.megatron_to_hf_mode = _teacher_mode_override
+            _teacher_mode = args.megatron_to_hf_mode
+
+            _teacher_load = Path(args.prm_teacher_load)
+            _teacher_is_megatron_ckpt = (_teacher_load / "latest_checkpointed_iteration.txt").is_file() or bool(
+                re.fullmatch(r"iter_\d{7}", _teacher_load.name)
+            )
+
+            # hf_checkpoint resolution. Used for: (a) tokenizer/HF-config lookup
+            # below, and (b) bridge model construction in model_provider when
+            # _teacher_mode == "bridge".
+            _teacher_hf_override = getattr(args, "prm_teacher_hf_checkpoint", None)
+            if _teacher_hf_override is not None:
+                args.hf_checkpoint = _teacher_hf_override
+            elif not _teacher_is_megatron_ckpt:
+                # Bridge-style HF dir as load path doubles as the HF source.
+                args.hf_checkpoint = args.prm_teacher_load
+
+            # Mode-specific consistency checks and architecture wiring.
+            if _teacher_mode == "bridge":
+                # Bridge teacher needs an HF directory it can build the model
+                # from. Either prm_teacher_load is HF, or the user pointed
+                # --prm-teacher-hf-checkpoint at one.
+                _hf_dir_ok = Path(args.hf_checkpoint).is_dir() and (
+                    Path(args.hf_checkpoint) / "config.json"
+                ).is_file()
+                assert _hf_dir_ok, (
+                    f"prm_teacher in bridge mode needs an HF directory with config.json. "
+                    f"Got hf_checkpoint={args.hf_checkpoint!r} (derived from "
+                    f"--prm-teacher-hf-checkpoint or --prm-teacher-load). "
+                    f"Pass --prm-teacher-hf-checkpoint when --prm-teacher-load is a "
+                    f"torch_dist directory."
+                )
+            else:
+                # Raw mode: prm_teacher_load MUST be a torch_dist directory and
+                # we read its common.pt to discover the teacher's architecture.
+                # This is what allows e.g. an 8B teacher next to a 4B student in
+                # raw mode -- without it, the student's MODEL_ARGS would be used
+                # to build the teacher and load_checkpoint would shape-mismatch.
+                assert _teacher_is_megatron_ckpt, (
+                    f"prm_teacher in raw mode requires a torch_dist directory at "
+                    f"--prm-teacher-load (with latest_checkpointed_iteration.txt). "
+                    f"Got {args.prm_teacher_load!r}. Either convert with "
+                    f"tools/convert_hf_to_torch_dist.py, or pass "
+                    f"--prm-teacher-megatron-to-hf-mode bridge."
+                )
+                _teacher_ckpt_args = _read_megatron_common_args(args.prm_teacher_load)
+                if _teacher_ckpt_args is None:
+                    logger.warning(
+                        "prm_teacher: could not read common.pt from %s; "
+                        "teacher will inherit student's architectural args, which "
+                        "will shape-mismatch unless student and teacher are the "
+                        "same model size.",
+                        args.prm_teacher_load,
+                    )
+                else:
+                    _changed = []
+                    for _field in _PRM_TEACHER_ARCH_FIELDS:
+                        if not hasattr(_teacher_ckpt_args, _field):
+                            continue
+                        _new = getattr(_teacher_ckpt_args, _field)
+                        _old = getattr(args, _field, None)
+                        if _new != _old:
+                            setattr(args, _field, _new)
+                            _changed.append((_field, _old, _new))
+                    if _changed:
+                        logger.info(
+                            "prm_teacher: applied %d architectural override(s) from "
+                            "teacher common.pt -> %s",
+                            len(_changed),
+                            ", ".join(f"{n}: {o}->{v}" for n, o, v in _changed),
+                        )
+
+            # --prm-teacher-rotary-base is an explicit user override and wins over
+            # whatever common.pt or the student carried. Use case: actor and PRM
+            # teacher with different rope_theta (e.g. actor is a long-context SFT
+            # fine-tune with rope_theta=5e6 while the teacher is stock base with
+            # rope_theta=1e6).
+            prm_teacher_rotary_base = getattr(args, "prm_teacher_rotary_base", None)
+            if prm_teacher_rotary_base is not None:
+                args.rotary_base = prm_teacher_rotary_base
 
         super().init(args, role, with_ref)
 
@@ -445,15 +623,118 @@ class MegatronTrainRayActor(TrainRayActor):
             return self.train_actor(rollout_id, rollout_data)
 
     def compute_prm_teacher_log_probs(self, rollout_id: int, rollout_data: RolloutBatch):
-        """Compute log-probs on the dedicated PRM teacher GPU using hint-enhanced tokens."""
+        """Compute log-probs on the dedicated PRM teacher GPU using hint-enhanced tokens.
+
+        Returns a dict ``{key_with_prm_teacher_prefix: list[Tensor]}`` so that
+        any extra outputs produced by ``get_log_probs_and_entropy`` (e.g. the
+        per-position top-K log-probs / indices when ``--distill-topk > 0``)
+        also travel back to the actor.
+        """
         teacher_tokens = rollout_data.get("teacher_tokens")
         if teacher_tokens is not None:
             rollout_data["tokens"] = teacher_tokens
             rollout_data["total_lengths"] = rollout_data["teacher_total_lengths"]
         data_iterator, num_microbatches = get_data_iterator(self.args, self.model, rollout_data)
-        result = self.compute_log_prob(data_iterator, num_microbatches, store_prefix="prm_teacher_")
-        log_probs = result["prm_teacher_log_probs"]
-        return [lp.cpu() if isinstance(lp, torch.Tensor) else lp for lp in log_probs]
+        # Opt the underlying get_log_probs_and_entropy into also returning
+        # per-token top-K log-probs / indices when --distill-topk > 0. The
+        # regular old_actor / ref forwards do NOT enter this context, so
+        # they remain byte-identical to before.
+        with emit_topk_logprobs():
+            result = self.compute_log_prob(data_iterator, num_microbatches, store_prefix="prm_teacher_")
+        out: dict[str, list] = {}
+        for key, val in result.items():
+            if isinstance(val, list):
+                out[key] = [v.cpu() if isinstance(v, torch.Tensor) else v for v in val]
+            else:
+                out[key] = val
+        return out
+
+    def compute_student_topk(self, rollout_id: int, rollout_data_ref: Box):
+        """Run an old_actor forward and return ONLY the student top-K indices.
+
+        Used by ``--distill-subset-mode student``: the outer training loop
+        feeds these indices to the PRM teacher actor's ``gather_at_indices``
+        so the teacher's log-probs are aligned to the student's subset.
+
+        Returns a dict ``{"topk_indices": list[Tensor]}`` (CPU long tensors)
+        on every actor rank; the outer loop reads only rank 0's payload.
+        """
+        if self.args.offload_train:
+            self.wake_up()
+
+        with timer("data_preprocess"):
+            rollout_data = self._get_rollout_data(rollout_data_ref)
+        data_iterator, num_microbatches = get_data_iterator(self.args, self.model, rollout_data)
+        if self.args.keep_old_actor:
+            self._switch_model("old_actor")
+        else:
+            self._switch_model("actor")
+        with emit_topk_logprobs():
+            result = self.compute_log_prob(
+                data_iterator, num_microbatches, store_prefix=""
+            )
+        topk_indices = result.get("topk_indices", [])
+        out_indices = [t.cpu() if isinstance(t, torch.Tensor) else t for t in topk_indices]
+        for iterator in data_iterator:
+            iterator.reset()
+        return {"topk_indices": out_indices}
+
+    def gather_at_indices(
+        self, rollout_id: int, rollout_data_ref: Box, indices_per_sample: list
+    ):
+        """Run a PRM-teacher forward gathering log-probs at provided indices.
+
+        Used by ``--distill-subset-mode student``. ``indices_per_sample`` is
+        a list of ``[R_i, K]`` long tensors (CPU) -- the student top-K
+        indices computed earlier on the actor side.
+
+        Returns ``{"prm_teacher_topk_log_probs": [...], "prm_teacher_topk_indices": [...]}``.
+        """
+        if self.args.offload_train:
+            self.wake_up()
+        with timer("data_preprocess"):
+            rollout_data = self._get_rollout_data(rollout_data_ref)
+        teacher_tokens = rollout_data.get("teacher_tokens")
+        if teacher_tokens is not None:
+            rollout_data["tokens"] = teacher_tokens
+            rollout_data["total_lengths"] = rollout_data["teacher_total_lengths"]
+        data_iterator, num_microbatches = get_data_iterator(self.args, self.model, rollout_data)
+        # The payload (`indices_per_sample`) arrives in ORIGINAL sample order
+        # (forward_only re-orders results back to original order; see
+        # model.py:`forward_only` post-loop reorder).  However, the teacher
+        # forward consumes one chunk per sample in the teacher's microbatch
+        # order, which differs whenever dynamic-batch packing is on.  Permute
+        # the payload to the teacher's consumption order; the post-forward
+        # reorder will put the gathered log-probs back to original order so
+        # downstream code remains correct.
+        teacher_mb_indices = getattr(data_iterator[0], "micro_batch_indices", None)
+        if teacher_mb_indices is not None:
+            flat_indices: list[int] = sum(teacher_mb_indices, [])
+            if len(flat_indices) != len(indices_per_sample):
+                raise RuntimeError(
+                    f"gather_at_indices: payload size {len(indices_per_sample)} != "
+                    f"teacher consumption order length {len(flat_indices)}"
+                )
+            payload_in_consumption_order = [indices_per_sample[i] for i in flat_indices]
+        else:
+            payload_in_consumption_order = list(indices_per_sample)
+        with timer("prm_teacher_gather_at_indices_log_probs"):
+            with set_gather_at_indices(payload_in_consumption_order):
+                result = forward_only(
+                    gather_log_probs_at_indices,
+                    self.args,
+                    self.model,
+                    data_iterator,
+                    num_microbatches,
+                    store_prefix="prm_teacher_",
+                )
+        out: dict[str, list] = {}
+        for key, val in result.items():
+            if isinstance(val, list):
+                out[key] = [v.cpu() if isinstance(v, torch.Tensor) else v for v in val]
+            else:
+                out[key] = val
+        return out
 
     def train_critic(self, rollout_id: int, rollout_data: RolloutBatch) -> None:
         # Create data iterator for log_probs and train.
@@ -508,7 +789,15 @@ class MegatronTrainRayActor(TrainRayActor):
                         )
                     )
                 if hasattr(self, "_prm_teacher_log_probs") and self._prm_teacher_log_probs is not None:
-                    rollout_data["prm_teacher_log_probs"] = self._prm_teacher_log_probs
+                    payload = self._prm_teacher_log_probs
+                    if isinstance(payload, dict):
+                        # New (multi-key) shape: {prm_teacher_log_probs: [...],
+                        # prm_teacher_topk_log_probs: [...], ...}
+                        for k, v in payload.items():
+                            rollout_data[k] = v
+                    else:
+                        # Legacy (single list) shape.
+                        rollout_data["prm_teacher_log_probs"] = payload
                     self._prm_teacher_log_probs = None
                 self._switch_model("old_actor" if self.args.keep_old_actor else "actor")
                 if not self.args.use_rollout_logprobs or self.args.get_mismatch_metrics:
@@ -517,15 +806,62 @@ class MegatronTrainRayActor(TrainRayActor):
                             os.environ["ROUTING_REPLAY_STAGE"] = "replay_forward"
                         else:
                             os.environ["ROUTING_REPLAY_STAGE"] = "record"
-                    rollout_data.update(
-                        self.compute_log_prob(
-                            data_iterator,
-                            num_microbatches,
-                            store_prefix="",
+                    # Top-K OPD: wrap old_actor's compute_log_prob in
+                    # emit_topk_logprobs() so it ALSO ships per-token
+                    # student top-K (`topk_log_probs` / `topk_indices` in
+                    # the result dict). Modes:
+                    #   * student / overlap: keep these as student-side data.
+                    #   * teacher: throw them away below and re-gather at the
+                    #     teacher's top-K indices.
+                    distill_topk = int(getattr(self.args, "distill_topk", 0) or 0)
+                    subset_mode = getattr(self.args, "distill_subset_mode", "student")
+                    # `teacher` mode re-gathers student-old at teacher's
+                    # indices below, so the student top-K from the regular
+                    # pass would be thrown away -- skip emit_topk to save
+                    # the extra TP top-K scan.
+                    use_emit = distill_topk > 0 and subset_mode in ("student", "overlap")
+                    emit_ctx = emit_topk_logprobs() if use_emit else nullcontext()
+                    with emit_ctx:
+                        rollout_data.update(
+                            self.compute_log_prob(
+                                data_iterator,
+                                num_microbatches,
+                                store_prefix="",
+                            )
                         )
-                    )
                     if self.args.use_rollout_routing_replay:
                         RoutingReplay.clear_all_forward()
+
+                    # Mode `teacher`: do an extra old_actor forward that
+                    # gathers student-old log-probs at the TEACHER's top-K
+                    # indices (already shipped via _prm_teacher_log_probs
+                    # → rollout_data["prm_teacher_topk_indices"]). REPLACE
+                    # the student-side topk_log_probs / topk_indices so the
+                    # loss sees S^q == S^p == teacher top-K (mask all-True).
+                    if distill_topk > 0 and subset_mode == "teacher":
+                        teacher_idx = rollout_data.get("prm_teacher_topk_indices")
+                        if teacher_idx is None or len(teacher_idx) == 0:
+                            raise RuntimeError(
+                                "subset_mode=teacher requires prm_teacher_topk_indices "
+                                "in rollout_data. Did the prm_teacher pass run with "
+                                "--distill-topk > 0?"
+                            )
+                        # Reset iterator: forward_only consumed it once.
+                        for it in data_iterator:
+                            it.reset()
+                        with timer("old_actor_gather_at_teacher_topk"):
+                            with set_gather_at_indices(teacher_idx):
+                                gather_res = forward_only(
+                                    gather_log_probs_at_indices,
+                                    self.args,
+                                    self.model,
+                                    data_iterator,
+                                    num_microbatches,
+                                    store_prefix="",
+                                )
+                        # Replace student-side keys with the teacher-aligned ones.
+                        rollout_data["topk_log_probs"] = gather_res["topk_log_probs"]
+                        rollout_data["topk_indices"] = gather_res["topk_indices"]
 
                 if self.args.use_critic:
                     sync_actor_critic_data(

--- a/slime/slime/backends/megatron_utils/data.py
+++ b/slime/slime/backends/megatron_utils/data.py
@@ -532,6 +532,10 @@ def log_rollout_data(
                 "step_wise_step_indices",
                 "teacher_topk_log_probs",
                 "teacher_topk_indices",
+                "prm_teacher_topk_log_probs",
+                "prm_teacher_topk_indices",
+                "topk_log_probs",
+                "topk_indices",
                 "teacher_tokens",
                 "teacher_total_lengths",
             ]:

--- a/slime/slime/backends/megatron_utils/loss.py
+++ b/slime/slime/backends/megatron_utils/loss.py
@@ -12,6 +12,35 @@ from slime.utils.distributed_utils import distributed_masked_whiten
 from slime.utils.misc import load_function
 
 logger = logging.getLogger(__name__)
+
+# Module-level toggle. When True, get_log_probs_and_entropy additionally
+# returns "topk_log_probs" / "topk_indices" (used by the prm_teacher actor
+# path for distillation). Defaults to False so that the regular old_actor
+# / ref / actor compute_log_prob passes are unchanged.
+_EMIT_TOPK_LOGPROBS: bool = False
+
+
+class emit_topk_logprobs:
+    """Context manager: opt the wrapped compute_log_prob call into emitting
+    per-token top-K log-probabilities and global vocab indices.
+
+    Only the prm_teacher actor uses this; the regular actor/old_actor/ref
+    forwards do NOT enter this context, so their output dicts are byte-
+    identical to before.
+    """
+
+    def __enter__(self):
+        global _EMIT_TOPK_LOGPROBS
+        self._prev = _EMIT_TOPK_LOGPROBS
+        _EMIT_TOPK_LOGPROBS = True
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        global _EMIT_TOPK_LOGPROBS
+        _EMIT_TOPK_LOGPROBS = self._prev
+        return False
+
+
 from slime.utils.ppo_utils import (
     calculate_log_probs_and_entropy,
     compute_approx_kl,
@@ -172,8 +201,16 @@ def get_log_probs_and_entropy(
         a list of `[R]` tensors.
     """
     assert non_loss_data
+    tp_group = mpu.get_tensor_model_parallel_group()
+    # Top-K is opt-in via emit_topk_logprobs() context manager. By default
+    # the regular old_actor / ref / actor compute_log_prob passes do NOT
+    # emit top-K data, so their outputs are unchanged. Only the prm_teacher
+    # path opts in (see actor.compute_prm_teacher_log_probs).
+    distill_topk = int(getattr(args, "distill_topk", 0) or 0) if _EMIT_TOPK_LOGPROBS else 0
     log_probs_list = []
     entropy_list = []
+    topk_log_probs_list = []
+    topk_indices_list = []
     for logits_chunk, tokens_chunk in get_responses(
         logits,
         args=args,
@@ -185,7 +222,7 @@ def get_log_probs_and_entropy(
         log_prob, entropy = calculate_log_probs_and_entropy(
             logits_chunk,
             tokens_chunk,
-            mpu.get_tensor_model_parallel_group(),
+            tp_group,
             with_entropy=with_entropy,
             chunk_size=args.log_probs_chunk_size,
         )
@@ -193,12 +230,219 @@ def get_log_probs_and_entropy(
         log_probs_list.append(log_prob.squeeze(-1))
         entropy_list.append(entropy)
 
+        if distill_topk > 0:
+            topk_lp, topk_idx = _vocab_parallel_topk_log_probs(logits_chunk, distill_topk, tp_group)
+            topk_log_probs_list.append(topk_lp)
+            topk_indices_list.append(topk_idx)
+
     res = {
         "log_probs": log_probs_list,
     }
     if with_entropy:
         res["entropy"] = entropy_list
+    if distill_topk > 0:
+        res["topk_log_probs"] = topk_log_probs_list
+        res["topk_indices"] = topk_indices_list
     return torch.empty((0,), device=logits.device), res
+
+
+def _vocab_parallel_topk_log_probs(
+    logits: torch.Tensor,
+    K: int,
+    tp_group,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Global top-K log-probs and (global vocab) indices from TP-sharded logits.
+
+    Args:
+        logits: ``[seq, vocab_local]`` (vocab_local = vocab // tp_world).
+        K: global top-K to keep.
+        tp_group: TP process group.
+
+    Returns:
+        ``(topk_log_probs [seq, K], topk_indices [seq, K])`` with indices in
+        the GLOBAL vocab space, so any TP rank can re-gather log-probs at
+        them with ``compute_log_probs``.
+    """
+    if K <= 0 or logits.numel() == 0:
+        return (
+            logits.new_zeros((logits.size(0), 0)),
+            torch.zeros((logits.size(0), 0), dtype=torch.long, device=logits.device),
+        )
+
+    tp_world = dist.get_world_size(group=tp_group) if dist.is_initialized() else 1
+    tp_rank = dist.get_rank(group=tp_group) if dist.is_initialized() else 0
+    vocab_local = logits.size(-1)
+
+    # Global log-softmax across TP-sharded vocab (kept in fp32 for safety;
+    # logits may arrive as bf16/fp16).
+    work = logits.float()
+    local_max = work.max(dim=-1, keepdim=True).values
+    if tp_world > 1:
+        dist.all_reduce(local_max, op=dist.ReduceOp.MAX, group=tp_group)
+    shifted = work - local_max
+    sum_exp = shifted.exp().sum(dim=-1, keepdim=True)
+    if tp_world > 1:
+        dist.all_reduce(sum_exp, op=dist.ReduceOp.SUM, group=tp_group)
+    log_probs_local = shifted - sum_exp.log()
+
+    K_local = min(K, vocab_local)
+    local_lp, local_idx_local = log_probs_local.topk(K_local, dim=-1)
+    local_idx_global = local_idx_local + tp_rank * vocab_local
+
+    if tp_world == 1:
+        return local_lp, local_idx_global
+
+    # Gather every shard's local top-K, then global top-K from K_local*tp_world
+    # candidates. Exact: any global top-K token is in some shard's top-K_local.
+    gathered_lp = [torch.zeros_like(local_lp) for _ in range(tp_world)]
+    gathered_idx = [torch.zeros_like(local_idx_global) for _ in range(tp_world)]
+    dist.all_gather(gathered_lp, local_lp, group=tp_group)
+    dist.all_gather(gathered_idx, local_idx_global, group=tp_group)
+    cat_lp = torch.cat(gathered_lp, dim=-1)
+    cat_idx = torch.cat(gathered_idx, dim=-1)
+    K_eff = min(K, cat_lp.size(-1))
+    final_lp, sort_pos = cat_lp.topk(K_eff, dim=-1)
+    final_idx = torch.gather(cat_idx, -1, sort_pos)
+    return final_lp, final_idx
+
+
+# Per-call indices payload for the gather-at-indices forward path. A list
+# of [R_i, K] long tensors (one per sample), GLOBAL vocab ids. Set just
+# before calling forward_only(gather_log_probs_at_indices, ...) and read
+# inside that function. Module-level (not threadlocal) because Megatron's
+# pipeline runner is single-threaded per actor process.
+_GATHER_AT_INDICES_PAYLOAD: list[torch.Tensor] | None = None
+_GATHER_AT_INDICES_CURSOR: int = 0
+
+
+class set_gather_at_indices:
+    """Context manager: provide a list[Tensor] of GLOBAL vocab ids per sample.
+
+    The next ``len(payload)`` calls to ``gather_log_probs_at_indices`` (one
+    per response chunk in pipeline order) consume one tensor each. Used to
+    drive the extra "gather at S_t" forwards needed by ``--distill-subset-
+    mode={student,teacher}`` distillation.
+    """
+
+    def __init__(self, payload: list[torch.Tensor]):
+        self._payload = payload
+
+    def __enter__(self):
+        global _GATHER_AT_INDICES_PAYLOAD, _GATHER_AT_INDICES_CURSOR
+        self._prev_payload = _GATHER_AT_INDICES_PAYLOAD
+        self._prev_cursor = _GATHER_AT_INDICES_CURSOR
+        _GATHER_AT_INDICES_PAYLOAD = self._payload
+        _GATHER_AT_INDICES_CURSOR = 0
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        global _GATHER_AT_INDICES_PAYLOAD, _GATHER_AT_INDICES_CURSOR
+        _GATHER_AT_INDICES_PAYLOAD = self._prev_payload
+        _GATHER_AT_INDICES_CURSOR = self._prev_cursor
+        return False
+
+
+def _vocab_parallel_log_probs_at_indices(
+    logits: torch.Tensor,
+    indices: torch.Tensor,
+    tp_group,
+) -> torch.Tensor:
+    """No-grad: GLOBAL log-probs at given GLOBAL vocab indices, TP-sharded.
+
+    Args:
+        logits:  ``[seq, V_local]``.
+        indices: ``[seq, K]`` global vocab ids in ``[0, V)``.
+
+    Returns:
+        ``[seq, K]`` fp32 ``log softmax(logits_global)[indices]``.
+    """
+    if logits.numel() == 0 or indices.numel() == 0:
+        return logits.new_zeros((logits.size(0), indices.size(-1) if indices.dim() > 1 else 0), dtype=torch.float32)
+
+    tp_world = dist.get_world_size(group=tp_group) if dist.is_initialized() else 1
+    tp_rank = dist.get_rank(group=tp_group) if dist.is_initialized() else 0
+    V_local = logits.size(-1)
+    shard_lo = tp_rank * V_local
+
+    work = logits.float()
+    local_max = work.max(dim=-1, keepdim=True).values
+    if tp_world > 1:
+        dist.all_reduce(local_max, op=dist.ReduceOp.MAX, group=tp_group)
+    shifted = work - local_max
+    sum_exp = shifted.exp().sum(dim=-1, keepdim=True)
+    if tp_world > 1:
+        dist.all_reduce(sum_exp, op=dist.ReduceOp.SUM, group=tp_group)
+    log_sum_exp = sum_exp.log()  # [seq, 1] fp32
+
+    in_shard = (indices >= shard_lo) & (indices < shard_lo + V_local)
+    idx_local = (indices - shard_lo).clamp(min=0, max=V_local - 1)
+    gathered = torch.gather(work, dim=-1, index=idx_local)  # [seq, K] fp32
+    gathered_masked = torch.where(in_shard, gathered, torch.zeros_like(gathered))
+    if tp_world > 1:
+        dist.all_reduce(gathered_masked, op=dist.ReduceOp.SUM, group=tp_group)
+    return gathered_masked - log_sum_exp
+
+
+def gather_log_probs_at_indices(
+    logits: torch.Tensor,
+    *,
+    args: Namespace,
+    unconcat_tokens: list[torch.Tensor],
+    total_lengths: list[int],
+    response_lengths: list[int],
+    with_entropy: bool = False,
+    non_loss_data: bool = True,
+    max_seq_lens: list[int] | None = None,
+) -> tuple[torch.Tensor, dict[str, list[torch.Tensor]]]:
+    """No-grad: gather GLOBAL log-probs at indices supplied via ``set_gather_at_indices``.
+
+    Mirrors ``get_log_probs_and_entropy``'s signature so it slots into the
+    same ``forward_only`` codepath. Returns a dict with two keys:
+
+    * ``topk_log_probs``: list of ``[R_i, K]`` fp32 log-probs per sample.
+    * ``topk_indices``:   list of ``[R_i, K]`` long indices per sample
+      (echoed from the payload for downstream consumers).
+    """
+    assert non_loss_data
+    global _GATHER_AT_INDICES_PAYLOAD, _GATHER_AT_INDICES_CURSOR
+    payload = _GATHER_AT_INDICES_PAYLOAD
+    if payload is None:
+        raise RuntimeError(
+            "gather_log_probs_at_indices called outside set_gather_at_indices() context."
+        )
+    tp_group = mpu.get_tensor_model_parallel_group()
+    log_probs_list: list[torch.Tensor] = []
+    indices_list: list[torch.Tensor] = []
+    for logits_chunk, _tokens_chunk in get_responses(
+        logits,
+        args=args,
+        unconcat_tokens=unconcat_tokens,
+        total_lengths=total_lengths,
+        response_lengths=response_lengths,
+        max_seq_lens=max_seq_lens,
+    ):
+        if _GATHER_AT_INDICES_CURSOR >= len(payload):
+            raise RuntimeError(
+                f"gather_log_probs_at_indices: payload exhausted at cursor "
+                f"{_GATHER_AT_INDICES_CURSOR} (payload len={len(payload)})."
+            )
+        idx_cpu = payload[_GATHER_AT_INDICES_CURSOR]
+        _GATHER_AT_INDICES_CURSOR += 1
+        idx = idx_cpu.to(device=logits_chunk.device, dtype=torch.long)
+        if idx.dim() == 1:
+            idx = idx.unsqueeze(-1)
+        if idx.size(0) != logits_chunk.size(0):
+            raise RuntimeError(
+                f"gather_log_probs_at_indices: chunk has {logits_chunk.size(0)} "
+                f"tokens but payload has {idx.size(0)} index rows."
+            )
+        lp = _vocab_parallel_log_probs_at_indices(logits_chunk, idx, tp_group)
+        log_probs_list.append(lp)
+        indices_list.append(idx)
+    return torch.empty((0,), device=logits.device), {
+        "topk_log_probs": log_probs_list,
+        "topk_indices": indices_list,
+    }
 
 
 def get_values(

--- a/slime/slime/backends/megatron_utils/model.py
+++ b/slime/slime/backends/megatron_utils/model.py
@@ -375,6 +375,10 @@ def train_one_step(
                 "prm_teacher_log_probs",
                 "teacher_topk_log_probs",
                 "teacher_topk_indices",
+                "prm_teacher_topk_log_probs",
+                "prm_teacher_topk_indices",
+                "topk_log_probs",
+                "topk_indices",
             ],
             args.data_pad_size_multiplier,
             args.qkv_format,
@@ -402,6 +406,14 @@ def train_one_step(
                 "labels": None,
                 "packed_seq_params": batch["packed_seq_params"],
                 "loss_mask": batch["full_loss_masks"],
+                # Match the forward-only path: do NOT have Megatron's
+                # Float16Module upcast the [1, T, V] logits to fp32. Slime's
+                # loss/log-prob code (get_responses + get_log_probs_and_entropy)
+                # accepts bf16/fp16 logits and upcasts only the per-sample
+                # response slices internally. Without this, packing 2 samples
+                # into a 16K microbatch produces a 7.58 GiB fp32 logits
+                # allocation that OOMs an 80GB GPU.
+                "fp32_output": False,
             }
 
             if args.enable_mtp_training:

--- a/slime/slime/backends/megatron_utils/model_provider.py
+++ b/slime/slime/backends/megatron_utils/model_provider.py
@@ -104,6 +104,73 @@ def get_model_provider_func(
             provider.num_layers_in_first_pipeline_stage = args.decoder_first_pipeline_num_layers
         if getattr(args, "decoder_last_pipeline_num_layers", None) is not None:
             provider.num_layers_in_last_pipeline_stage = args.decoder_last_pipeline_num_layers
+        # Bridge providers are constructed from HF config and ignore most CLI flags
+        # forwarded to TransformerConfig in the raw path. Activation-recompute is
+        # the most consequential one: without it, full activations stay resident
+        # for every layer and large-context RL runs OOM. Forward it explicitly so
+        # bridge runs are at least memory-comparable to raw runs.
+        if getattr(args, "recompute_granularity", None) is not None:
+            provider.recompute_granularity = args.recompute_granularity
+            provider.recompute_method = args.recompute_method
+            provider.recompute_num_layers = args.recompute_num_layers
+
+        # CLI flags that materially affect train numerics/quality and per-step
+        # speed but are NOT derivable from the HF config. Without these, bridge
+        # mode silently keeps HF-config defaults (e.g. attention_dropout=0.1
+        # for many Qwen configs), which causes train-vs-inference distribution
+        # skew and biased GRPO importance sampling. Forward only attributes the
+        # provider already exposes so we don't break providers that omit them.
+        _BRIDGE_FORWARDED_ARGS = (
+            # numerics / quality
+            "attention_dropout",
+            "hidden_dropout",
+            "attention_softmax_in_fp32",
+            
+            "accumulate_allreduce_grads_in_fp32",
+            "fp16_lm_cross_entropy",
+            "cross_entropy_loss_fusion",
+            "cross_entropy_fusion_impl",
+            # kernels / fused ops (perf, occasionally numerics)
+            "attention_backend",
+            "apply_rope_fusion",
+            "bias_swiglu_fusion",
+            "bias_dropout_fusion",
+            "bias_gelu_fusion",
+            "masked_softmax_fusion",
+            "gradient_accumulation_fusion",
+            "async_tensor_model_parallel_allreduce",
+            "tp_comm_overlap",
+            # context-parallel / sequence-parallel related
+            "context_parallel_size",
+            # dtype / precision
+            "params_dtype",
+            "bf16",
+            "fp16",
+        )
+        forwarded = []
+        skipped = []
+        for name in _BRIDGE_FORWARDED_ARGS:
+            if not hasattr(args, name):
+                continue
+            value = getattr(args, name)
+            if value is None:
+                continue
+            if not hasattr(provider, name):
+                skipped.append(name)
+                continue
+            setattr(provider, name, value)
+            forwarded.append((name, value))
+        if forwarded:
+            print(
+                "Bridge provider: forwarded CLI flags -> "
+                + ", ".join(f"{n}={v}" for n, v in forwarded)
+            )
+        if skipped:
+            print(
+                "Bridge provider: skipped CLI flags not exposed by provider -> "
+                + ", ".join(skipped)
+            )
+
         provider.finalize()
         return provider.provide
 

--- a/slime/slime/backends/sglang_utils/qwen3_5.py
+++ b/slime/slime/backends/sglang_utils/qwen3_5.py
@@ -171,14 +171,14 @@ def patch_sglang_qwen35() -> None:
                     continue
                 if "language_model" in name:
                     name = name.replace(r"model.language_model.", r"model.")
+                # SGLang's Qwen3.5 full-attention layer registers `qkv_proj`,
+                # `o_proj`, `q_norm`, `k_norm` etc. as direct attributes of the
+                # decoder layer (not under a `self_attn` submodule). Megatron
+                # emits HF-style names with `.self_attn.` so we must strip it
+                # to match the actual params_dict tree. Linear-attention layers
+                # use `.linear_attn.` and are unaffected.
                 if ".self_attn." in name:
                     name = name.replace(".self_attn", "")
-                if not name.startswith("model.") and (
-                    name.startswith("layers.")
-                    or name.startswith("embed_tokens.")
-                    or name.startswith("norm.")
-                ):
-                    name = add_prefix(name, "model")
 
                 if name == "model.embed_tokens.weight":
                     if self.pp_group.is_last_rank and self.config.tie_word_embeddings:

--- a/slime/slime/ray/actor_group.py
+++ b/slime/slime/ray/actor_group.py
@@ -148,3 +148,20 @@ class RayTrainGroup:
         """Broadcast PRM teacher log-probs (computed on a separate GPU) to all actor ranks."""
         prm_lps_ref = ray.put(prm_teacher_log_probs)
         return ray.get([actor.set_prm_teacher_log_probs.remote(prm_lps_ref) for actor in self._actor_handlers])
+
+    def async_compute_student_topk(self, rollout_id, rollout_data_ref):
+        """Run the student-side old_actor pass and return rank-0's student top-K indices.
+
+        Used by ``--distill-subset-mode student``: the outer loop ships these
+        indices to the PRM teacher group's ``async_gather_at_indices`` so the
+        teacher's log-probs are aligned to the student's subset.
+        """
+        return [actor.compute_student_topk.remote(rollout_id, rollout_data_ref) for actor in self._actor_handlers]
+
+    def async_gather_at_indices(self, rollout_id, rollout_data_ref, indices_per_sample):
+        """Run a PRM-teacher forward gathering log-probs at provided indices."""
+        idx_ref = ray.put(indices_per_sample)
+        return [
+            actor.gather_at_indices.remote(rollout_id, rollout_data_ref, idx_ref)
+            for actor in self._actor_handlers
+        ]

--- a/slime/slime/utils/arguments.py
+++ b/slime/slime/utils/arguments.py
@@ -781,6 +781,48 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 default=1,
                 help="Number of GPUs for the PRM teacher model (default 1, TP=1).",
             )
+            parser.add_argument(
+                "--prm-teacher-rotary-base",
+                type=float,
+                default=None,
+                help=(
+                    "Override --rotary-base for the PRM teacher only. Use when the teacher and "
+                    "the actor have different rope_theta (e.g. stock Qwen3-4B rope_theta=1e6 "
+                    "vs a long-context SFT fine-tune with rope_theta=5e6). "
+                    "Defaults to --rotary-base when unset."
+                ),
+            )
+            parser.add_argument(
+                "--prm-teacher-megatron-to-hf-mode",
+                choices=["raw", "bridge"],
+                default=None,
+                help=(
+                    "Override --megatron-to-hf-mode for the PRM teacher only. When unset, the "
+                    "teacher inherits the global --megatron-to-hf-mode. Setting this to a "
+                    "different value than the student is the supported way to mix modes "
+                    "(e.g. raw student + bridge teacher, or raw student of one size + raw "
+                    "teacher of a different size). In 'raw' mode the teacher's architectural "
+                    "fields (num_layers / hidden_size / ffn_hidden_size / num_query_groups / "
+                    "kv_channels / vocab / RoPE / etc.) are auto-populated from the teacher's "
+                    "torch_dist common.pt, so the teacher can be a different model size than "
+                    "the student's MODEL_ARGS (e.g. Qwen3-8B teacher with Qwen3-4B student). "
+                    "In 'bridge' mode the architecture is built from the teacher's HF config; "
+                    "use --prm-teacher-hf-checkpoint to point at the teacher's HF directory "
+                    "when --prm-teacher-load is a torch_dist directory."
+                ),
+            )
+            parser.add_argument(
+                "--prm-teacher-hf-checkpoint",
+                type=str,
+                default=None,
+                help=(
+                    "Override --hf-checkpoint for the PRM teacher only. Used for the teacher's "
+                    "tokenizer and HF-config lookup, and as the bridge source when "
+                    "--prm-teacher-megatron-to-hf-mode=bridge. Required for bridge teacher "
+                    "when --prm-teacher-load is a torch_dist (non-HF) directory. Defaults to "
+                    "the actor's --hf-checkpoint when unset."
+                ),
+            )
             reset_arg(parser, "--load", type=str, default=None)
             reset_arg(parser, "--save", type=str, default=None)
             reset_arg(parser, "--save-interval", type=int, default=None)
@@ -891,6 +933,19 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 default=0,
                 help="Number of top-K teacher logprobs for logits-based distillation loss. "
                 "Set to >0 (e.g. 50) to enable top-K distillation via custom_loss.",
+            )
+            parser.add_argument(
+                "--distill-subset-mode",
+                type=str,
+                choices=["student", "teacher", "overlap"],
+                default="student",
+                help=(
+                    "How the per-token subset Sₜ is selected for top-K OPD: "
+                    "'student' (default) = student top-K (extra teacher gather pass), "
+                    "'teacher' = teacher top-K (extra student-old gather pass), "
+                    "'overlap' = student top-K ∩ teacher top-K (no extra pass). "
+                    "Only consumed when --distill-topk > 0."
+                ),
             )
             parser.add_argument(
                 "--use-kl-loss", action="store_true", default=False, help="whether to use KL loss from GRPO"

--- a/slime/slime/utils/http_utils.py
+++ b/slime/slime/utils/http_utils.py
@@ -162,8 +162,23 @@ def _next_actor():
     return actor
 
 
+_PERMANENT_ROUTER_MARKERS = (
+    "no_available_workers",
+    "all circuits open",
+    "circuits open or unhealthy",
+)
+# After this many *consecutive* permanent-looking 503s from the router, give
+# up retrying so the real engine-side exception surfaces instead of being
+# drowned by minutes of identical "retrying..." log lines.
+_PERMANENT_FAIL_FAST_AFTER = int(os.getenv("SLIME_HTTP_PERMANENT_FAIL_FAST", "3"))
+# Only log retries at these attempt numbers (plus the final one) so the
+# terminal is not flooded with one line per attempt per concurrent request.
+_LOG_RETRY_ATTEMPTS = {1, 5, 10, 25, 50}
+
+
 async def _post(client, url, payload, max_retries=60):
     retry_count = 0
+    permanent_streak = 0
     while retry_count < max_retries:
         response = None
         try:
@@ -179,12 +194,45 @@ async def _post(client, url, payload, max_retries=60):
 
             if isinstance(e, httpx.HTTPStatusError):
                 response_text = e.response.text
+                status_code = e.response.status_code
             else:
                 response_text = None
+                status_code = None
 
-            logger.info(
-                f"Error: {e}, retrying... (attempt {retry_count}/{max_retries}, url={url}, response={response_text})"
+            is_permanent = (
+                status_code == 503
+                and response_text is not None
+                and any(m in response_text for m in _PERMANENT_ROUTER_MARKERS)
             )
+            if is_permanent:
+                permanent_streak += 1
+            else:
+                permanent_streak = 0
+
+            should_log = (
+                retry_count in _LOG_RETRY_ATTEMPTS
+                or retry_count >= max_retries
+                or (is_permanent and permanent_streak == _PERMANENT_FAIL_FAST_AFTER)
+            )
+            if should_log:
+                logger.info(
+                    f"Error: {e}, retrying... (attempt {retry_count}/{max_retries}, url={url}, response={response_text})"
+                )
+
+            if is_permanent and permanent_streak >= _PERMANENT_FAIL_FAST_AFTER:
+                logger.error(
+                    "SGLang router returned a permanent 'no_available_workers' "
+                    f"503 {permanent_streak}x in a row for {url}. The engine "
+                    "subprocess behind the router has almost certainly crashed; "
+                    f"skipping the remaining {max_retries - retry_count} retries "
+                    "so the real failure surfaces. Inspect "
+                    "`/tmp/ray/session_latest/logs/worker-*02000000*.{out,err}` "
+                    "for the underlying traceback (CUDA OOM, NCCL, assertion, "
+                    "etc.). Set SLIME_HTTP_PERMANENT_FAIL_FAST=0 to disable "
+                    "this fast-fail and restore the original 60-retry behaviour."
+                )
+                raise
+
             if retry_count >= max_retries:
                 logger.info(f"Max retries ({max_retries}) reached, failing... (url={url})")
                 raise e

--- a/slime/slime_plugins/models/hf_attention.py
+++ b/slime/slime_plugins/models/hf_attention.py
@@ -1,3 +1,5 @@
+import json
+import os
 from abc import ABC, abstractmethod
 
 import torch
@@ -7,6 +9,63 @@ from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.transformer.module import MegatronModule
 from transformers import AutoConfig
+
+
+def _load_hf_config(checkpoint_path):
+    """Load HF config with a JSON fallback for unsupported model types.
+
+    Some Qwen3.5 / Qwen3.5-VL checkpoints carry ``model_type`` strings that
+    upstream ``transformers`` may not yet register, in which case
+    ``AutoConfig.from_pretrained`` raises before we get a chance to inspect the
+    text-only sub-config. This helper falls back to parsing ``config.json``
+    directly and synthesises a lightweight namespace object that exposes the
+    fields the spec function needs (``layer_types``, ``full_attention_interval``,
+    ``num_hidden_layers``, ``text_config``, ...).
+    """
+    try:
+        return AutoConfig.from_pretrained(checkpoint_path, trust_remote_code=True)
+    except (ValueError, KeyError):
+        config_path = os.path.join(checkpoint_path, "config.json")
+        with open(config_path) as f:
+            config_dict = json.load(f)
+
+        _DTYPE_MAP = {"bfloat16": torch.bfloat16, "float16": torch.float16, "float32": torch.float32}
+
+        def _fix_dtype(d):
+            if "torch_dtype" in d:
+                d["torch_dtype"] = _DTYPE_MAP.get(d["torch_dtype"], d["torch_dtype"])
+            if "dtype" in d:
+                d["dtype"] = _DTYPE_MAP.get(d["dtype"], d["dtype"])
+
+        _fix_dtype(config_dict)
+        ns = type("HFConfig", (), config_dict)()
+        if "text_config" in config_dict:
+            _fix_dtype(config_dict["text_config"])
+            ns.text_config = type("TextConfig", (), config_dict["text_config"])()
+        return ns
+
+
+class _AllGatherForDuplicatedComputation(torch.autograd.Function):
+    """All-gather whose backward returns the local gradient slice (no reduce).
+
+    Use this instead of ``dist.nn.all_gather`` when the computation after the
+    gather is *duplicated* across ranks (same weights, same full input →
+    identical gradients). The default ``all_gather`` backward performs a
+    reduce-scatter, which incorrectly sums ``world_size`` identical copies of
+    the gradient, effectively scaling it by ``world_size``.
+    """
+
+    @staticmethod
+    def forward(ctx, x, group):
+        ctx.group = group
+        ctx.rank = dist.get_rank(group=group)
+        out = [torch.empty_like(x) for _ in range(dist.get_world_size(group=group))]
+        dist.all_gather(out, x.contiguous(), group=group)
+        return tuple(out)
+
+    @staticmethod
+    def backward(ctx, *grads):
+        return grads[ctx.rank], None
 
 
 class HuggingfaceAttention(MegatronModule, ABC):
@@ -30,7 +89,7 @@ class HuggingfaceAttention(MegatronModule, ABC):
         # Note that megatron layer_number starts at 1
         self.layer_number = layer_number
         self.hf_layer_idx = layer_number - 1
-        self.hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+        self.hf_config = _load_hf_config(args.hf_checkpoint)
         # hardcode to fa2 at the moment.
         self.hf_config._attn_implementation = "flash_attention_2"
 
@@ -54,15 +113,24 @@ class HuggingfaceAttention(MegatronModule, ABC):
         cu_seqlens = packed_seq_params.cu_seqlens_q
 
         if self.args.sequence_parallel:
+            # tensor_parallel_output_grad=False: the hf_forward below is NOT
+            # TP-sharded for hybrid linear-attention layers (it is duplicated
+            # on every TP rank), so the backward must split (not reduce-scatter)
+            # to avoid inflating gradients by a factor of TP.
             hidden_states = tensor_parallel.gather_from_sequence_parallel_region(
-                hidden_states, group=mpu.get_tensor_model_parallel_group()
+                hidden_states,
+                tensor_parallel_output_grad=False,
+                group=mpu.get_tensor_model_parallel_group(),
             )
 
         if mpu.get_context_parallel_world_size() > 1:
             cp_size = mpu.get_context_parallel_world_size()
-            hidden_states_list = dist.nn.all_gather(
+            # Use a custom all-gather whose backward returns the local gradient
+            # instead of reduce-scatter, since the computation that follows is
+            # duplicated across CP ranks.
+            hidden_states_list = _AllGatherForDuplicatedComputation.apply(
                 hidden_states,
-                group=mpu.get_context_parallel_group(),
+                mpu.get_context_parallel_group(),
             )
 
             # TODO: preprocess this for each batch to prevent tolist in the training step

--- a/slime/slime_plugins/models/qwen3_5.py
+++ b/slime/slime_plugins/models/qwen3_5.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     pass
 
-from .hf_attention import HuggingfaceAttention
+from .hf_attention import HuggingfaceAttention, _load_hf_config
 
 
 def _get_text_config(hf_config):

--- a/slime/train_async.py
+++ b/slime/train_async.py
@@ -39,8 +39,25 @@ def train(args):
             rollout_data_next_future = rollout_manager.generate.remote(rollout_id + 1)
 
         if prm_teacher_model is not None:
-            prm_teacher_futures = prm_teacher_model.async_train(rollout_id, rollout_data_curr_ref)
-            prm_teacher_log_probs = ray.get(prm_teacher_futures[0])
+            distill_topk = int(getattr(args, "distill_topk", 0) or 0)
+            subset_mode = getattr(args, "distill_subset_mode", "student")
+            if distill_topk > 0 and subset_mode == "student":
+                # Three-pass dance for student-driven Sₜ:
+                #   1. actor runs old_actor → student top-K indices (rank 0 only).
+                #   2. PRM teacher runs forward gathering at those indices.
+                #   3. set on actor; actor.train re-runs old_actor with emit_topk
+                #      (recomputes the same student top-K) and proceeds to train.
+                student_topk = ray.get(
+                    actor_model.async_compute_student_topk(rollout_id, rollout_data_curr_ref)[0]
+                )
+                prm_teacher_log_probs = ray.get(
+                    prm_teacher_model.async_gather_at_indices(
+                        rollout_id, rollout_data_curr_ref, student_topk["topk_indices"]
+                    )[0]
+                )
+            else:
+                prm_teacher_futures = prm_teacher_model.async_train(rollout_id, rollout_data_curr_ref)
+                prm_teacher_log_probs = ray.get(prm_teacher_futures[0])
             actor_model.set_prm_teacher_log_probs(prm_teacher_log_probs)
 
         if args.use_critic:


### PR DESCRIPTION
…, and Qwen3.5 robustness fixes

Core slime changes that unblock running a different-sized PRM teacher next to the student (e.g. Qwen3-8B teacher with Qwen3-4B student) and add a token-level top-K OPD distillation path. Also bundles several Qwen3.5 robustness fixes and an SGLang router fast-fail.

PRM teacher and top-K OPD
- actor.py: copy architectural fields (num_layers/hidden_size/ffn/heads/ query_groups/kv/RoPE/MoE/MLA/MTP/vocab) from the teacher's torch_dist common.pt onto a deepcopied args namespace so the teacher can be a different model size than the student's MODEL_ARGS without going through --megatron-to-hf-mode bridge. Adds compute_student_topk and gather_at_indices wired into ray/actor_group.py.
- loss.py: opt-in emit_topk_logprobs context manager; _vocab_parallel_topk_log_probs and gather_log_probs_at_indices for per-token top-K extraction. Default actor/old_actor/ref forwards are byte-identical to before.
- arguments.py: --prm-teacher-rotary-base, --prm-teacher-megatron-to-hf-mode, --prm-teacher-hf-checkpoint, --distill-subset-mode {student,teacher,overlap}.
- train_async.py: three-pass dispatch when distill_topk>0 with subset_mode=student (student top-K, teacher gather, student loss).
- data.py / model.py: carry prm_teacher_topk_log_probs / topk_indices / topk_log_probs through rollout logging and train_one_step packing.

Bridge / raw mode parity and OOM fix
- model_provider.py: forward CLI flags into bridge providers (recompute, dropout, attention/dropout/SwiGLU/RoPE fusion, dtype, CP) so bridge mode does not silently keep HF-config defaults (e.g. attention_dropout=0.1) and cause train-vs-inference skew.
- model.py: pass fp32_output=False on the train forward to match the forward-only path; without this, packing 2 samples into a 16K microbatch produces a 7.58 GiB fp32 logits allocation that OOMs an 80GB GPU.

Qwen3.5 robustness
- backends/sglang_utils/qwen3_5.py: drop the .self_attn. prefix from Megatron-emitted weight names and remove the erroneous model. re-prefix so weights load correctly into SGLang's Qwen3.5 full-attention layer (qkv_proj/o_proj/q_norm/k_norm registered as direct attributes of the decoder layer, not under self_attn).
- slime_plugins/models/hf_attention.py: _load_hf_config JSON fallback for Qwen3.5 / Qwen3.5-VL checkpoints whose model_type is not yet registered in transformers; new _AllGatherForDuplicatedComputation autograd Function whose backward returns the local slice (avoids the world_size gradient inflation when wrapping duplicated computation); pass tensor_parallel_output_grad=False on the SP gather of hidden_states for hybrid linear-attention layers.
- slime_plugins/models/qwen3_5.py: re-export _load_hf_config.

SGLang router fail-fast
- utils/http_utils.py: stop drowning logs after N consecutive no_available_workers / circuits-open 503s from the router; tunable via SLIME_HTTP_PERMANENT_FAIL_FAST (default 3). Also throttles retry log spam to attempts {1,5,10,25,50}.

Launch scripts (Qwen3.5)
- scripts/run-qwen35-4B.sh: Qwen3.5 4B training launcher.
- scripts/models/qwen3.5-9B-VL.sh, qwen3.5-27B-VL.sh: Qwen3.5 VL configs.