### PR TITLE
openclaw-combine: multi-candidate top-K OPD select path

### DIFF
--- a/openclaw-combine/openclaw_combine_select_api_server.py
+++ b/openclaw-combine/openclaw_combine_select_api_server.py
@@ -1,0 +1,347 @@
+"""Multi-candidate variant of OpenClawCombineAPIServer.
+
+Drop-in replacement that, instead of selecting the SINGLE longest accepted
+hint and shipping ONE ``teacher_tokens``, KEEPS ALL accepted hints
+(deduped, shortest-first, capped at ``OPENCLAW_TOPK_MAX_CAND``),
+materializes a ``teacher_tokens`` candidate per hint, and ships them as
+``sample.teacher_tokens_candidates`` (a ``list[list[int]]``).
+
+Slime's multi-candidate teacher infra detects ``teacher_tokens_candidates``
+automatically (see ``slime/backends/megatron_utils/actor.py::
+compute_prm_teacher_log_probs`` and ``_gather_at_indices_multi_cand``)
+and runs the K-loop, producing ``prm_teacher_topk_log_probs_cand``,
+``prm_teacher_topk_indices_cand``, and (under student subset mode)
+``prm_teacher_native_topk_indices_cand`` -- exactly what the
+``openclaw_topk_select_loss`` kernel consumes.
+
+Architectural notes
+-------------------
+* Forces the megatron PRM-teacher path. The inference-side
+  ``_compute_teacher_log_probs`` / ``_compute_teacher_topk_logprobs``
+  computed by the parent are NOT used by the topk select kernel and
+  are skipped here for efficiency. The launcher must export
+  ``OPENCLAW_COMBINE_OPD_TEACHER_SOURCE=megatron`` and pass
+  ``--prm-teacher-load <ckpt>``.
+
+* Single-CoT semantics per Sample: each turn fires
+  ``_submit_turn_sample`` (or ``_submit_rl_turn_sample``) -> ONE
+  Sample per session-turn (the dynamic-history training paradigm; each
+  step is its own training datum).  ``step_token_spans`` is
+  intentionally absent from the Sample; ``sequence_optimal`` naturally
+  collapses to one ``k*`` per Sample which IS the canonical per-PRM-step
+  ``k*`` under dynamic-history rollout.
+
+* RL-only turns (no hint accepted, eval ±1) ship
+  ``teacher_tokens_candidates = [prompt_ids + response_ids]``
+  (degenerate ``K_i=1``, un-enhanced).  Slime's K-loop cyclically
+  reuses this single candidate up to ``K_max`` identical forwards.
+  The loss kernel handles ``K_i=1`` correctly (``k*=0`` always for
+  those samples).
+
+* Hint ordering: candidates are sorted SHORTEST-first by ``len(hint)``,
+  matching the retool / hint_opd_exp convention.  This makes
+  ``--hint-selection shortest`` correspond to ``k*=0`` deterministically.
+
+Knobs
+-----
+``OPENCLAW_TOPK_MAX_CAND``
+    Max ``K_i`` candidate hints to keep per turn.  Default 3 (matches the
+    retool / hint_opd_exp ``--hint-m`` default of 3 wired through the
+    launcher).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+import torch
+
+from openclaw_combine_api_server import OpenClawCombineAPIServer
+from openclaw_opd_api_server import (
+    _append_hint_to_messages,
+    _build_hint_judge_messages,
+    _build_prm_eval_prompt,
+    _flatten_message_content,
+    _normalize_messages_for_template,
+    _prm_eval_majority_vote,
+)
+from slime.utils.types import Sample
+
+logger = logging.getLogger(__name__)
+
+_CYAN = "\033[96m"
+_RESET = "\033[0m"
+
+
+def _max_cand() -> int:
+    return max(1, int(os.environ.get("OPENCLAW_TOPK_MAX_CAND", "3")))
+
+
+class OpenClawCombineSelectAPIServer(OpenClawCombineAPIServer):
+    """Multi-candidate hint variant of ``OpenClawCombineAPIServer``.
+
+    The three-case dispatch table from the parent (OPD-only / OPD+RL /
+    RL-only) is preserved; only the OPD evaluation step changes:
+
+      * Parent: ``_select_best_hint(votes)`` -> single hint -> single
+        ``teacher_tokens``.
+      * Here  : keep ALL accepted votes (deduped, shortest-first,
+        capped at ``OPENCLAW_TOPK_MAX_CAND``) -> list of ``teacher_tokens``
+        candidates -> ``sample.teacher_tokens_candidates``.
+    """
+
+    async def _opd_evaluate(
+        self,
+        session_id: str,
+        turn_num: int,
+        turn_data: dict[str, Any],
+        next_state: dict[str, Any],
+    ) -> dict[str, Any]:
+        next_state_text = (
+            _flatten_message_content(next_state.get("content")) if next_state else ""
+        )
+        next_state_role = next_state.get("role", "user") if next_state else "user"
+        judge_msgs = _build_hint_judge_messages(
+            turn_data["response_text"], next_state_text, next_state_role,
+        )
+        if self._prm_tokenizer:
+            judge_prompt = self._prm_tokenizer.apply_chat_template(
+                judge_msgs, tokenize=False, add_generation_prompt=True,
+            )
+        else:
+            judge_prompt = "\n".join(m["content"] for m in judge_msgs)
+
+        votes = await asyncio.gather(
+            *[self._query_judge_once(judge_prompt, i) for i in range(self._prm_m)]
+        )
+
+        # PRM eval branch (unchanged from parent).
+        if self._eval_mode:
+            eval_msgs = _build_prm_eval_prompt(
+                turn_data["response_text"], next_state_text, next_state_role,
+            )
+            if self._prm_tokenizer:
+                eval_prompt = self._prm_tokenizer.apply_chat_template(
+                    eval_msgs, tokenize=False, add_generation_prompt=True,
+                )
+            else:
+                eval_prompt = "\n".join(m["content"] for m in eval_msgs)
+            async with self._teacher_lp_semaphore:
+                eval_raw = await asyncio.gather(
+                    *[self._query_prm_eval_once(eval_prompt, i) for i in range(self._prm_m)]
+                )
+            eval_score = _prm_eval_majority_vote(eval_raw)
+            logger.info(
+                "%s[OpenClaw-Combine-Select] PRM eval session=%s turn=%d "
+                "eval_votes=%s -> eval_score=%.1f%s",
+                _CYAN, session_id, turn_num,
+                [s if s is not None else "fail" for s in eval_raw],
+                eval_score, _RESET,
+            )
+        else:
+            eval_score = None
+
+        # Multi-candidate selection: keep ALL accepted hints (score==1,
+        # len>10), dedupe by hint text, sort shortest-first, cap at
+        # OPENCLAW_TOPK_MAX_CAND. This matches the retool / hint_opd_exp
+        # convention so --hint-selection shortest -> k*=0.
+        accepted: list[dict[str, Any]] = []
+        seen_hints: set[str] = set()
+        for v in votes:
+            if v.get("score") != 1:
+                continue
+            hint_raw = v.get("hint")
+            if not isinstance(hint_raw, str):
+                continue
+            hint = hint_raw.strip()
+            if len(hint) <= 10:
+                continue
+            if hint in seen_hints:
+                continue
+            seen_hints.add(hint)
+            accepted.append({**v, "hint": hint})
+        accepted.sort(key=lambda v: len(v["hint"]))
+        accepted = accepted[: _max_cand()]
+        votes_display = [v.get("score", "fail") for v in votes]
+
+        if not accepted:
+            logger.info(
+                "%s[OpenClaw-Combine-Select] session=%s turn=%d no valid "
+                "hint (votes=%s), sample dropped%s",
+                _CYAN, session_id, turn_num, votes_display, _RESET,
+            )
+            self._append_prm_record(
+                {
+                    "session_id": session_id,
+                    "turn": turn_num,
+                    "accepted": False,
+                    "hint": "",
+                    "votes": votes,
+                }
+            )
+            return {
+                "accepted": False,
+                "teacher_tokens_candidates": None,
+                "hint": "",
+                "hints": [],
+                "votes": votes,
+                "eval_score": eval_score,
+            }
+
+        # Materialize teacher_tokens_candidates: one enhanced_ids per
+        # surviving hint. The teacher LP / topk are computed by the
+        # Megatron PRM-teacher pass downstream; we DO NOT call
+        # _compute_teacher_log_probs here.
+        candidates: list[list[int]] = []
+        hints: list[str] = []
+        for v in accepted:
+            hint = v["hint"]
+            enhanced_messages = _append_hint_to_messages(turn_data["messages"], hint)
+            norm_enhanced = _normalize_messages_for_template(enhanced_messages)
+            enhanced_prompt_text = self.tokenizer.apply_chat_template(
+                norm_enhanced,
+                tools=turn_data.get("tools"),
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+            enhanced_full_text = enhanced_prompt_text + turn_data["response_text"]
+            enhanced_ids = self.tokenizer(
+                enhanced_full_text, add_special_tokens=False,
+            )["input_ids"]
+            candidates.append(enhanced_ids)
+            hints.append(hint)
+
+        logger.info(
+            "%s[OpenClaw-Combine-Select] session=%s turn=%d accepted "
+            "K_i=%d hint_lens=%s votes=%s%s",
+            _CYAN, session_id, turn_num,
+            len(candidates),
+            [len(h) for h in hints],
+            votes_display,
+            _RESET,
+        )
+        self._append_prm_record(
+            {
+                "session_id": session_id,
+                "turn": turn_num,
+                "accepted": True,
+                "K_i": len(candidates),
+                "hints": hints,
+                "hint_lens": [len(h) for h in hints],
+                "votes": votes,
+                "teacher_tokens_lens": [len(c) for c in candidates],
+            }
+        )
+        return {
+            "accepted": True,
+            "teacher_tokens_candidates": candidates,
+            "hint": hints[0],   # for log-line back-compat with parent
+            "hints": hints,
+            "votes": votes,
+            "eval_score": eval_score,
+        }
+
+    async def _submit_turn_sample(
+        self,
+        turn_data: dict[str, Any],
+        session_id: str,
+        opd_result: dict[str, Any],
+        reward: float = 0.0,
+    ):
+        prompt_ids = turn_data["prompt_ids"]
+        response_ids = turn_data["response_ids"]
+
+        candidates = opd_result.get("teacher_tokens_candidates") or []
+        if not candidates:
+            # _maybe_submit_ready_samples shouldn't dispatch here when
+            # no hint was accepted; guard anyway with a degenerate
+            # K_i=1 (un-enhanced) so the multi-cand pipeline always
+            # has a valid candidate list.
+            candidates = [list(prompt_ids) + list(response_ids)]
+
+        sample = Sample()
+        sample.prompt = turn_data["prompt_text"]
+        sample.response = turn_data["response_text"]
+        sample.tokens = list(prompt_ids) + list(response_ids)
+        sample.response_length = len(response_ids)
+        sample.loss_mask = [1] * len(response_ids)
+        sample.rollout_log_probs = turn_data["response_logprobs"]
+
+        # teacher_log_probs is consumed only by the legacy combine_loss /
+        # hint_opd_loss kernels (token-level teacher signal). Our topk
+        # select kernel ignores it but slime's data pipeline still
+        # concatenates it -- ship zeros of the right length.
+        sample.teacher_log_probs = torch.zeros(len(response_ids), dtype=torch.float32)
+
+        # Multi-candidate teacher tokens (the slime K-loop hook).
+        sample.teacher_tokens_candidates = candidates
+        # Back-compat: legacy code paths (and the K_i=1 degenerate case)
+        # still read teacher_tokens; keep it pointing at candidate 0.
+        sample.teacher_tokens = candidates[0]
+
+        sample.status = Sample.Status.COMPLETED
+        sample.index = next(self._index_counter)
+        sample.group_index = next(self._group_counter)
+        sample.reward = {"score": reward}
+
+        tag = "OPD+RL" if reward != 0.0 else "OPD"
+        logger.info(
+            "[OpenClaw-Combine-Select] submitted %s sample session=%s "
+            "index=%d reward=%.1f prompt_len=%d response_len=%d K_i=%d "
+            "hint_lens=%s",
+            tag, session_id, sample.index, reward,
+            len(prompt_ids), len(response_ids),
+            len(candidates),
+            [len(h) for h in opd_result.get("hints") or [opd_result.get("hint", "")]],
+        )
+        await asyncio.to_thread(self.output_queue.put, (sample.group_index, [sample]))
+
+    async def _submit_rl_turn_sample(
+        self, turn_data: dict, session_id: str, eval_score: float,
+    ):
+        prompt_ids = turn_data["prompt_ids"]
+        response_ids = turn_data["response_ids"]
+        response_logprobs = turn_data["response_logprobs"]
+
+        if len(response_logprobs) > len(response_ids):
+            response_logprobs = response_logprobs[: len(response_ids)]
+        elif len(response_logprobs) < len(response_ids):
+            response_logprobs = response_logprobs + [0.0] * (
+                len(response_ids) - len(response_logprobs)
+            )
+
+        sample = Sample()
+        sample.prompt = turn_data["prompt_text"]
+        sample.response = turn_data["response_text"]
+        sample.tokens = list(prompt_ids) + list(response_ids)
+        sample.response_length = len(response_ids)
+        sample.loss_mask = [1] * len(response_ids)
+        sample.rollout_log_probs = response_logprobs
+
+        # No real teacher signal for RL-only samples -- ship zeros
+        # (consumed by legacy kernels but ignored by topk select).
+        sample.teacher_log_probs = torch.zeros(len(response_ids), dtype=torch.float32)
+
+        # Degenerate K_i=1 candidate so the multi-cand pipeline always
+        # has SOMETHING to gather. The teacher just forwards on the
+        # un-enhanced sequence; the loss kernel handles K_i=1 with
+        # k*=0 by construction.
+        un_enhanced = list(prompt_ids) + list(response_ids)
+        sample.teacher_tokens_candidates = [un_enhanced]
+        sample.teacher_tokens = un_enhanced
+
+        sample.status = Sample.Status.COMPLETED
+        sample.index = next(self._index_counter)
+        sample.group_index = next(self._group_counter)
+        sample.reward = {"score": float(eval_score)}
+
+        logger.info(
+            "[OpenClaw-Combine-Select] submitted RL sample session=%s "
+            "index=%d score=%.1f prompt_len=%d response_len=%d K_i=1",
+            session_id, sample.index, float(eval_score),
+            len(prompt_ids), len(response_ids),
+        )
+        await asyncio.to_thread(self.output_queue.put, (sample.group_index, [sample]))

--- a/openclaw-combine/openclaw_combine_select_rollout.py
+++ b/openclaw-combine/openclaw_combine_select_rollout.py
@@ -1,0 +1,198 @@
+"""Multi-candidate rollout entry point for openclaw-combine.
+
+Drop-in alternative to ``openclaw_combine_rollout.generate_rollout_openclaw_combine``.
+Identical worker / queue / drain plumbing; the only change is the API
+server class -- ``OpenClawCombineSelectAPIServer`` instead of
+``OpenClawCombineAPIServer``.
+
+Module-level state (``_global_worker``, ``_worker_lock``) is INTENTIONALLY
+separate from the original combine rollout so the two entry points can
+co-exist in the same launcher PYTHONPATH without aliasing the singleton.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import os
+import queue
+import threading
+import time
+
+from openclaw_combine_select_api_server import OpenClawCombineSelectAPIServer
+from slime.rollout.base_types import RolloutFnTrainOutput
+from slime.rollout.sglang_rollout import eval_rollout
+from slime.utils.async_utils import run
+from slime.utils.types import Sample
+
+_global_worker = None
+_worker_lock = threading.Lock()
+
+
+def get_global_worker(args, data_buffer):
+    global _global_worker
+    with _worker_lock:
+        if _global_worker is None or not _global_worker.worker_thread.is_alive():
+            _global_worker = AsyncRolloutWorker(args, data_buffer)
+            _global_worker.start()
+        return _global_worker
+
+
+def stop_global_worker():
+    global _global_worker
+    with _worker_lock:
+        if _global_worker is not None:
+            _global_worker.stop()
+            _global_worker = None
+
+
+class AsyncRolloutWorker:
+    def __init__(self, args, data_buffer):
+        self.args = args
+        self.data_buffer = data_buffer
+        self.running = True
+        self.output_queue = queue.Queue(maxsize=100000)
+        self.worker_thread = None
+        self._submission_enabled = threading.Event()
+        self._server = OpenClawCombineSelectAPIServer(
+            args=args,
+            output_queue=self.output_queue,
+            submission_enabled=self._submission_enabled,
+        )
+
+    async def continuous_worker_loop(self):
+        while self.running:
+            await asyncio.sleep(1.0)
+
+    def worker_thread_func(self):
+        asyncio.run(self.continuous_worker_loop())
+
+    def start(self):
+        self._server.start()
+        if self.worker_thread is None or not self.worker_thread.is_alive():
+            self.worker_thread = threading.Thread(
+                target=self.worker_thread_func, daemon=True,
+            )
+            self.worker_thread.start()
+
+    def stop(self):
+        self.running = False
+        self._submission_enabled.clear()
+        self._server.stop()
+        if self.worker_thread and self.worker_thread.is_alive():
+            self.worker_thread.join(timeout=5)
+
+    def pause_submission(self):
+        if self._submission_enabled.is_set():
+            self._submission_enabled.clear()
+            self._server.purge_record_files()
+            print("[OpenClawCombineSelectWorker] submission paused")
+
+    def resume_submission(self):
+        if not self._submission_enabled.is_set():
+            self._submission_enabled.set()
+            print("[OpenClawCombineSelectWorker] submission resumed")
+
+    def get_completed_groups(self) -> list[tuple]:
+        completed = []
+        while True:
+            try:
+                completed.append(self.output_queue.get_nowait())
+            except queue.Empty:
+                break
+        return completed
+
+    def get_queue_size(self) -> int:
+        return self.output_queue.qsize()
+
+
+async def _drain_output_queue(args, worker: AsyncRolloutWorker) -> list[list[Sample]]:
+    target_data_size = args.rollout_batch_size
+    data: list[list[Sample]] = []
+    completed_groups: dict[int, list[Sample]] = {}
+    start = time.time()
+    last_progress = start
+
+    while len(data) < target_data_size:
+        completed = worker.get_completed_groups()
+        if completed:
+            last_progress = time.time()
+            for group_id, group in completed:
+                completed_groups[group_id] = group
+
+        for group_id in list(completed_groups.keys()):
+            if len(data) >= target_data_size:
+                break
+            group = completed_groups.pop(group_id)
+            if any(sample.status == Sample.Status.ABORTED for sample in group):
+                continue
+            data.append(group)
+
+        if time.time() - last_progress > 30:
+            print(
+                f"[OpenClawCombineSelectWorker] waiting for combine samples: "
+                f"{len(data)}/{target_data_size}, queue={worker.get_queue_size()}",
+                flush=True,
+            )
+            last_progress = time.time()
+
+        if len(data) < target_data_size:
+            await asyncio.sleep(0.05)
+
+    data.sort(
+        key=lambda group: group[0].index if group and group[0].index is not None else -1
+    )
+    print(
+        f"[OpenClawCombineSelectWorker] drained {len(data)} groups in "
+        f"{time.time() - start:.2f}s",
+        flush=True,
+    )
+    return data
+
+
+def generate_rollout_openclaw_combine_select(
+    args, rollout_id, data_buffer, evaluation=False,
+):
+    """``--rollout-function-path`` entry point for openclaw_combine_select.
+
+    Same drain / eval logic as ``generate_rollout_openclaw_combine``;
+    the only behavioural difference is upstream -- the
+    ``OpenClawCombineSelectAPIServer`` produces multi-candidate
+    ``teacher_tokens_candidates`` per Sample.
+    """
+    worker = get_global_worker(args, data_buffer)
+
+    if evaluation:
+        eval_output, _ = run(eval_rollout(args, rollout_id))
+        return eval_output
+
+    worker._server.reset_eval_scores()
+    worker.resume_submission()
+    completed_samples = run(_drain_output_queue(args, worker))
+    worker.pause_submission()
+
+    train_epochs = int(os.getenv("TRAIN_EPOCHS", "1"))
+    if train_epochs > 1:
+        original = list(completed_samples)
+        for _ in range(train_epochs - 1):
+            completed_samples.extend(original)
+        print(
+            f"[OpenClawCombineSelectWorker] duplicated {len(original)} groups "
+            f"x{train_epochs} = {len(completed_samples)} groups for training",
+            flush=True,
+        )
+
+    extra_metrics = None
+    eval_scores = worker._server.drain_eval_scores()
+    if eval_scores:
+        extra_metrics = {"rollout/prm_eval_score": sum(eval_scores) / len(eval_scores)}
+        print(
+            f"[OpenClawCombineSelectWorker] prm_eval_score="
+            f"{extra_metrics['rollout/prm_eval_score']:.4f} (n={len(eval_scores)})",
+            flush=True,
+        )
+
+    return RolloutFnTrainOutput(samples=completed_samples, metrics=extra_metrics)
+
+
+atexit.register(stop_global_worker)

