### PR TITLE
feat: support resuming existing W&B runs

### DIFF
--- a/slime/slime/utils/arguments.py
+++ b/slime/slime/utils/arguments.py
@@ -1179,6 +1179,7 @@ def get_slime_extra_args_provider(add_custom_arguments=None):
                 help="Whether to turn on passrate logging, which will log the pass@n of the responses in the rollout.",
             )
             parser.add_argument("--wandb-run-id", type=str, default=None)
+            parser.add_argument("--wandb-resume", type=str, default="allow")
             return parser
 
         # tensorboard

--- a/slime/slime/utils/wandb_utils.py
+++ b/slime/slime/utils/wandb_utils.py
@@ -58,6 +58,13 @@ def init_wandb_primary(args):
         "config": _compute_config_for_logging(args),
     }
 
+    # When resuming training, continue logging to the same W&B run if a run id is provided
+    wandb_run_id = getattr(args, "wandb_run_id", None)
+    if wandb_run_id is not None:
+        init_kwargs["id"] = wandb_run_id
+        init_kwargs["resume"] = args.wandb_resume
+        logger.info("Resuming W&B run %s with resume=%s", wandb_run_id, args.wandb_resume)
+
     # Configure settings based on offline/online mode
     if offline:
         init_kwargs["settings"] = wandb.Settings(mode="offline")

--- a/toolcall-rl/retool_qwen3_4b_rl.sh
+++ b/toolcall-rl/retool_qwen3_4b_rl.sh
@@ -51,8 +51,7 @@ HF_CKPT=${HF_CKPT:-/data_storage/wyj/systems/huggingface/hub/qwen3-4b-retool-sft
 REF_LOAD=${REF_LOAD:-/data_storage/wyj/systems/huggingface/hub/qwen3-4b-retool-sft_torch_dist}
 SAVE_CKPT=${SAVE_CKPT:-/data_storage/wyj/OpenClaw-RL/ckpt/qwen3-4b-retool-rl/}
 RESUME_LOAD=${RESUME_LOAD:-${SAVE_CKPT}}
-# Use the existing run id to continue plotting on the same W&B curve.
-#WANDB_RESUME=${WANDB_RESUME:-must}
+
 
 CKPT_ARGS=(
    --hf-checkpoint ${HF_CKPT}
@@ -136,6 +135,9 @@ WANDB_ARGS=(
    --wandb-project slime_retool
    --wandb-group qwen3-4B-rl_retool
    --wandb-key ${WANDB_KEY}
+   # Use the existing run id to continue plotting on the same W&B curve.
+   # --wandb-run-id <existing_run_id>
+   # --wandb-resume must
 )
 
 SGLANG_ARGS=(


### PR DESCRIPTION
Summary:
- add --wandb-resume argument for W&B run resumption
- pass wandb run id and resume mode into wandb.init when provided
- update the qwen3 4b RL script example to show how to resume the same W&B run

Example:
Uncomment the following in WANDB_ARGS when resuming:
- --wandb-run-id <existing_run_id>
- --wandb-resume must
