### PR TITLE
fix: skip DDP and optimizer for prm_teacher (inference-only mode)

### DIFF
--- a/slime/slime/backends/megatron_utils/model.py
+++ b/slime/slime/backends/megatron_utils/model.py
@@ -770,6 +770,21 @@ def save_hf_model(args, rollout_id: int, model: Sequence[DDP]) -> None:
             logger.error(f"Failed to save HuggingFace format: {e}")
 
 
+def _setup_inference_only_model(args: Namespace, role: str):
+    """Build model without DDP wrapping or optimizer for inference-only roles.
+
+    This avoids allocating gradient buffers and optimizer states that would
+    otherwise cause OOM on a single GPU when the model only needs forward
+    passes.
+    """
+    model = get_model(
+        wrap_model_provider_with_freeze(get_model_provider_func(args, role), args),
+        ModelType.encoder_or_decoder,
+        wrap_with_ddp=False,
+    )
+    return model
+
+
 def initialize_model_and_optimizer(
     args: Namespace, role: str = "actor"
 ) -> tuple[list[DDP], MegatronOptimizer, OptimizerParamScheduler, int]:
@@ -790,6 +805,20 @@ def initialize_model_and_optimizer(
 
         filesystem_async_module.FileSystemWriterAsync = ROCmFileSystemWriterAsync
         print("[ROCm] Applied FileSystemWriterAsync patch for HIP compatibility")
+
+    if role == "prm_teacher":
+        model = _setup_inference_only_model(args, role)
+        model[0].role = role
+        clear_memory()
+        iteration, _ = load_checkpoint(
+            model,
+            None,
+            None,
+            checkpointing_context={},
+            skip_load_to_model_and_opt=False,
+        )
+        clear_memory()
+        return model, None, None, iteration
 
     model, optimizer, opt_param_scheduler = setup_model_and_optimizer(args, role)
     model[0].role = role


### PR DESCRIPTION
## Summary

  PRM Teacher only performs forward passes to compute teacher log-probabilities for OPD loss. It never does backward passes or gradient updates. However, the current code loads it with full DDP
  wrapping + Adam optimizer, wasting ~160GB of memory and causing OOM on single-GPU deployments.

  ## Changes

  **File:** `slime/slime/backends/megatron_utils/model.py`

  1. **New function** `_setup_inference_only_model(args, role)`: Creates model with `wrap_with_ddp=False`, avoiding DDP gradient buffer allocation.
  2. **New branch** in `initialize_model_and_optimizer()`: When `role == "prm_teacher"`, calls the inference-only setup, loads checkpoint without optimizer/scheduler, and returns early.

  ## Memory Impact (27B BF16 model, single GPU)

  | Component | Before (training mode) | After (inference-only) |
  |-----------|----------------------|----------------------|
  | Model params (BF16) | 54 GB | 54 GB |
  | DDP gradient buffers | 54 GB | **0** |
  | Adam m + v (FP32) | 108 GB | **0** |
  | **Total** | **~216 GB** OOM | **~54 GB** fits |

  ## Safety Verification

  - [x] **Checkpoint key matching**: `load_checkpoint` -> `unwrap_model()` handles DDP/non-DDP correctly via `sharded_state_dict` path
  - [x] **eval + no_grad**: `forward_only()` has `@torch.no_grad()` decorator; `model_module.eval()` is set
  - [x] **Gradient isolation**: `compute_prm_teacher_log_probs` output is `.cpu()` under `@torch.no_grad()`, never participates in training `loss.backward()`

  ## Testing

  - **Model**: Qwen3.5-27B (BF16)
  - **Config**: PRM Teacher on 1x GPU (TP=1)
  - **Result**: Model loads successfully, log-prob computation works correctly, no OOM