--- a/openclaw-combine/openclaw_topk_select_loss.py
+++ b/openclaw-combine/openclaw_topk_select_loss.py
@@ -1,0 +1,504 @@
+"""Combined GRPO + top-K On-Policy-Distillation loss for openclaw-combine,
+with K-candidate teacher supervision selection (9-cell matrix).
+
+Drop-in alternative to ``combine_loss.combine_loss_function`` for the
+``openclaw_combine_select_rollout.generate_rollout_openclaw_combine_select``
+rollout path.
+
+Supports all 9 combinations of ``--distill-subset-mode`` × ``--hint-selection``:
+
+============================== =================  ==============  =====================
+``--hint-selection``           ``student``        ``overlap``     ``teacher``
+============================== =================  ==============  =====================
+``shortest``                   in-kernel k*=0     in-kernel k*=0  legacy (actor-side k*=0)
+``token_optimal``              in-kernel k*(t)    in-kernel k*(t) legacy (actor-side k*(t))
+``sequence_optimal``           in-kernel k*       in-kernel k*    legacy (actor-side k*)
+============================== =================  ==============  =====================
+
+For openclaw-combine, ``sequence_optimal`` is per-Sample. This is the
+canonical per-PRM-step k* under the dynamic-history training paradigm:
+``_submit_turn_sample`` fires ONCE per session-turn, so each Sample IS
+one PRM step (rather than a multi-step trajectory rolled into one
+Sample as in retool). The kernel's "no step_token_spans → per-sample"
+fallback fires here because there's nothing to step over inside a
+Sample; the step granularity has already been materialized at the
+Sample level by the rollout.
+
+Equations (consistent with hint_opd_select_loss; see that file's docstring
+for full derivation):
+
+  S^q_t = top-K(pi_old)         (student top-K vocab at t)
+  S^p_{t,k} = top-K(pi_T,k)     (teacher candidate k's top-K vocab at t)
+  O[k, t] = | S^q_t ∩ S^p_{t,k} |       (overlap selection signal)
+
+  k*(t)  = 0                                          if shortest
+         = argmax_k O[k, t]                           if token_optimal
+         = argmax_k Σ_t O[k, t]                       if sequence_optimal
+                                                      (per-Sample = per-PRM-step
+                                                      under openclaw dynamic-history)
+
+  S_t    = S^q_t                                      if subset_mode=student
+         = S^p_{t, k*(t)}                             if subset_mode=teacher
+         = S^q_t ∩ S^p_{t, k*(t)}                     if subset_mode=overlap
+
+  w_v       = softmax_{v∈S_t}( ell_old(v) )           (IS weight, detached)
+  diff_v    = clip( ell_T,k*(v) - ell_old(v),
+                    -OPENCLAW_TOPK_ADV_DIFF_CLIP,
+                    +OPENCLAW_TOPK_ADV_DIFF_CLIP )    (detached)
+  A_v       = diff_v * w_v                             (detached)
+  rho_v     = exp( ell_cur(v) - ell_old(v) )           (GLOBAL ratio, gradient)
+  L_v       = max( -A_v * rho_v, -A_v * clip(rho_v, 1-eps, 1+eps_hi) )
+  L^OPD_t   = Σ_{v ∈ S_t} L_v                          (sum, NOT mean)
+
+GRPO branch (per-token):
+  L^GRPO_t  = max( -A^grpo_t * rho^seq_t,
+                   -A^grpo_t * clip(rho^seq_t, 1-eps, 1+eps_hi) )
+
+Combined per-token (the combine semantics):
+  L^combine_t = w_RL * L^GRPO_t + w_OPD * L^OPD_t
+
+Trajectory aggregation: slime ``sum_of_sample_mean`` over response tokens.
+
+Environment variables (all OPENCLAW_TOPK_* prefix; defaults shown):
+    OPENCLAW_TOPK_W_RL              weight on GRPO PG     (default 1.0)
+    OPENCLAW_TOPK_W_OPD             weight on top-K OPD   (default 1.0)
+    OPENCLAW_TOPK_ADV_DIFF_CLIP     clamp on (ell_T - ell_old)  (default 2.0)
+    OPENCLAW_TOPK_PPO_CLIP_EPS_LO   override args.eps_clip       (optional)
+    OPENCLAW_TOPK_PPO_CLIP_EPS_HI   override args.eps_clip_high  (optional)
+
+Defaults differ from hint_opd's (w_rl=0.0, w_opd=1.0): combine has BOTH
+signals on every Sample (RL+OPD, OPD-only, or RL-only depending on
+which branches accepted; see openclaw_combine_api_server's three-case
+table), so we leave both weights at 1.0 to match the existing combine
+launcher's defaults.
+"""
+
+from __future__ import annotations
+
+import os
+from argparse import Namespace
+from collections.abc import Callable
+
+import torch
+from megatron.core import mpu
+
+# Reuse the verl-aligned per-sample OPD surrogate AND the multi-cand
+# selection helpers from the hint_opt_exp implementation. These are
+# pure functions (no env-var coupling) so importing them is safe and
+# keeps the math identical to retool / hint_opd_exp.
+from hint_opd_loss import _opd_one_sample
+from hint_opd_select_loss import (
+    _gather_along_K,
+    _overlap_count_per_token,
+    _select_k_star_per_token,
+)
+from slime.backends.megatron_utils.loss import get_log_probs_and_entropy, get_responses
+from slime.utils.ppo_utils import compute_approx_kl, compute_policy_loss
+
+
+def _w_rl() -> float:
+    return float(os.environ.get("OPENCLAW_TOPK_W_RL", "1.0"))
+
+
+def _w_opd() -> float:
+    return float(os.environ.get("OPENCLAW_TOPK_W_OPD", "1.0"))
+
+
+def _eps_clip_lo(args: Namespace) -> float:
+    v = os.environ.get("OPENCLAW_TOPK_PPO_CLIP_EPS_LO", "")
+    return float(v) if v else float(args.eps_clip)
+
+
+def _eps_clip_hi(args: Namespace) -> float:
+    v = os.environ.get("OPENCLAW_TOPK_PPO_CLIP_EPS_HI", "")
+    return float(v) if v else float(args.eps_clip_high)
+
+
+def _adv_diff_clip() -> float | None:
+    raw = os.environ.get("OPENCLAW_TOPK_ADV_DIFF_CLIP", "")
+    if raw == "":
+        return 2.0
+    val = float(raw)
+    return val if val > 0.0 else None
+
+
+def openclaw_topk_select_loss_function(
+    args: Namespace,
+    batch: dict,
+    logits: torch.Tensor,
+    sum_of_sample_mean: Callable[[torch.Tensor], torch.Tensor],
+) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    """``--custom-loss-function-path`` entry point for openclaw_combine_select.
+
+    Dispatches on (``args.distill_subset_mode``, ``args.hint_selection``)
+    to cover all 9 cells:
+
+      * ``subset_mode == "teacher"``: actor-side ``train_actor`` already
+        collapsed the cand teacher tensors into single-cand keys
+        (``prm_teacher_topk_log_probs``, ``prm_teacher_topk_indices``)
+        AFTER selecting k* and re-gathering student-old log-probs at the
+        chosen S^p. We consume those single-cand keys directly.
+      * ``subset_mode in {student, overlap}``: read the cand keys
+        directly and slice at k*(t) in-kernel. Under ``student`` the
+        teacher cand log-probs are GATHERED at S^q (constant indices
+        across k); the per-(k, t) selection signal travels in
+        ``prm_teacher_native_topk_indices_cand``.
+    """
+    hint_selection = getattr(args, "hint_selection", "shortest")
+    subset_mode = getattr(args, "distill_subset_mode", "student")
+    if hint_selection not in ("shortest", "token_optimal", "sequence_optimal"):
+        raise ValueError(
+            f"Unknown --hint-selection: {hint_selection!r}. Expected one of "
+            "'shortest', 'token_optimal', 'sequence_optimal'."
+        )
+    if subset_mode not in ("student", "teacher", "overlap"):
+        raise ValueError(
+            f"Unknown --distill-subset-mode: {subset_mode!r}. Expected one of "
+            "'student', 'teacher', 'overlap'."
+        )
+
+    response_lengths = batch["response_lengths"]
+    total_lengths = batch["total_lengths"]
+    max_seq_lens = batch.get("max_seq_lens", None)
+
+    w_rl = _w_rl()
+    w_opd = _w_opd()
+    eps_lo = _eps_clip_lo(args)
+    eps_hi = _eps_clip_hi(args)
+    diff_clip = _adv_diff_clip()
+    need_entropy_for_loss = args.entropy_coef != 0.0
+
+    _, log_probs_and_entropy = get_log_probs_and_entropy(
+        logits,
+        args=args,
+        unconcat_tokens=batch["unconcat_tokens"],
+        total_lengths=total_lengths,
+        response_lengths=response_lengths,
+        with_entropy=need_entropy_for_loss,
+        max_seq_lens=max_seq_lens,
+    )
+    new_log_probs = torch.cat(log_probs_and_entropy["log_probs"], dim=0)
+
+    # Hard guarantee: old log-probs come from the Megatron old_actor
+    # forward, NOT from rollout. Aligns with the OPD math (we need the
+    # full-vocab old logits, which the rollout SGLang engine doesn't
+    # emit).
+    assert not getattr(args, "use_rollout_logprobs", False), (
+        "openclaw_topk_select_loss requires --use-rollout-logprobs to be "
+        "unset so old-policy log-probs come from the Megatron old_actor."
+    )
+
+    grpo_pg_loss = torch.zeros((), device=logits.device, dtype=torch.float32)
+    grpo_pg_clipfrac = torch.zeros((), device=logits.device, dtype=torch.float32)
+    ppo_kl_mean_sampled = torch.zeros((), device=logits.device, dtype=torch.float32)
+    if w_rl != 0.0:
+        old_log_probs = torch.cat(batch["log_probs"], dim=0)
+        ppo_kl_sampled = old_log_probs - new_log_probs
+        rl_advantages = torch.cat(batch["advantages"], dim=0)
+        pg_loss_tokens, pg_clipfrac_tokens = compute_policy_loss(
+            ppo_kl_sampled, rl_advantages, eps_lo, eps_hi
+        )
+        grpo_pg_loss = sum_of_sample_mean(pg_loss_tokens)
+        grpo_pg_clipfrac = sum_of_sample_mean(pg_clipfrac_tokens)
+        ppo_kl_mean_sampled = sum_of_sample_mean(ppo_kl_sampled)
+
+    opd_loss = torch.zeros((), device=logits.device, dtype=torch.float32)
+    opd_clipfrac_scalar = torch.zeros((), device=logits.device, dtype=torch.float32)
+    teacher_student_logp_diff_mean: torch.Tensor | None = None
+    subset_size_mean: torch.Tensor | None = None
+    sel_overlap_mean: torch.Tensor | None = None
+    sel_k_star_mean: torch.Tensor | None = None
+
+    student_topk_lp = batch.get("topk_log_probs")
+    student_topk_idx = batch.get("topk_indices")
+
+    have_student = (
+        student_topk_lp is not None
+        and student_topk_idx is not None
+        and len(student_topk_lp) > 0
+        and len(student_topk_idx) > 0
+    )
+
+    # The teacher tensors are EITHER cand-suffixed (multi-cand path,
+    # subset in {student, overlap}) OR plain single-cand (actor-side
+    # collapsed, subset == teacher). Pick which side to read once.
+    use_cand_keys = subset_mode != "teacher"
+    if use_cand_keys:
+        teacher_topk_lp_any = batch.get("prm_teacher_topk_log_probs_cand")
+        teacher_topk_idx_any = batch.get("prm_teacher_topk_indices_cand")
+        teacher_native_idx_cand = batch.get("prm_teacher_native_topk_indices_cand")
+    else:
+        teacher_topk_lp_any = batch.get("prm_teacher_topk_log_probs")
+        teacher_topk_idx_any = batch.get("prm_teacher_topk_indices")
+        teacher_native_idx_cand = None
+
+    have_teacher = (
+        teacher_topk_lp_any is not None
+        and teacher_topk_idx_any is not None
+        and len(teacher_topk_lp_any) > 0
+        and len(teacher_topk_idx_any) > 0
+    )
+
+    step_spans_per_sample = batch.get("step_wise_step_token_spans")
+
+    if w_opd != 0.0:
+        if not (have_student and have_teacher):
+            cand_suffix = "_cand" if use_cand_keys else ""
+            raise RuntimeError(
+                "openclaw_topk_select_loss requires both student top-K "
+                "(topk_log_probs / topk_indices) and the teacher top-K "
+                f"(prm_teacher_topk_log_probs{cand_suffix} / "
+                f"prm_teacher_topk_indices{cand_suffix}) in the batch. "
+                "Confirm --distill-topk > 0, --hint-m > 0, "
+                "OPENCLAW_COMBINE_OPD_TEACHER_SOURCE=megatron, --prm-teacher-load "
+                "set, and the rollout function path is "
+                "openclaw_combine_select_rollout."
+                "generate_rollout_openclaw_combine_select."
+            )
+        # Selection signal sanity for student/{token,sequence}_optimal.
+        if (
+            subset_mode == "student"
+            and hint_selection != "shortest"
+            and (
+                teacher_native_idx_cand is None
+                or len(teacher_native_idx_cand) == 0
+            )
+        ):
+            raise RuntimeError(
+                "subset_mode=student with --hint-selection in "
+                "{token_optimal, sequence_optimal} requires "
+                "prm_teacher_native_topk_indices_cand (the per-candidate "
+                "selection signal) in the batch. Confirm slime's "
+                "gather_at_indices multi-cand path is engaged. "
+                "(shortest does not need it because k*=0 always.)"
+            )
+
+        tp_group = mpu.get_tensor_model_parallel_group()
+        all_pg = []
+        all_clip = []
+        all_diff = []
+        all_size = []
+        all_overlap_sel = []
+        all_k_star = []
+
+        for i, (logits_chunk, _tokens_chunk) in enumerate(
+            get_responses(
+                logits,
+                args=args,
+                unconcat_tokens=batch["unconcat_tokens"],
+                total_lengths=total_lengths,
+                response_lengths=response_lengths,
+                max_seq_lens=max_seq_lens,
+            )
+        ):
+            s_idx = student_topk_idx[i].to(device=logits_chunk.device, dtype=torch.long)
+            s_lp = student_topk_lp[i].to(device=logits_chunk.device, dtype=torch.float32)
+            R = logits_chunk.size(0)
+            assert s_idx.dim() == 2 and s_idx.size(0) == R, (
+                f"student topk shape mismatch: s_idx={tuple(s_idx.shape)} "
+                f"vs R={R}"
+            )
+
+            t_lp_any_i = teacher_topk_lp_any[i].to(
+                device=logits_chunk.device, dtype=torch.float32
+            )
+            t_idx_any_i = teacher_topk_idx_any[i].to(
+                device=logits_chunk.device, dtype=torch.long
+            )
+
+            if use_cand_keys:
+                # Multi-candidate path (subset in {student, overlap}):
+                # tensors are [K, R, K_p].
+                assert t_idx_any_i.dim() == 3 and t_idx_any_i.size(1) == R, (
+                    f"teacher topk_cand shape mismatch: t_idx_cand="
+                    f"{tuple(t_idx_any_i.shape)} vs R={R}; expected [K, R, K_p]."
+                )
+                assert t_lp_any_i.shape == t_idx_any_i.shape, (
+                    f"teacher logp/idx cand shape mismatch: "
+                    f"lp={tuple(t_lp_any_i.shape)} idx={tuple(t_idx_any_i.shape)}"
+                )
+
+                # Selection signal (only computed when needed).
+                if hint_selection == "shortest":
+                    overlap_kr = None
+                else:
+                    if subset_mode == "student":
+                        # Cand log-probs are at S^q (constant across k);
+                        # use each candidate's NATIVE top-K for the
+                        # overlap signal instead.
+                        sel_idx_src = teacher_native_idx_cand[i].to(
+                            device=logits_chunk.device, dtype=torch.long
+                        )
+                        assert sel_idx_src.shape[1] == R, (
+                            f"native_topk shape mismatch: native="
+                            f"{tuple(sel_idx_src.shape)} vs R={R}; "
+                            "expected [K, R, K_p]."
+                        )
+                    else:  # overlap
+                        sel_idx_src = t_idx_any_i
+                    overlap_kr = _overlap_count_per_token(s_idx, sel_idx_src)
+
+                spans_i = (
+                    step_spans_per_sample[i]
+                    if step_spans_per_sample is not None
+                    and i < len(step_spans_per_sample)
+                    else None
+                )
+                k_star_per_token = _select_k_star_per_token(
+                    overlap_kr,
+                    hint_selection=hint_selection,
+                    step_token_spans=spans_i,
+                    R=R,
+                    device=logits_chunk.device,
+                )
+
+                # Slice cand tensors at k*(t).
+                t_lp_sel = _gather_along_K(t_lp_any_i, k_star_per_token)
+                if subset_mode == "student":
+                    # Force kernel's S^p to S^q (cand indices are already
+                    # constant across k under student subset; this keeps
+                    # the contract explicit).
+                    t_idx_sel = s_idx
+                else:  # overlap
+                    t_idx_sel = _gather_along_K(t_idx_any_i, k_star_per_token)
+
+                if overlap_kr is None:
+                    # ``shortest``: report selected-overlap as 0 so the
+                    # wandb panel is well-defined and visibly distinct
+                    # from the optimal modes (where it ≈ K_q for student).
+                    overlap_sel_per_token = torch.zeros(
+                        R, device=logits_chunk.device, dtype=torch.float32
+                    )
+                else:
+                    row_idx = torch.arange(R, device=overlap_kr.device)
+                    overlap_sel_per_token = overlap_kr[k_star_per_token, row_idx].float()
+            else:
+                # Legacy single-cand path (subset == teacher): the actor
+                # has already done k*-selection AND re-gathered
+                # student-old log-probs at the chosen S^p. We consume
+                # the collapsed [R, K_p] tensors directly.
+                assert t_idx_any_i.dim() == 2 and t_idx_any_i.size(0) == R, (
+                    f"teacher topk shape mismatch: t_idx="
+                    f"{tuple(t_idx_any_i.shape)} vs R={R}; expected [R, K_p]."
+                )
+                assert t_lp_any_i.shape == t_idx_any_i.shape
+                t_idx_sel = t_idx_any_i
+                t_lp_sel = t_lp_any_i
+                overlap_sel_per_token = torch.zeros(
+                    R, device=logits_chunk.device, dtype=torch.float32
+                )
+                k_star_per_token = torch.zeros(
+                    R, device=logits_chunk.device, dtype=torch.long
+                )
+
+            pg_t, clip_t, diff_t, valid_t = _opd_one_sample(
+                logits_chunk,
+                student_indices=s_idx,
+                student_old_lp=s_lp,
+                teacher_indices=t_idx_sel,
+                teacher_lp=t_lp_sel,
+                eps_lo=eps_lo,
+                eps_hi=eps_hi,
+                diff_clip=diff_clip,
+                tp_group=tp_group,
+            )
+            all_pg.append(pg_t)
+            all_clip.append(clip_t)
+            all_diff.append(diff_t)
+            if torch.equal(s_idx, t_idx_sel):
+                size_t = s_idx.new_full(
+                    (s_idx.size(0),), s_idx.size(-1), dtype=torch.float32
+                )
+            else:
+                eq = s_idx.unsqueeze(-1) == t_idx_sel.unsqueeze(-2)
+                size_t = eq.any(dim=-1).float().sum(dim=-1)
+            all_size.append(size_t * valid_t.float())
+            all_overlap_sel.append(overlap_sel_per_token * valid_t.float())
+            all_k_star.append(k_star_per_token.float() * valid_t.float())
+
+        opd_pg_tokens = torch.cat(all_pg, dim=0)
+        opd_clip_tokens = torch.cat(all_clip, dim=0)
+        opd_diff_tokens = torch.cat(all_diff, dim=0)
+        opd_size_tokens = torch.cat(all_size, dim=0)
+        opd_overlap_sel_tokens = torch.cat(all_overlap_sel, dim=0)
+        opd_k_star_tokens = torch.cat(all_k_star, dim=0)
+        opd_loss = sum_of_sample_mean(opd_pg_tokens)
+        opd_clipfrac_scalar = sum_of_sample_mean(opd_clip_tokens)
+        teacher_student_logp_diff_mean = sum_of_sample_mean(opd_diff_tokens)
+        subset_size_mean = sum_of_sample_mean(opd_size_tokens)
+        sel_overlap_mean = sum_of_sample_mean(opd_overlap_sel_tokens)
+        sel_k_star_mean = sum_of_sample_mean(opd_k_star_tokens)
+
+    if need_entropy_for_loss:
+        entropy = torch.cat(log_probs_and_entropy["entropy"], dim=0)
+        entropy_loss = sum_of_sample_mean(entropy)
+    else:
+        with torch.no_grad():
+            _, ent_data = get_log_probs_and_entropy(
+                logits,
+                args=args,
+                unconcat_tokens=batch["unconcat_tokens"],
+                total_lengths=total_lengths,
+                response_lengths=response_lengths,
+                with_entropy=True,
+                max_seq_lens=max_seq_lens,
+            )
+            entropy_loss = sum_of_sample_mean(torch.cat(ent_data["entropy"], dim=0))
+
+    loss = w_rl * grpo_pg_loss + w_opd * opd_loss - args.entropy_coef * entropy_loss
+
+    kl_loss = torch.tensor(0.0, device=logits.device)
+    if args.use_kl_loss and batch.get("ref_log_probs") is not None:
+        ref_log_probs = torch.cat(batch["ref_log_probs"], dim=0)
+        kl = compute_approx_kl(
+            new_log_probs, ref_log_probs, kl_loss_type=args.kl_loss_type,
+        )
+        kl_loss = sum_of_sample_mean(kl)
+        loss = loss + args.kl_loss_coef * kl_loss
+
+    if new_log_probs.numel() == 0:
+        loss = loss + 0 * logits.sum()
+
+    train_rollout_logprob_abs_diff = None
+    if "rollout_log_probs" in batch and batch["rollout_log_probs"]:
+        rollout_lp = torch.cat(batch["rollout_log_probs"], dim=0)
+        train_rollout_logprob_abs_diff = sum_of_sample_mean(
+            (new_log_probs.detach() - rollout_lp).abs()
+        )
+
+    reported: dict[str, torch.Tensor] = {
+        "loss": loss.clone().detach(),
+        "grpo_pg_loss": grpo_pg_loss.clone().detach(),
+        "opd_loss": opd_loss.clone().detach(),
+        "entropy_loss": entropy_loss.clone().detach(),
+        "grpo_pg_clipfrac": grpo_pg_clipfrac.clone().detach(),
+        "opd_pg_clipfrac": opd_clipfrac_scalar.clone().detach(),
+        "ppo_kl_sampled": ppo_kl_mean_sampled.clone().detach(),
+        "w_rl": torch.tensor(w_rl, device=loss.device),
+        "w_opd": torch.tensor(w_opd, device=loss.device),
+    }
+    if teacher_student_logp_diff_mean is not None:
+        reported["opd_teacher_student_logp_topk_abs_mean"] = (
+            teacher_student_logp_diff_mean.clone().detach()
+        )
+    if subset_size_mean is not None:
+        reported["opd_subset_size"] = subset_size_mean.clone().detach()
+    if sel_overlap_mean is not None:
+        reported["sel_overlap_at_k_star"] = sel_overlap_mean.clone().detach()
+    if sel_k_star_mean is not None:
+        reported["sel_k_star_mean"] = sel_k_star_mean.clone().detach()
+    if train_rollout_logprob_abs_diff is not None:
+        reported["train_rollout_logprob_abs_diff"] = (
+            train_rollout_logprob_abs_diff.clone().detach()
+        )
+    if args.use_kl_loss:
+        reported["kl_loss"] = kl_loss.clone().detach()
+
+    # Embed selection-mode / subset-mode tags as constant ints for wandb
+    # grouping without needing the run config.
+    mode_id = {"shortest": 0, "token_optimal": 1, "sequence_optimal": 2}[hint_selection]
+    subset_id = {"student": 0, "overlap": 1, "teacher": 2}[subset_mode]
+    reported["hint_selection_mode_id"] = torch.tensor(mode_id, device=loss.device)
+    reported["distill_subset_mode_id"] = torch.tensor(subset_id, device=loss.device)
+
+    return loss, reported

--- a/openclaw-combine/run_qwen3_4b_openclaw_topk_select.sh
+++ b/openclaw-combine/run_qwen3_4b_openclaw_topk_select.sh
@@ -1,0 +1,294 @@
+#!/bin/bash
+
+# Multi-candidate top-K OPD launcher for openclaw-combine.
+#
+# Drop-in counterpart to ``run_qwen3_4b_openclaw_combine.sh`` that swaps:
+#   * rollout fn   :  openclaw_combine_rollout.generate_rollout_openclaw_combine
+#                  -> openclaw_combine_select_rollout.
+#                     generate_rollout_openclaw_combine_select
+#   * loss fn      :  combine_loss.combine_loss_function
+#                  -> openclaw_topk_select_loss.openclaw_topk_select_loss_function
+#   * api server   :  OpenClawCombineAPIServer
+#                  -> OpenClawCombineSelectAPIServer  (multi-cand hints)
+#
+# 9-cell support matrix (--distill-subset-mode × --hint-selection):
+#                          shortest   token_optimal   sequence_optimal
+#   student              :    ✓             ✓                ✓
+#   overlap              :    ✓             ✓                ✓
+#   teacher              :    ✓             ✓                ✓
+# All cells handled by openclaw_topk_select_loss_function (see its
+# docstring for the full equations and the in-kernel vs actor-side
+# k* selection split).
+#
+# torch_dist conversion (if you don't already have these directories):
+#
+#   # student: Qwen3-4B-Thinking-2507
+#   cd /data_storage/wyj/OpenClaw-RL/slime
+#   source scripts/models/qwen3-4B.sh
+#   PYTHONPATH=/data_storage/wyj/OpenClaw-RL/Megatron-LM \
+#     python tools/convert_hf_to_torch_dist.py \
+#       ${MODEL_ARGS[@]} \
+#       --hf-checkpoint /data_storage/wyj/systems/huggingface/hub/Qwen3-4B-Thinking-2507 \
+#       --rotary-base 5000000 \
+#       --save /data_storage/wyj/systems/huggingface/hub/Qwen3-4B-Thinking-2507_torch_dist
+
+pkill -9 sglang
+sleep 3
+ray stop --force
+pkill -9 ray
+pkill -9 python
+sleep 3
+pkill -9 ray
+pkill -9 python
+
+set -ex
+
+export PYTHONUNBUFFERED=1
+export PYTHONFAULTHANDLER=1
+
+NUM_GPUS=${NUM_GPUS:-8}
+ACTOR_GPUS=${ACTOR_GPUS:-4}
+ROLLOUT_GPUS=${ROLLOUT_GPUS:-2}
+
+# topk-select REQUIRES megatron PRM teacher -- the inference-side
+# teacher path computes single-cand teacher_log_probs only and does
+# not produce per-cand top-K. Force the megatron layout (1 GPU PRM
+# SGLang + 1 GPU Megatron teacher).
+export OPENCLAW_COMBINE_OPD_TEACHER_SOURCE="megatron"
+PRM_GPUS=${PRM_GPUS:-1}
+PRM_NUM_GPUS_PER_ENGINE=${PRM_NUM_GPUS_PER_ENGINE:-1}
+PRM_TEACHER_GPUS=${PRM_TEACHER_GPUS:-1}
+
+if (( ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS + PRM_TEACHER_GPUS > NUM_GPUS )); then
+    echo "ACTOR_GPUS + ROLLOUT_GPUS + PRM_GPUS + PRM_TEACHER_GPUS must be <= NUM_GPUS"
+    echo "ACTOR_GPUS=${ACTOR_GPUS}, ROLLOUT_GPUS=${ROLLOUT_GPUS}, PRM_GPUS=${PRM_GPUS}, PRM_TEACHER_GPUS=${PRM_TEACHER_GPUS}, NUM_GPUS=${NUM_GPUS}"
+    exit 1
+fi
+
+export RAY_health_check_failure_threshold=20
+export RAY_health_check_period_ms=5000
+export RAY_health_check_timeout_ms=30000
+export RAY_num_heartbeats_timeout=60
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+SLIME_ROOT="${REPO_ROOT}/slime"
+source "${SLIME_ROOT}/scripts/models/qwen3-4B.sh"
+
+# Student (HF for tokenizer + SGLang) and student-torch_dist (Megatron load).
+HF_CKPT=${HF_CKPT:-/data_storage/wyj/systems/huggingface/hub/Qwen3-4B-Thinking-2507}
+REF_LOAD=${REF_LOAD:-/data_storage/wyj/systems/huggingface/hub/Qwen3-4B-Thinking-2507-_torch_dist}
+SAVE_CKPT=${SAVE_CKPT:-/data_storage/wyj/OpenClaw-RL/ckpt/qwen3-4b-openclaw-topk-select}
+
+# PRM teacher: same family as the student in this setting (Qwen3-4B
+# Thinking variant). Megatron teacher loads from torch_dist; SGLang PRM
+# loads from HF (it cannot load torch_dist). Override either via env.
+PRM_MODEL_PATH=${PRM_MODEL_PATH:-${HF_CKPT}}
+PRM_TEACHER_LOAD=${PRM_TEACHER_LOAD:-${REF_LOAD}}
+PRM_TEACHER_HF=${PRM_TEACHER_HF:-${HF_CKPT}}
+
+export SGLANG_API_KEY="${SGLANG_API_KEY}"
+export SERVED_MODEL_NAME="qwen3-4b"
+export HOST="0.0.0.0"
+export PORT="30000"
+export OPENCLAW_RECORD_ENABLED="${OPENCLAW_RECORD_ENABLED:-1}"  # 0=off, 1=on
+export OPENCLAW_RECORD_FILE="${SCRIPT_DIR}/results/qwen3_4b_topk_select_record.jsonl"
+export TP="2"
+export CONTEXT_LENGTH="32768"
+export MEM_FRACTION_STATIC="0.8"
+export REASONING_PARSER="qwen3"
+export TOOL_CALL_PARSER="${TOOL_CALL_PARSER:-qwen25}"
+export PRM_M="${PRM_M:-3}"  # judge votes per turn; topk-select keeps all accepted
+export OPENCLAW_OPD_TEACHER_LP_MAX_CONCURRENCY="${OPENCLAW_OPD_TEACHER_LP_MAX_CONCURRENCY:-1}"
+
+# combine_loss-style RL+OPD weighting
+export OPENCLAW_TOPK_W_RL="${OPENCLAW_TOPK_W_RL:-1.0}"
+export OPENCLAW_TOPK_W_OPD="${OPENCLAW_TOPK_W_OPD:-1.0}"
+# clip is important in stabilizing the training
+export OPENCLAW_TOPK_ADV_DIFF_CLIP="${OPENCLAW_TOPK_ADV_DIFF_CLIP:-1.0}"
+export TRAIN_EPOCHS="${TRAIN_EPOCHS:-1}"
+
+# Subset S_t selection mode for the OPD loss kernel. See
+# openclaw_topk_select_loss docstring for the equations.
+#   student : S_t = top-K(π_old)
+#   teacher : S_t = top-K(π_T,k*)
+#   overlap : S_t = top-K(π_old) ∩ top-K(π_T,k*)
+OPENCLAW_TOPK_SUBSET_MODE="${OPENCLAW_TOPK_SUBSET_MODE:-student}"
+
+# Which generated hint will be used for supervision? Three different selection modes:
+#   shortest          : k* = 0 always (cand list is sorted shortest-first
+#                       at the API server). M=3 candidates are still
+#                       generated but only the shortest drives supervision.
+#   sequence_optimal  : per-Sample argmax_k Σ_t |S^q_t ∩ S^p_{t,k}|.
+#                       the best hint is the one that maximizes the overlap between the student and teacher top k in sequence level.
+#   token_optimal     : k*(t) = argmax_k |S^q_t ∩ S^p_{t,k}| per token.
+#                       the best hint is the one that maximizes the overlap between the student and teacher top k in token level. Empirically, these two methods have similar performance.
+OPENCLAW_TOPK_HINT_SELECTION="${OPENCLAW_TOPK_HINT_SELECTION:-sequence_optimal}"
+
+# Top-K width on both student and teacher sides.
+OPENCLAW_TOPK_K="${OPENCLAW_TOPK_K:-4}"
+# Max #candidate hints kept per turn at the API server 
+export OPENCLAW_TOPK_MAX_CAND="${OPENCLAW_TOPK_MAX_CAND:-3}"
+
+CKPT_ARGS=(
+   --hf-checkpoint "${HF_CKPT}"
+   --ref-load "${REF_LOAD}"
+   --save "${SAVE_CKPT}"
+   --save-interval 100
+   # Qwen3 rope_theta (matches the qwen3-4B model script).
+   --rotary-base 5000000
+   --prm-teacher-load "${PRM_TEACHER_LOAD}"
+   --prm-teacher-num-gpus "${PRM_TEACHER_GPUS}"
+   --prm-teacher-hf-checkpoint "${PRM_TEACHER_HF}"
+   # Teacher rope (same family as student in this setting).
+   --prm-teacher-rotary-base 5000000
+)
+
+ROLLOUT_ARGS=(
+   --disable-rollout-global-dataset
+   --rollout-function-path openclaw_combine_select_rollout.generate_rollout_openclaw_combine_select
+
+   --num-rollout 100000000
+   --rollout-batch-size 16
+   --n-samples-per-prompt 1
+   --rollout-max-response-len 8192
+   --rollout-max-context-len 32768
+   --rollout-temperature 0.6
+   --reward-key score
+
+   --num-steps-per-rollout 1
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 4
+   --sequence-parallel
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 32768
+   --log-probs-chunk-size 1024
+)
+
+TOPK_SELECT_ARGS=(
+   --advantage-estimator grpo
+   --disable-rewards-normalization
+   --loss-type custom_loss
+   --custom-loss-function-path openclaw_topk_select_loss.openclaw_topk_select_loss_function
+   --distill-topk "${OPENCLAW_TOPK_K}"
+   --distill-subset-mode "${OPENCLAW_TOPK_SUBSET_MODE}"
+   --hint-m "${OPENCLAW_TOPK_MAX_CAND}"
+   --hint-selection "${OPENCLAW_TOPK_HINT_SELECTION}"
+   --use-kl-loss
+   --kl-loss-coef 0.0
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-5
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+)
+
+EVAL_ARGS=()
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 2
+   --sglang-tool-call-parser "${TOOL_CALL_PARSER}"
+   --sglang-mem-fraction-static 0.8
+   --sglang-context-length 32768
+   --sglang-reasoning-parser qwen3
+)
+
+PRM_ARGS=(
+   --prm-enable
+   --prm-num-gpus "${PRM_GPUS}"
+   --prm-num-gpus-per-engine "${PRM_NUM_GPUS_PER_ENGINE}"
+   --prm-model-path "${PRM_MODEL_PATH}"
+   --prm-m "${PRM_M}"
+   --prm-temperature "${PRM_TEMPERATURE:-0.6}"
+   --prm-max-new-tokens "${PRM_MAX_NEW_TOKENS:-8192}"
+)
+
+
+CUSTOM_ARGS=(
+   --custom-generate-function-path openclaw_combine_api_server.generate
+   --custom-rm-path openclaw_combine_api_server.reward_func
+)
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+)
+
+USE_WANDB=${USE_WANDB:-1}
+WANDB_PROJECT=${WANDB_PROJECT:-openclaw_rl}
+WANDB_KEY_VALUE=${WANDB_KEY:-${WANDB_API_KEY:-}}
+if [ "${USE_WANDB}" = "1" ] && [ -n "${WANDB_KEY_VALUE}" ]; then
+  WANDB_ARGS=(
+    --use-wandb
+    --wandb-project ${WANDB_PROJECT}
+    --wandb-group qwen3-4b-openclaw-topk-select
+    --wandb-key ${WANDB_KEY_VALUE}
+  )
+else
+  WANDB_ARGS=()
+fi
+
+export OPENCLAW_EVAL_MODE="${OPENCLAW_EVAL_MODE:-1}"
+
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+export no_proxy="127.0.0.1,${MASTER_ADDR}"
+ray start --head --node-ip-address "${MASTER_ADDR}" --num-gpus "${NUM_GPUS}" --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"${REPO_ROOT}/Megatron-LM:${SCRIPT_DIR}:${REPO_ROOT}/openclaw-opd:${REPO_ROOT}/hint_opt_exp:${SLIME_ROOT}\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"OPENCLAW_EVAL_MODE\": \"${OPENCLAW_EVAL_MODE}\",
+    \"OPENCLAW_COMBINE_OPD_TEACHER_SOURCE\": \"${OPENCLAW_COMBINE_OPD_TEACHER_SOURCE}\",
+    \"OPENCLAW_TOPK_W_RL\": \"${OPENCLAW_TOPK_W_RL}\",
+    \"OPENCLAW_TOPK_W_OPD\": \"${OPENCLAW_TOPK_W_OPD}\",
+    \"OPENCLAW_TOPK_ADV_DIFF_CLIP\": \"${OPENCLAW_TOPK_ADV_DIFF_CLIP}\",
+    \"OPENCLAW_TOPK_MAX_CAND\": \"${OPENCLAW_TOPK_MAX_CAND}\",
+    \"TRAIN_EPOCHS\": \"${TRAIN_EPOCHS}\"
+  }
+}"
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 train_async.py \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node "${ACTOR_GPUS}" \
+   --rollout-num-gpus "${ROLLOUT_GPUS}" \
+   --num-gpus-per-node "${NUM_GPUS}" \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${TOPK_SELECT_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${EVAL_ARGS[@]} \
+   ${SGLANG_ARGS[@]} \
+   ${MISC_ARGS[@]} \
+   ${WANDB_ARGS[@]} \
+   ${CUSTOM_ARGS[@]} \
+   ${PRM_ARGS[@]}


### PR DESCRIPTION
Adds the multi-candidate variant of the openclaw-combine pipeline that uses the slime retool-hybrid-select infra (PR #105) to drive K teacher forwards per Sample, with in-kernel k* selection over the 9-cell (--distill-subset-mode x --hint-selection) matrix.

Files added (all under openclaw-combine/):

* openclaw_combine_select_api_server.py OpenClawCombineSelectAPIServer subclass of OpenClawCombineAPIServer. Three-case dispatch (OPD-only / OPD+RL / RL-only) is preserved; the OPD evaluate step keeps ALL accepted hints (deduped, shortest-first, capped at OPENCLAW_TOPK_MAX_CAND) and ships them as sample.teacher_tokens_candidates instead of selecting a single hint. RL-only turns ship a degenerate K_i=1 un-enhanced candidate so the multi-cand pipeline always has something to gather.

* openclaw_combine_select_rollout.py Drop-in alternative to openclaw_combine_rollout.generate_rollout_*; same worker / queue / drain plumbing, swaps in OpenClawCombineSelectAPIServer. Module-level singleton state is intentionally separate so both rollout entry points can co-exist on the same launcher PYTHONPATH.

* openclaw_topk_select_loss.py Combined GRPO + top-K OPD loss with the 9-cell selection matrix. Reuses _opd_one_sample / _gather_along_K / _overlap_count_per_token / _select_k_star_per_token from hint_opt_exp so the math stays identical to retool / hint_opd_exp. Per-Sample sequence_optimal under openclaw-combine IS per-PRM-step k* under the dynamic-history paradigm (one Sample per session-turn).

* run_qwen3_4b_openclaw_topk_select.sh Launcher: 4 actor + 2 rollout + 1 SGLang PRM + 1 Megatron PRM teacher GPUs. Forces OPENCLAW_COMBINE_OPD_TEACHER_SOURCE=megatron (the topk-select kernel needs per-cand top-K log-probs / indices, which the inference-side teacher path does not produce). Uses raw torch_dist load (no bridge) for both student and teacher.

No changes to existing code paths; the legacy combine_loss / openclaw_combine_api_server / openclaw_combine_rollout entries are untouched. Activation is fully gated by the launcher's choice of --rollout-function-path / --custom-loss-function-path / --custom-generate-function-path.
